### PR TITLE
feat(cli): migrate CLI parsing to clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +350,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
 name = "color"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +403,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact_str"
@@ -1125,6 +1221,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,6 +1609,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,6 +1943,7 @@ dependencies = [
 name = "pvf"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "crossterm 0.28.1",
  "fast_image_resize 6.0.0",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 hayro = "0.5.0"
 kurbo = "0.12.0"
 crossterm = { version = "0.28.1", features = ["event-stream"] }
+clap = { version = "4.5.49", features = ["derive"] }
 ratatui = "0.30.0"
 ratatui-image = { version = "10.0.6", default-features = false, features = ["crossterm"] }
 tui-input = "0.11.1"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 ```bash
 cargo run --release -- <file.pdf>
+cargo run --release -- perf <file.pdf> --scenario page-flip-forward --out report.json
 ```
 
 ## Features

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -8,13 +8,14 @@ Command:
 
 ```bash
 pvf <file.pdf>
-pvf <file.pdf> --perf-run <scenario-id> [--perf-out <path|->]
+pvf perf <file.pdf> --scenario <scenario-id> [--out <path|->]
 ```
 
 Rules:
 - Exactly one PDF path argument is required.
 - The path is opened through the default backend factory (`open_default_backend`).
 - Perf mode runs a built-in scenario, emits JSON, and exits.
+- Perf mode is accessed through the `perf` subcommand.
 - Supported perf scenarios:
   - `page-flip-forward`
   - `page-flip-backward`

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
-use std::ffi::OsString;
 use std::path::PathBuf;
 
+use clap::{Args, Parser, Subcommand};
 use pvf::app::App;
 use pvf::backend::open_default_backend;
-use pvf::error::{AppError, AppResult};
+use pvf::error::AppResult;
 use pvf::perf::{PerfRunConfig, PerfScenarioId, run_report, write_report};
 use pvf::presenter::PresenterKind;
 
@@ -21,6 +21,38 @@ struct CliOptions {
     perf: Option<PerfCliOptions>,
 }
 
+#[derive(Debug, Parser)]
+#[command(
+    version,
+    about = "PDF viewer for the terminal",
+    args_conflicts_with_subcommands = true,
+    subcommand_negates_reqs = true
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+
+    #[arg(value_name = "FILE", required = true)]
+    pdf_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    Perf(PerfCommand),
+}
+
+#[derive(Debug, Args)]
+struct PerfCommand {
+    #[arg(value_name = "FILE")]
+    pdf_path: PathBuf,
+
+    #[arg(long, value_enum)]
+    scenario: PerfScenarioId,
+
+    #[arg(long, value_name = "PATH|-")]
+    out: Option<PathBuf>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PerfCliOptions {
     run: PerfRunConfig,
@@ -28,7 +60,7 @@ struct PerfCliOptions {
 }
 
 async fn run() -> AppResult<()> {
-    let options = parse_cli(std::env::args_os())?;
+    let options = parse_cli(Cli::parse());
 
     if let Some(perf) = options.perf {
         let report = run_report(&options.pdf_path, perf.run).await?;
@@ -40,147 +72,96 @@ async fn run() -> AppResult<()> {
     app.run(pdf.as_mut()).await
 }
 
-fn parse_cli<I>(args: I) -> AppResult<CliOptions>
-where
-    I: Iterator<Item = OsString>,
-{
-    let mut args = args;
-    let _program = args.next();
-
-    let mut pdf_path = None;
-    let mut perf_scenario = None;
-    let mut perf_out = None;
-    let mut perf_out_flag = false;
-
-    while let Some(arg) = args.next() {
-        match arg.to_string_lossy().as_ref() {
-            "--perf-run" => {
-                let Some(value) = args.next() else {
-                    return Err(AppError::invalid_argument(
-                        "usage: pvf <file.pdf> [--perf-run <scenario-id>] [--perf-out <path|->]",
-                    ));
-                };
-                let scenario = value
-                    .to_str()
-                    .and_then(PerfScenarioId::parse)
-                    .ok_or_else(|| {
-                        AppError::invalid_argument(format!(
-                            "unknown perf scenario: {}",
-                            value.to_string_lossy()
-                        ))
-                    })?;
-                perf_scenario = Some(scenario);
-            }
-            "--perf-out" => {
-                let Some(value) = args.next() else {
-                    return Err(AppError::invalid_argument(
-                        "usage: pvf <file.pdf> [--perf-run <scenario-id>] [--perf-out <path|->]",
-                    ));
-                };
-                perf_out_flag = true;
-                if value != "-" {
-                    perf_out = Some(PathBuf::from(value));
-                }
-            }
-            value if value.starts_with('-') => {
-                return Err(AppError::invalid_argument(format!(
-                    "unknown option: {value}"
-                )));
-            }
-            _ => {
-                if pdf_path.is_some() {
-                    return Err(AppError::invalid_argument(
-                        "usage: pvf <file.pdf> [--perf-run <scenario-id>] [--perf-out <path|->]",
-                    ));
-                }
-                pdf_path = Some(PathBuf::from(arg));
-            }
-        }
+fn parse_cli(cli: Cli) -> CliOptions {
+    match cli.command {
+        Some(Commands::Perf(perf)) => CliOptions {
+            pdf_path: perf.pdf_path,
+            perf: Some(PerfCliOptions {
+                run: PerfRunConfig {
+                    scenario: perf.scenario,
+                    ..PerfRunConfig::default()
+                },
+                out: perf.out.and_then(|path| {
+                    if path.as_os_str() == "-" {
+                        None
+                    } else {
+                        Some(path)
+                    }
+                }),
+            }),
+        },
+        None => CliOptions {
+            pdf_path: cli
+                .pdf_path
+                .expect("clap enforces pdf path when no subcommand is present"),
+            perf: None,
+        },
     }
-
-    let Some(pdf_path) = pdf_path else {
-        return Err(AppError::invalid_argument(
-            "usage: pvf <file.pdf> [--perf-run <scenario-id>] [--perf-out <path|->]",
-        ));
-    };
-
-    if perf_out_flag && perf_scenario.is_none() {
-        return Err(AppError::invalid_argument("--perf-out requires --perf-run"));
-    }
-
-    Ok(CliOptions {
-        pdf_path,
-        perf: perf_scenario.map(|scenario| PerfCliOptions {
-            run: PerfRunConfig {
-                scenario,
-                ..PerfRunConfig::default()
-            },
-            out: perf_out,
-        }),
-    })
 }
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::OsString;
     use std::path::PathBuf;
 
+    use clap::Parser;
     use pvf::perf::PerfScenarioId;
 
-    use super::parse_cli;
+    use super::{Cli, parse_cli};
 
     #[test]
     fn parse_cli_accepts_plain_pdf_path() {
-        let args = vec![OsString::from("pvf"), OsString::from("sample.pdf")];
-
-        let options = parse_cli(args.into_iter()).expect("single arg should parse");
+        let cli = Cli::try_parse_from(["pvf", "sample.pdf"]).expect("single arg should parse");
+        let options = parse_cli(cli);
         assert_eq!(options.pdf_path, PathBuf::from("sample.pdf"));
         assert!(options.perf.is_none());
     }
 
     #[test]
     fn parse_cli_accepts_perf_options() {
-        let args = vec![
-            OsString::from("pvf"),
-            OsString::from("sample.pdf"),
-            OsString::from("--perf-run"),
-            OsString::from("page-flip-forward"),
-            OsString::from("--perf-out"),
-            OsString::from("report.json"),
-        ];
-
-        let options = parse_cli(args.into_iter()).expect("perf args should parse");
+        let cli = Cli::try_parse_from([
+            "pvf",
+            "perf",
+            "sample.pdf",
+            "--scenario",
+            "page-flip-forward",
+            "--out",
+            "report.json",
+        ])
+        .expect("perf args should parse");
+        let options = parse_cli(cli);
         let perf = options.perf.expect("perf options should exist");
         assert_eq!(perf.run.scenario, PerfScenarioId::PageFlipForward);
         assert_eq!(perf.out, Some(PathBuf::from("report.json")));
     }
 
     #[test]
+    fn parse_cli_accepts_stdout_perf_output() {
+        let cli = Cli::try_parse_from([
+            "pvf",
+            "perf",
+            "sample.pdf",
+            "--scenario",
+            "idle-pending-redraw",
+            "--out",
+            "-",
+        ])
+        .expect("stdout output should parse");
+        let options = parse_cli(cli);
+        let perf = options.perf.expect("perf options should exist");
+        assert_eq!(perf.run.scenario, PerfScenarioId::IdlePendingRedraw);
+        assert_eq!(perf.out, None);
+    }
+
+    #[test]
     fn parse_cli_rejects_invalid_combinations() {
-        let missing = vec![OsString::from("pvf")];
-        assert!(parse_cli(missing.into_iter()).is_err());
-
-        let extra = vec![
-            OsString::from("pvf"),
-            OsString::from("a.pdf"),
-            OsString::from("b.pdf"),
-        ];
-        assert!(parse_cli(extra.into_iter()).is_err());
-
-        let out_without_run = vec![
-            OsString::from("pvf"),
-            OsString::from("a.pdf"),
-            OsString::from("--perf-out"),
-            OsString::from("report.json"),
-        ];
-        assert!(parse_cli(out_without_run.into_iter()).is_err());
-
-        let stdout_without_run = vec![
-            OsString::from("pvf"),
-            OsString::from("a.pdf"),
-            OsString::from("--perf-out"),
-            OsString::from("-"),
-        ];
-        assert!(parse_cli(stdout_without_run.into_iter()).is_err());
+        assert!(Cli::try_parse_from(["pvf"]).is_err());
+        assert!(Cli::try_parse_from(["pvf", "a.pdf", "b.pdf"]).is_err());
+        assert!(Cli::try_parse_from(["pvf", "perf", "a.pdf"]).is_err());
+        assert!(
+            Cli::try_parse_from(["pvf", "sample.pdf", "--perf-run", "page-flip-forward",]).is_err()
+        );
+        assert!(
+            Cli::try_parse_from(["pvf", "perf", "sample.pdf", "--scenario", "unknown",]).is_err()
+        );
     }
 }

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use clap::ValueEnum;
 use serde::Serialize;
 
 use crate::app::App;
@@ -313,7 +314,7 @@ pub struct PerfScenarioParameters {
     pub idle_duration_ms: u64,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ValueEnum)]
 #[serde(rename_all = "kebab-case")]
 pub enum PerfScenarioId {
     PageFlipForward,


### PR DESCRIPTION
## Summary
- replace the handwritten CLI parser with clap derive types
- keep `pvf <file>` for normal viewing and move perf runs to `pvf perf <file> --scenario ...`
- update CLI docs and parser tests to match the new contract

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Perf testing now uses a dedicated subcommand: `pvf perf <file.pdf> --scenario <scenario-id> [--out <path|->]`
  * Added idle-pending-redraw performance scenario

* **Documentation**
  * Updated CLI usage documentation and examples reflecting new perf subcommand structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->