### PR TITLE
feat(command-palette): improve select matching and scoring

### DIFF
--- a/docs/palette-provider.md
+++ b/docs/palette-provider.md
@@ -89,6 +89,10 @@ This document defines the palette provider contract in `pvf`.
   4. Otherwise reopen preserving input.
 - `Tab` may autocomplete from selected candidate.
 - If input includes whitespace (argument phase), candidate list is hidden.
+- Candidate ranking uses command-aware scoring:
+  - command `id` (hyphen-separated lowercase) is the primary target.
+  - `title` is a weaker secondary target.
+  - acronym-style queries from id tokens are supported (for example, `nsh` -> `next-search-hit`).
 - Candidate visibility may depend on runtime app state.
   - `next-search-hit` / `prev-search-hit` are shown only while search is active.
 


### PR DESCRIPTION
## Summary
- improve command palette candidate matching with command-aware scoring
- prioritize hyphenated command id matches and support acronym-style input (e.g. 
sh)
- keep title matching as a secondary, weaker signal
- add ranking tie-breakers (shorter id, then lexicographic) and expand provider tests
- update palette provider docs to describe ranking behavior

## Validation
- cargo fmt
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings