### PR TITLE
docs: fix cargo clippy option syntax in docs

### DIFF
--- a/.agents/skills/pr-workflow/SKILL.md
+++ b/.agents/skills/pr-workflow/SKILL.md
@@ -8,7 +8,7 @@ description: Create and review GitHub pull requests with a consistent workflow. 
 1. Before creating a PR, run quality checks in this order:
    - `cargo fmt --check`
    - `cargo test`
-   - `cargo clippy --all-targets --all-features -D warnings`
+   - `cargo clippy --all-targets --all-features -- -D warnings`
 2. If any check fails, do not create the PR until fixed.
 
 ## Create PR

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 - `cargo run`: run locally.
 - `cargo test`: run tests.
 - `cargo fmt`: format.
-- `cargo clippy --all-targets --all-features -D warnings`: lint and fail on warnings.
+- `cargo clippy --all-targets --all-features -- -D warnings`: lint and fail on warnings.
 
 ## Testing
 - Default: in-file `#[cfg(test)]` modules


### PR DESCRIPTION
## Summary
- fix `cargo clippy` examples in docs to pass lint flags after `--`
- update both `AGENTS.md` and `.agents/skills/pr-workflow/SKILL.md`

## Verification
- Not run (docs-only change, per request)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal quality assurance tooling configurations to refine command-line argument parsing for code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->