### PR TITLE
Move search UI state out of global AppState into extension-owned SearchState and propagate search-active flag to palette APIs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,6 +48,7 @@ This document defines the current architecture of `pvf`.
   - `engine.rs`: async search worker and job lifecycle.
   - `palette.rs`: search palette provider.
   - `mod.rs`: `SearchExtension` wiring.
+  - Search activity/progress/hits are owned by extension `SearchState` (not mirrored in `AppState`).
 
 - `src/history/`
   - `state.rs`: history stacks and navigation logic.

--- a/docs/extension-system.md
+++ b/docs/extension-system.md
@@ -69,6 +69,10 @@ Dispatch order is fixed:
   - UI asks `ExtensionHost::status_bar_segments()`.
   - Host aggregates non-empty segments from registered extensions.
 
+Search state ownership:
+- Search activity/progress/hits are owned by `SearchState` inside `ExtensionHost`.
+- `AppState` does not mirror search state; consumers query extension-host/search APIs for search activity.
+
 ## Built-in extensions
 
 ### Search (`src/search/`)

--- a/src/app/input_ops.rs
+++ b/src/app/input_ops.rs
@@ -112,9 +112,12 @@ impl InteractionSubsystem {
         state: &mut AppState,
         key: KeyEvent,
     ) -> AppResult<PaletteKeyResult> {
-        self.palette
-            .manager
-            .handle_key(&self.palette.registry, state, key)
+        self.palette.manager.handle_key(
+            &self.palette.registry,
+            state,
+            self.extensions.host.is_search_active(),
+            key,
+        )
     }
 
     pub(crate) fn close_palette_session(&mut self, state: &mut AppState, session_id: u64) -> bool {
@@ -138,11 +141,13 @@ impl InteractionSubsystem {
         while let Some(request) = self.palette.pending_requests.pop_front() {
             match request {
                 PaletteRequest::Open { kind, seed } => {
-                    match self
-                        .palette
-                        .manager
-                        .open(&self.palette.registry, state, kind, seed)
-                    {
+                    match self.palette.manager.open(
+                        &self.palette.registry,
+                        state,
+                        self.extensions.host.is_search_active(),
+                        kind,
+                        seed,
+                    ) {
                         Ok(()) => {
                             state.mode = Mode::Palette;
                             state.status.last_action_id = Some(ActionId::OpenPalette);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -18,6 +18,4 @@ mod tests;
 
 pub use core::App;
 pub use runtime::RenderRuntime;
-pub use state::{
-    AppState, CacheHandle, CacheRefs, Mode, PaletteRequest, SearchUiState, StatusState,
-};
+pub use state::{AppState, CacheHandle, CacheRefs, Mode, PaletteRequest, StatusState};

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -22,17 +22,6 @@ pub struct StatusState {
     pub last_action_id: Option<ActionId>,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct SearchUiState {
-    pub active: bool,
-    pub in_progress: bool,
-    pub scanned_pages: usize,
-    pub total_pages: usize,
-    pub hits_found: usize,
-    /// 0-based index into current result set.
-    pub current_hit: Option<usize>,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CacheHandle {
     pub name: &'static str,
@@ -53,7 +42,6 @@ pub struct AppState {
     pub debug_status_visible: bool,
     pub mode: Mode,
     pub status: StatusState,
-    pub search_ui: SearchUiState,
     pub caches: CacheRefs,
 }
 
@@ -67,7 +55,6 @@ impl Default for AppState {
             debug_status_visible: false,
             mode: Mode::Normal,
             status: StatusState::default(),
-            search_ui: SearchUiState::default(),
             caches: CacheRefs::default(),
         }
     }

--- a/src/command/dispatch.rs
+++ b/src/command/dispatch.rs
@@ -296,7 +296,7 @@ mod tests {
             SearchMatcherKind::ContainsInsensitive,
         )
         .expect("submit-search should succeed");
-        assert!(app.search_ui.active);
+        assert!(host.is_search_active());
 
         let result = dispatch(
             &mut app,
@@ -309,7 +309,7 @@ mod tests {
 
         assert_eq!(result.outcome, CommandOutcome::Applied);
         assert_eq!(result.emitted_events.len(), 1);
-        assert!(!app.search_ui.active);
+        assert!(!host.is_search_active());
         assert_eq!(app.status.message, "search canceled");
         assert!(palette_requests.is_empty());
     }

--- a/src/extension/host.rs
+++ b/src/extension/host.rs
@@ -121,6 +121,10 @@ impl ExtensionHost {
         self.search.matcher()
     }
 
+    pub fn is_search_active(&self) -> bool {
+        !self.search.query().is_empty()
+    }
+
     pub fn status_bar_segments(&self, app: &AppState) -> Vec<String> {
         let mut segments = Vec::new();
         if let Some(segment) = SearchExtension::status_bar_segment(&self.search, app)
@@ -235,12 +239,12 @@ mod tests {
             SearchMatcherKind::ContainsInsensitive,
         )
         .expect("submit-search should succeed");
-        assert!(app.search_ui.active);
+        assert!(host.is_search_active());
 
         let canceled = host
             .cancel_search(&mut app, &pdf)
             .expect("cancel-search should succeed");
         assert!(canceled);
-        assert!(!app.search_ui.active);
+        assert!(!host.is_search_active());
     }
 }

--- a/src/palette/manager.rs
+++ b/src/palette/manager.rs
@@ -48,6 +48,7 @@ impl PaletteManager {
         &mut self,
         registry: &PaletteRegistry,
         app: &AppState,
+        search_active: bool,
         kind: PaletteKind,
         seed: Option<String>,
     ) -> AppResult<()> {
@@ -57,6 +58,7 @@ impl PaletteManager {
 
         let ctx = PaletteContext {
             app,
+            search_active,
             kind,
             input: input.value(),
             seed: seed.as_deref(),
@@ -107,6 +109,7 @@ impl PaletteManager {
         &mut self,
         registry: &PaletteRegistry,
         app: &AppState,
+        search_active: bool,
         key: KeyEvent,
     ) -> AppResult<PaletteKeyResult> {
         let Some(session) = self.active.as_mut() else {
@@ -140,6 +143,7 @@ impl PaletteManager {
                 let selected = selected_candidate(session);
                 let ctx = PaletteContext {
                     app,
+                    search_active,
                     kind: session.kind,
                     input: session.input.value(),
                     seed: session.seed.as_deref(),
@@ -153,7 +157,7 @@ impl PaletteManager {
                         session.input = Input::new(value);
                     }
                 }
-                self.rebuild(registry, app)?;
+                self.rebuild(registry, app, search_active)?;
                 return Ok(PaletteKeyResult::Consumed { redraw: true });
             }
             KeyCode::Enter => {
@@ -161,6 +165,7 @@ impl PaletteManager {
                 let provider = registry.get(session.kind);
                 let ctx = PaletteContext {
                     app,
+                    search_active,
                     kind: session.kind,
                     input: session.input.value(),
                     seed: session.seed.as_deref(),
@@ -175,7 +180,7 @@ impl PaletteManager {
         }
 
         session.input.handle_event(&Event::Key(key));
-        self.rebuild(registry, app)?;
+        self.rebuild(registry, app, search_active)?;
         Ok(PaletteKeyResult::Consumed { redraw: true })
     }
 
@@ -202,7 +207,12 @@ impl PaletteManager {
         })
     }
 
-    fn rebuild(&mut self, registry: &PaletteRegistry, app: &AppState) -> AppResult<()> {
+    fn rebuild(
+        &mut self,
+        registry: &PaletteRegistry,
+        app: &AppState,
+        search_active: bool,
+    ) -> AppResult<()> {
         let Some(existing) = self.active.as_ref() else {
             return Ok(());
         };
@@ -215,6 +225,7 @@ impl PaletteManager {
         let provider = registry.get(kind);
         let ctx = PaletteContext {
             app,
+            search_active,
             kind,
             input: &input_text,
             seed: seed.as_deref(),

--- a/src/palette/providers/command.rs
+++ b/src/palette/providers/command.rs
@@ -195,7 +195,7 @@ fn find_spec(id: &str) -> Option<crate::command::CommandSpec> {
 
 fn can_show_command_spec(id: &str, ctx: &PaletteContext<'_>) -> bool {
     if is_search_navigation_command(id) {
-        return ctx.app.search_ui.active;
+        return ctx.search_active;
     }
     true
 }
@@ -363,10 +363,10 @@ mod tests {
         search_active: bool,
     ) -> Vec<crate::palette::PaletteCandidate> {
         let provider = CommandPaletteProvider;
-        let mut app = AppState::default();
-        app.search_ui.active = search_active;
+        let app = AppState::default();
         let ctx = PaletteContext {
             app: &app,
+            search_active,
             kind: PaletteKind::Command,
             input,
             seed: None,
@@ -380,6 +380,7 @@ mod tests {
         let app = AppState::default();
         let ctx = PaletteContext {
             app: &app,
+            search_active: false,
             kind: PaletteKind::Command,
             input: "",
             seed: None,
@@ -401,10 +402,10 @@ mod tests {
     #[test]
     fn list_shows_search_hit_navigation_when_search_is_active() {
         let provider = CommandPaletteProvider;
-        let mut app = AppState::default();
-        app.search_ui.active = true;
+        let app = AppState::default();
         let ctx = PaletteContext {
             app: &app,
+            search_active: true,
             kind: PaletteKind::Command,
             input: "",
             seed: None,

--- a/src/palette/registry.rs
+++ b/src/palette/registry.rs
@@ -128,6 +128,7 @@ mod tests {
         let registry = PaletteRegistry::default();
         let ctx = PaletteContext {
             app: &crate::app::AppState::default(),
+            search_active: false,
             kind: PaletteKind::Command,
             input: "",
             seed: None,

--- a/src/palette/types.rs
+++ b/src/palette/types.rs
@@ -57,6 +57,7 @@ pub enum PaletteTabEffect {
 
 pub struct PaletteContext<'a> {
     pub app: &'a AppState,
+    pub search_active: bool,
     pub kind: PaletteKind,
     pub input: &'a str,
     pub seed: Option<&'a str>,

--- a/src/search/state.rs
+++ b/src/search/state.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crossterm::event::KeyCode;
 
-use crate::app::{AppState, PaletteRequest, SearchUiState};
+use crate::app::{AppState, PaletteRequest};
 use crate::backend::PdfBackend;
 use crate::command::{ActionId, Command, CommandOutcome, SearchMatcherKind};
 use crate::error::AppResult;
@@ -80,7 +80,6 @@ impl SearchState {
             self.generation = search_engine.cancel(pdf.path())?;
             self.query.clear();
             self.clear_results();
-            self.sync_ui_state(app);
             app.status.message = "search query is empty".to_string();
             return Ok(CommandOutcome::Noop);
         }
@@ -97,7 +96,6 @@ impl SearchState {
         self.hits.clear();
         self.current_hit = None;
         self.last_error = None;
-        self.sync_ui_state(app);
 
         app.status.message = format!("search started ({})", self.matcher.id());
         Ok(CommandOutcome::Applied)
@@ -124,7 +122,6 @@ impl SearchState {
         self.generation = search_engine.cancel(pdf.path())?;
         self.query.clear();
         self.clear_results();
-        self.sync_ui_state(app);
         Ok(true)
     }
 
@@ -203,9 +200,6 @@ impl SearchState {
                 }
             }
         }
-        if changed {
-            self.sync_ui_state(app);
-        }
         changed
     }
 
@@ -242,7 +236,6 @@ impl SearchState {
             } else {
                 "no search hits available".to_string()
             };
-            self.sync_ui_state(app);
             return CommandOutcome::Noop;
         }
 
@@ -266,7 +259,6 @@ impl SearchState {
             self.hits.len(),
             app.current_page + 1
         );
-        self.sync_ui_state(app);
         CommandOutcome::Applied
     }
 
@@ -278,17 +270,6 @@ impl SearchState {
         self.hits.clear();
         self.current_hit = None;
         self.last_error = None;
-    }
-
-    fn sync_ui_state(&self, app: &mut AppState) {
-        app.search_ui = SearchUiState {
-            active: !self.query.is_empty(),
-            in_progress: self.in_progress,
-            scanned_pages: self.scanned_pages,
-            total_pages: self.total_pages,
-            hits_found: self.hits_found,
-            current_hit: self.current_hit,
-        };
     }
 }
 
@@ -419,7 +400,7 @@ mod tests {
     }
 
     #[test]
-    fn submit_search_marks_search_ui_active() {
+    fn submit_search_activates_query_state() {
         let mut state = SearchState::default();
         let mut app = AppState::default();
         let pdf = StubPdf::new(5);
@@ -436,9 +417,7 @@ mod tests {
             .expect("submit should succeed");
 
         assert_eq!(outcome, CommandOutcome::Applied);
-        assert!(app.search_ui.active);
-        assert!(app.search_ui.in_progress);
-        assert_eq!(app.search_ui.total_pages, 5);
+        assert_eq!(state.query(), "needle");
         assert_eq!(
             state.status_bar_segment(),
             Some("SEARCH 0 hits".to_string())
@@ -446,7 +425,7 @@ mod tests {
     }
 
     #[test]
-    fn submit_empty_query_clears_search_ui() {
+    fn submit_empty_query_clears_search_state() {
         let mut state = SearchState::default();
         let mut app = AppState::default();
         let pdf = StubPdf::new(2);
@@ -461,7 +440,7 @@ mod tests {
                 SearchMatcherKind::ContainsInsensitive,
             )
             .expect("submit should succeed");
-        assert!(app.search_ui.active);
+        assert_eq!(state.query(), "needle");
 
         let outcome = state
             .submit(
@@ -474,8 +453,7 @@ mod tests {
             .expect("empty submit should succeed");
 
         assert_eq!(outcome, CommandOutcome::Noop);
-        assert!(!app.search_ui.active);
-        assert!(!app.search_ui.in_progress);
+        assert!(state.query().is_empty());
         assert_eq!(state.status_bar_segment(), None);
     }
 
@@ -495,13 +473,13 @@ mod tests {
                 SearchMatcherKind::ContainsInsensitive,
             )
             .expect("submit should succeed");
-        assert!(app.search_ui.active);
+        assert_eq!(state.query(), "needle");
 
         let canceled = state
             .cancel(&mut app, &pdf, &mut engine)
             .expect("cancel should succeed");
         assert!(canceled);
-        assert!(!app.search_ui.active);
+        assert!(state.query().is_empty());
         assert_eq!(state.status_bar_segment(), None);
     }
 


### PR DESCRIPTION
### Motivation

- Remove duplication of search UI state from `AppState` and centralize search activity/progress/hits in the `SearchState` owned by the extension host.
- Make palette providers and manager aware of whether search is active so command visibility and behavior can depend on extension-owned search state.

### Description

- Removed the `SearchUiState` type and the `search_ui` field from `AppState`, and removed UI sync calls from `SearchState` methods.
- Added `ExtensionHost::is_search_active()` and updated callers to query the host for search activity instead of reading `AppState`.
- Extended `PaletteContext` with a `search_active: bool` field and updated `PaletteManager::open`, `handle_key`, and `rebuild` signatures to accept `search_active`, propagating that flag into providers.
- Updated `CommandPaletteProvider` and other palette code to consult `ctx.search_active` for hiding/showing search navigation commands, and adjusted many call sites and tests accordingly; also updated docs to reflect that search state is owned by the extension host.

### Testing

- Ran the unit test suite with `cargo test` after the changes, and all tests passed including updated tests that now assert search state via `ExtensionHost`/`SearchState` rather than `AppState`.
- Updated and ran provider and search unit tests that exercise palette listing and search lifecycle, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6888708b0833381b1589c08c63c00)