### PR TITLE
refactor(backend): share pdf backend across workers

### DIFF
--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -1,9 +1,10 @@
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::time::{self, MissedTickBehavior};
 
-use crate::backend::PdfBackend;
+use crate::backend::{PdfBackend, SharedPdfBackend};
 use crate::command::{ActionId, CommandOutcome};
 use crate::error::{AppError, AppResult};
 use crate::event::DomainEvent;
@@ -89,7 +90,7 @@ impl App {
         std::process::exit(0);
     }
 
-    pub async fn run(&mut self, pdf: &mut dyn PdfBackend) -> AppResult<()> {
+    pub async fn run(&mut self, pdf: SharedPdfBackend) -> AppResult<()> {
         let page_count = pdf.page_count();
         if page_count == 0 {
             return Err(AppError::invalid_argument("pdf has no pages"));
@@ -99,7 +100,7 @@ impl App {
         let (loop_event_tx, loop_event_rx, loop_event_runtime) =
             EventBusRuntime::spawn_interactive();
         let mut runtime = self.initialize_loop_runtime(
-            pdf,
+            Arc::clone(&pdf),
             page_count,
             session,
             loop_event_tx,
@@ -119,7 +120,7 @@ impl App {
 
     pub async fn run_perf(
         &mut self,
-        pdf: &mut dyn PdfBackend,
+        pdf: SharedPdfBackend,
         scenario: PerfScenarioId,
     ) -> AppResult<PerfIterationSnapshot> {
         let page_count = pdf.page_count();
@@ -134,7 +135,7 @@ impl App {
         let session = HeadlessTerminalSession::new(PERF_HEADLESS_WIDTH, PERF_HEADLESS_HEIGHT)?;
         let (loop_event_tx, loop_event_rx, loop_event_runtime) = EventBusRuntime::spawn_headless();
         let mut runtime = self.initialize_loop_runtime(
-            pdf,
+            Arc::clone(&pdf),
             page_count,
             session,
             loop_event_tx,
@@ -151,7 +152,7 @@ impl App {
 
     fn initialize_loop_runtime<S>(
         &mut self,
-        pdf: &dyn PdfBackend,
+        pdf: SharedPdfBackend,
         page_count: usize,
         session: S,
         loop_event_tx: UnboundedSender<DomainEvent>,
@@ -182,18 +183,16 @@ impl App {
         prefetch_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
         let mut redraw_tick = time::interval(pending_redraw_interval);
         redraw_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
-        let render_worker = RenderWorker::spawn(
-            pdf.path().to_path_buf(),
-            pdf.doc_id(),
-            self.config.render.worker_threads,
-        );
+        let render_worker =
+            RenderWorker::spawn(Arc::clone(&pdf), self.config.render.worker_threads);
         let viewport = Self::current_viewport(&session, self.state.debug_status_visible);
         let visible_pages = self.state.visible_page_slots(page_count);
-        let tracked_scale = self.compute_current_scale(pdf, visible_pages.anchor_page, viewport);
+        let tracked_scale =
+            self.compute_current_scale(pdf.as_ref(), visible_pages.anchor_page, viewport);
         let mut render_actor =
             RenderActor::new(visible_pages.anchor_page, self.state.zoom, tracked_scale);
         self.render.runtime.reset_prefetch(
-            pdf,
+            pdf.as_ref(),
             visible_pages.anchor_page,
             render_actor.nav_mut().intent(),
             tracked_scale,
@@ -220,11 +219,14 @@ impl App {
     async fn run_interactive_loop(
         &mut self,
         runtime: &mut LoopRuntime<InteractiveTerminalSession>,
-        pdf: &mut dyn PdfBackend,
+        pdf: SharedPdfBackend,
     ) -> AppResult<()> {
         loop {
-            let step = self.process_loop_iteration(runtime, pdf)?;
-            match self.wait_and_handle_next_event(runtime, &step, pdf).await? {
+            let step = self.process_loop_iteration(runtime, pdf.as_ref())?;
+            match self
+                .wait_and_handle_next_event(runtime, &step, Arc::clone(&pdf))
+                .await?
+            {
                 LoopControl::Continue => {}
                 LoopControl::Break => return Ok(()),
             }
@@ -234,13 +236,13 @@ impl App {
     async fn run_perf_loop(
         &mut self,
         runtime: &mut LoopRuntime<HeadlessTerminalSession>,
-        pdf: &mut dyn PdfBackend,
+        pdf: SharedPdfBackend,
         scenario: PerfScenarioId,
     ) -> AppResult<PerfIterationSnapshot> {
         let mut perf_driver = PerfLoopDriver::new(scenario);
 
         loop {
-            let step = self.process_loop_iteration(runtime, pdf)?;
+            let step = self.process_loop_iteration(runtime, pdf.as_ref())?;
             let system_idle = step.current_cached
                 && runtime.render_worker.in_flight_len() == 0
                 && !self.render.presenter.has_pending_work()
@@ -257,7 +259,10 @@ impl App {
                 });
             }
 
-            match self.wait_and_handle_next_event(runtime, &step, pdf).await? {
+            match self
+                .wait_and_handle_next_event(runtime, &step, Arc::clone(&pdf))
+                .await?
+            {
                 LoopControl::Continue => {}
                 LoopControl::Break => {
                     return Err(AppError::unsupported(
@@ -321,7 +326,7 @@ impl App {
         &mut self,
         runtime: &mut LoopRuntime<S>,
         step: &LoopStep,
-        pdf: &mut dyn PdfBackend,
+        pdf: SharedPdfBackend,
     ) -> AppResult<LoopControl>
     where
         S: TerminalSurface + SessionRestore,
@@ -491,7 +496,7 @@ impl App {
         &mut self,
         waited: WaitEvent,
         runtime: &mut LoopRuntime<S>,
-        pdf: &mut dyn PdfBackend,
+        pdf: SharedPdfBackend,
     ) -> AppResult<LoopControl>
     where
         S: TerminalSurface + SessionRestore,
@@ -520,9 +525,11 @@ impl App {
                 self.request_redraw(runtime, RedrawReason::InputError);
             }
             WaitEvent::Event(DomainEvent::Command(command)) => {
-                let dispatch = self
-                    .interaction
-                    .dispatch_command(&mut self.state, command, pdf)?;
+                let dispatch = self.interaction.dispatch_command(
+                    &mut self.state,
+                    command,
+                    Arc::clone(&pdf),
+                )?;
                 for event in dispatch.emitted_events {
                     let _ = runtime.loop_event_tx.send(DomainEvent::App(event));
                 }
@@ -546,7 +553,8 @@ impl App {
                 let viewport =
                     Self::current_viewport(&runtime.session, self.state.debug_status_visible);
                 let visible_pages = self.state.visible_page_slots(pdf.page_count());
-                let scale = self.compute_current_scale(pdf, visible_pages.anchor_page, viewport);
+                let scale =
+                    self.compute_current_scale(pdf.as_ref(), visible_pages.anchor_page, viewport);
                 let mut current_keys = vec![RenderedPageKey::new(
                     pdf.doc_id(),
                     visible_pages.anchor_page,

--- a/src/app/input_ops.rs
+++ b/src/app/input_ops.rs
@@ -1,6 +1,6 @@
 use crossterm::event::KeyEvent;
 
-use crate::backend::PdfBackend;
+use crate::backend::SharedPdfBackend;
 use crate::command::{ActionId, Command, CommandDispatchResult, dispatch, drain_background_events};
 use crate::error::AppResult;
 use crate::event::AppEvent;
@@ -181,7 +181,7 @@ impl InteractionSubsystem {
         &mut self,
         state: &mut AppState,
         command: Command,
-        pdf: &mut dyn PdfBackend,
+        pdf: SharedPdfBackend,
     ) -> AppResult<CommandDispatchResult> {
         dispatch(
             state,

--- a/src/app/tests/runtime_worker.rs
+++ b/src/app/tests/runtime_worker.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::PathBuf;
 use std::process;
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -9,7 +10,7 @@ use ratatui::backend::TestBackend;
 use ratatui::layout::Rect;
 
 use super::super::runtime::RenderRuntime;
-use crate::backend::{PdfDoc, RgbaFrame};
+use crate::backend::{PdfBackend, PdfDoc, RgbaFrame, SharedPdfBackend};
 use crate::error::AppResult;
 use crate::perf::PerfStats;
 use crate::presenter::{
@@ -262,13 +263,23 @@ fn prefetch_encode_from_cache_invokes_presenter() {
 fn render_worker_accepts_up_to_three_inflight_tasks() {
     let file = unique_temp_path("render_worker_parallel.pdf");
     fs::write(&file, build_pdf(&["p1", "p2", "p3", "p4"])).expect("test pdf should be created");
-    let doc = PdfDoc::open(&file).expect("pdf should open");
-    let mut worker = spawn_worker(file.clone(), doc.doc_id(), 3);
+    let doc = Arc::new(PdfDoc::open(&file).expect("pdf should open"));
+    let mut worker = spawn_worker(Arc::clone(&doc), 3);
 
-    assert!(worker.enqueue(render_task(&doc, 0, RenderPriority::CriticalCurrent, 1)));
-    assert!(worker.enqueue(render_task(&doc, 1, RenderPriority::DirectionalLead, 1)));
-    assert!(worker.enqueue(render_task(&doc, 2, RenderPriority::Background, 1)));
-    assert!(!worker.enqueue(render_task(&doc, 3, RenderPriority::Background, 1)));
+    assert!(worker.enqueue(render_task(
+        doc.as_ref(),
+        0,
+        RenderPriority::CriticalCurrent,
+        1
+    )));
+    assert!(worker.enqueue(render_task(
+        doc.as_ref(),
+        1,
+        RenderPriority::DirectionalLead,
+        1
+    )));
+    assert!(worker.enqueue(render_task(doc.as_ref(), 2, RenderPriority::Background, 1)));
+    assert!(!worker.enqueue(render_task(doc.as_ref(), 3, RenderPriority::Background, 1)));
     assert_eq!(worker.in_flight_len(), 3);
 
     let deadline = Instant::now() + Duration::from_secs(2);
@@ -285,13 +296,23 @@ fn render_worker_accepts_up_to_three_inflight_tasks() {
 fn render_worker_rejects_duplicate_key_while_inflight() {
     let file = unique_temp_path("render_worker_dedupe.pdf");
     fs::write(&file, build_pdf(&["p1", "p2"])).expect("test pdf should be created");
-    let doc = PdfDoc::open(&file).expect("pdf should open");
-    let mut worker = spawn_worker(file.clone(), doc.doc_id(), 3);
+    let doc = Arc::new(PdfDoc::open(&file).expect("pdf should open"));
+    let mut worker = spawn_worker(Arc::clone(&doc), 3);
     let key = RenderedPageKey::new(doc.doc_id(), 0, 1.0);
 
-    assert!(worker.enqueue(render_task(&doc, 0, RenderPriority::CriticalCurrent, 1)));
+    assert!(worker.enqueue(render_task(
+        doc.as_ref(),
+        0,
+        RenderPriority::CriticalCurrent,
+        1
+    )));
     assert!(worker.has_in_flight(&key));
-    assert!(!worker.enqueue(render_task(&doc, 0, RenderPriority::DirectionalLead, 1)));
+    assert!(!worker.enqueue(render_task(
+        doc.as_ref(),
+        0,
+        RenderPriority::DirectionalLead,
+        1
+    )));
 
     let deadline = Instant::now() + Duration::from_secs(2);
     while worker.in_flight_len() > 0 && Instant::now() < deadline {
@@ -302,7 +323,12 @@ fn render_worker_rejects_duplicate_key_while_inflight() {
     fs::remove_file(&file).expect("test pdf should be removed");
 }
 
-fn render_task(doc: &PdfDoc, page: usize, priority: RenderPriority, generation: u64) -> RenderTask {
+fn render_task(
+    doc: &dyn PdfBackend,
+    page: usize,
+    priority: RenderPriority,
+    generation: u64,
+) -> RenderTask {
     RenderTask {
         doc_id: doc.doc_id(),
         page,
@@ -313,8 +339,9 @@ fn render_task(doc: &PdfDoc, page: usize, priority: RenderPriority, generation: 
     }
 }
 
-fn spawn_worker(path: PathBuf, doc_id: u64, worker_threads: usize) -> RenderWorker {
-    RenderWorker::spawn(path, doc_id, worker_threads)
+fn spawn_worker(doc: Arc<PdfDoc>, worker_threads: usize) -> RenderWorker {
+    let doc: SharedPdfBackend = doc;
+    RenderWorker::spawn(doc, worker_threads)
 }
 
 fn drain_render_results(worker: &mut RenderWorker) -> Vec<RenderedPageKey> {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -9,8 +9,10 @@ mod traits;
 pub use hayro::{HayroPdfBackend, PdfDoc};
 pub use traits::{PdfBackend, PixelBuffer, PixelBufferPool, RgbaFrame};
 
-pub fn open_default_backend(path: impl AsRef<Path>) -> AppResult<Box<dyn PdfBackend>> {
-    PdfDoc::open(path).map(|doc| Box::new(doc) as Box<dyn PdfBackend>)
+pub type SharedPdfBackend = Arc<dyn PdfBackend>;
+
+pub fn open_default_backend(path: impl AsRef<Path>) -> AppResult<SharedPdfBackend> {
+    PdfDoc::open(path).map(|doc| Arc::new(doc) as SharedPdfBackend)
 }
 
 pub fn load_default_shared_bytes(path: impl AsRef<Path>) -> AppResult<Arc<Vec<u8>>> {
@@ -20,6 +22,6 @@ pub fn load_default_shared_bytes(path: impl AsRef<Path>) -> AppResult<Arc<Vec<u8
 pub fn open_default_backend_with_shared_bytes(
     path: impl AsRef<Path>,
     bytes: Arc<Vec<u8>>,
-) -> AppResult<Box<dyn PdfBackend>> {
-    PdfDoc::open_with_shared_bytes(path, bytes).map(|doc| Box::new(doc) as Box<dyn PdfBackend>)
+) -> AppResult<SharedPdfBackend> {
+    PdfDoc::open_with_shared_bytes(path, bytes).map(|doc| Arc::new(doc) as SharedPdfBackend)
 }

--- a/src/backend/traits.rs
+++ b/src/backend/traits.rs
@@ -132,7 +132,7 @@ impl RgbaFrame {
     }
 }
 
-pub trait PdfBackend: Send {
+pub trait PdfBackend: Send + Sync {
     fn path(&self) -> &Path;
     fn doc_id(&self) -> u64;
     fn page_count(&self) -> usize;

--- a/src/command/dispatch.rs
+++ b/src/command/dispatch.rs
@@ -1,7 +1,8 @@
 use std::collections::VecDeque;
+use std::sync::Arc;
 
 use crate::app::{AppState, Mode, PaletteRequest};
-use crate::backend::PdfBackend;
+use crate::backend::SharedPdfBackend;
 use crate::error::AppResult;
 use crate::event::{AppEvent, GotoKind, HistoryOp, NavReason};
 use crate::extension::ExtensionHost;
@@ -23,7 +24,7 @@ pub struct CommandDispatchResult {
 pub fn dispatch(
     app: &mut AppState,
     cmd: Command,
-    pdf: &mut dyn PdfBackend,
+    pdf: SharedPdfBackend,
     extension_host: &mut ExtensionHost,
     palette_requests: &mut VecDeque<PaletteRequest>,
 ) -> AppResult<CommandDispatchResult> {
@@ -72,7 +73,7 @@ pub fn dispatch(
         }
         Command::OpenSearch => Ok(extension_host.open_search_palette(app, palette_requests)),
         Command::SubmitSearch { query, matcher } => {
-            extension_host.submit_search(app, pdf, query, matcher)
+            extension_host.submit_search(app, Arc::clone(&pdf), query, matcher)
         }
         Command::NextSearchHit => Ok(extension_host.next_search_hit(app)),
         Command::PrevSearchHit => Ok(extension_host.prev_search_hit(app)),
@@ -191,9 +192,10 @@ fn derive_nav_reason(command: &Command, extension_host: &ExtensionHost) -> Optio
 mod tests {
     use std::collections::VecDeque;
     use std::path::{Path, PathBuf};
+    use std::sync::Arc;
 
     use crate::app::AppState;
-    use crate::backend::{PdfBackend, RgbaFrame};
+    use crate::backend::{PdfBackend, RgbaFrame, SharedPdfBackend};
     use crate::command::{ActionId, Command, CommandOutcome, PageLayoutModeArg, SearchMatcherKind};
     use crate::event::{AppEvent, NavReason};
     use crate::extension::ExtensionHost;
@@ -249,14 +251,14 @@ mod tests {
     #[test]
     fn dispatch_next_page_emits_page_changed_and_command_executed() {
         let mut app = AppState::default();
-        let mut pdf = StubPdf::new(3);
+        let pdf = Arc::new(StubPdf::new(3)) as SharedPdfBackend;
         let mut host = ExtensionHost::default();
         let mut palette_requests = VecDeque::new();
 
         let result = dispatch(
             &mut app,
             Command::NextPage,
-            &mut pdf,
+            pdf,
             &mut host,
             &mut palette_requests,
         )
@@ -284,14 +286,14 @@ mod tests {
     #[test]
     fn dispatch_open_palette_emits_command_executed_only() {
         let mut app = AppState::default();
-        let mut pdf = StubPdf::new(3);
+        let pdf = Arc::new(StubPdf::new(3)) as SharedPdfBackend;
         let mut host = ExtensionHost::default();
         let mut palette_requests = VecDeque::new();
 
         let result = dispatch(
             &mut app,
             Command::ClosePalette,
-            &mut pdf,
+            pdf,
             &mut host,
             &mut palette_requests,
         )
@@ -311,13 +313,13 @@ mod tests {
     #[test]
     fn dispatch_cancel_clears_active_search() {
         let mut app = AppState::default();
-        let mut pdf = StubPdf::new(3);
+        let pdf = Arc::new(StubPdf::new(3)) as SharedPdfBackend;
         let mut host = ExtensionHost::default();
         let mut palette_requests = VecDeque::new();
 
         host.submit_search(
             &mut app,
-            &pdf,
+            Arc::clone(&pdf),
             "needle".to_string(),
             SearchMatcherKind::ContainsInsensitive,
         )
@@ -327,7 +329,7 @@ mod tests {
         let result = dispatch(
             &mut app,
             Command::Cancel,
-            &mut pdf,
+            pdf,
             &mut host,
             &mut palette_requests,
         )
@@ -343,11 +345,11 @@ mod tests {
     #[test]
     fn collect_transition_events_emits_search_when_page_is_unchanged() {
         let mut app = AppState::default();
-        let pdf = StubPdf::new(3);
+        let pdf = Arc::new(StubPdf::new(3)) as SharedPdfBackend;
         let mut host = ExtensionHost::default();
         host.submit_search(
             &mut app,
-            &pdf,
+            pdf,
             "needle".to_string(),
             SearchMatcherKind::ContainsInsensitive,
         )
@@ -381,7 +383,7 @@ mod tests {
             current_page: 3,
             ..AppState::default()
         };
-        let mut pdf = StubPdf::new(8);
+        let pdf = Arc::new(StubPdf::new(8)) as SharedPdfBackend;
         let mut host = ExtensionHost::default();
         let mut palette_requests = VecDeque::new();
 
@@ -391,7 +393,7 @@ mod tests {
                 mode: PageLayoutModeArg::Spread,
                 direction: None,
             },
-            &mut pdf,
+            pdf,
             &mut host,
             &mut palette_requests,
         )

--- a/src/extension/host.rs
+++ b/src/extension/host.rs
@@ -1,13 +1,12 @@
-use std::collections::VecDeque;
-
 use crate::app::{AppState, PaletteRequest};
-use crate::backend::PdfBackend;
+use crate::backend::SharedPdfBackend;
 use crate::command::{CommandOutcome, SearchMatcherKind};
 use crate::error::AppResult;
 use crate::event::AppEvent;
 use crate::history::{HistoryExtension, HistoryState};
 use crate::input::{AppInputEvent, InputHookResult};
 use crate::search::{SearchExtension, SearchRuntime};
+use std::collections::VecDeque;
 
 use super::traits::Extension;
 
@@ -71,14 +70,14 @@ impl ExtensionHost {
     pub fn submit_search(
         &mut self,
         app: &mut AppState,
-        pdf: &dyn PdfBackend,
+        pdf: SharedPdfBackend,
         query: String,
         matcher: SearchMatcherKind,
     ) -> AppResult<CommandOutcome> {
         self.search.submit(app, pdf, query, matcher)
     }
 
-    pub fn cancel_search(&mut self, pdf: &dyn PdfBackend) -> AppResult<bool> {
+    pub fn cancel_search(&mut self, pdf: SharedPdfBackend) -> AppResult<bool> {
         self.search.cancel(pdf)
     }
 
@@ -154,8 +153,9 @@ impl Default for ExtensionHost {
 #[cfg(test)]
 mod tests {
     use std::path::{Path, PathBuf};
+    use std::sync::Arc;
 
-    use crate::backend::{PdfBackend, RgbaFrame};
+    use crate::backend::{PdfBackend, RgbaFrame, SharedPdfBackend};
     use crate::command::SearchMatcherKind;
 
     use super::ExtensionHost;
@@ -219,7 +219,7 @@ mod tests {
 
         host.submit_search(
             &mut app,
-            &pdf,
+            Arc::new(pdf) as SharedPdfBackend,
             "needle".to_string(),
             SearchMatcherKind::ContainsInsensitive,
         )
@@ -234,11 +234,11 @@ mod tests {
     fn cancel_search_clears_active_query() {
         let mut host = ExtensionHost::default();
         let mut app = crate::app::AppState::default();
-        let pdf = StubPdf::new(4);
+        let pdf = Arc::new(StubPdf::new(4)) as SharedPdfBackend;
 
         host.submit_search(
             &mut app,
-            &pdf,
+            Arc::clone(&pdf),
             "needle".to_string(),
             SearchMatcherKind::ContainsInsensitive,
         )
@@ -246,7 +246,7 @@ mod tests {
         assert!(host.ui_snapshot().search_active);
 
         let canceled = host
-            .cancel_search(&pdf)
+            .cancel_search(pdf)
             .expect("cancel-search should succeed");
         assert!(canceled);
         assert!(!host.ui_snapshot().search_active);

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,9 +67,9 @@ async fn run() -> AppResult<()> {
         return write_report(&report, perf.out.as_deref());
     }
 
-    let mut pdf = open_default_backend(&options.pdf_path)?;
+    let pdf = open_default_backend(&options.pdf_path)?;
     let mut app = App::new(PresenterKind::RatatuiImage)?;
-    app.run(pdf.as_mut()).await
+    app.run(pdf).await
 }
 
 fn parse_cli(cli: Cli) -> CliOptions {

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -462,10 +462,10 @@ pub async fn run_report(pdf_path: &Path, run: PerfRunConfig) -> AppResult<PerfRe
     let mut doc_id = None;
 
     for iteration in 0..total_iterations {
-        let mut pdf = open_default_backend(pdf_path)?;
+        let pdf = open_default_backend(pdf_path)?;
         doc_id.get_or_insert(pdf.doc_id());
         let mut app = App::new(PresenterKind::RatatuiImage)?;
-        let snapshot = app.run_perf(pdf.as_mut(), run.scenario).await?;
+        let snapshot = app.run_perf(pdf, run.scenario).await?;
         if iteration >= run.warmup_iterations {
             measured.push(snapshot);
         }

--- a/src/render/worker.rs
+++ b/src/render/worker.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::path::Path;
-use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -8,9 +6,7 @@ use tokio::runtime::{Builder, Handle, Runtime};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio::task::JoinHandle;
 
-use crate::backend::{
-    PdfBackend, RgbaFrame, load_default_shared_bytes, open_default_backend_with_shared_bytes,
-};
+use crate::backend::{RgbaFrame, SharedPdfBackend};
 use crate::error::{AppError, AppResult};
 use crate::render::cache::RenderedPageKey;
 use crate::render::scheduler::{RenderPriority, RenderTask};
@@ -22,32 +18,6 @@ enum RenderWorkerRequest {
         enqueued_at: Instant,
     },
     Shutdown,
-}
-
-pub trait RenderPdfLoader: Send + Sync {
-    fn load_shared_bytes(&self, path: &Path) -> AppResult<Arc<Vec<u8>>>;
-    fn open_with_shared_bytes(
-        &self,
-        path: &Path,
-        bytes: Arc<Vec<u8>>,
-    ) -> AppResult<Box<dyn PdfBackend>>;
-}
-
-#[derive(Debug, Default)]
-pub struct HayroRenderPdfLoader;
-
-impl RenderPdfLoader for HayroRenderPdfLoader {
-    fn load_shared_bytes(&self, path: &Path) -> AppResult<Arc<Vec<u8>>> {
-        load_default_shared_bytes(path)
-    }
-
-    fn open_with_shared_bytes(
-        &self,
-        path: &Path,
-        bytes: Arc<Vec<u8>>,
-    ) -> AppResult<Box<dyn PdfBackend>> {
-        open_default_backend_with_shared_bytes(path, bytes)
-    }
 }
 
 #[derive(Debug)]
@@ -124,41 +94,19 @@ struct InFlightTask {
 }
 
 impl RenderWorker {
-    pub(crate) fn spawn(path: PathBuf, doc_id: u64, worker_threads: usize) -> Self {
-        Self::spawn_with_loader(path, doc_id, worker_threads, Arc::new(HayroRenderPdfLoader))
-    }
-
-    pub(crate) fn spawn_with_loader(
-        path: PathBuf,
-        doc_id: u64,
-        worker_threads: usize,
-        loader: Arc<dyn RenderPdfLoader>,
-    ) -> Self {
+    pub(crate) fn spawn(pdf: SharedPdfBackend, worker_threads: usize) -> Self {
         let (request_tx, request_rx) = unbounded_channel();
         let (result_tx, result_rx) = unbounded_channel();
         let runtime = RenderWorkerRuntime::new();
         let worker_threads = worker_threads.max(1);
         let request_rx = Arc::new(Mutex::new(request_rx));
-        let shared_pdf_bytes = loader
-            .load_shared_bytes(&path)
-            .map_err(|err| err.to_string());
         let mut workers = Vec::with_capacity(worker_threads);
         for _ in 0..worker_threads {
-            let path = path.clone();
             let request_rx = Arc::clone(&request_rx);
-            let shared_pdf_bytes = shared_pdf_bytes.clone();
-            let loader = Arc::clone(&loader);
+            let pdf = Arc::clone(&pdf);
             let result_tx = result_tx.clone();
-            let worker = runtime.spawn_blocking(move || {
-                render_worker_main(
-                    path,
-                    doc_id,
-                    shared_pdf_bytes,
-                    request_rx,
-                    loader,
-                    result_tx,
-                )
-            });
+            let worker =
+                runtime.spawn_blocking(move || render_worker_main(pdf, request_rx, result_tx));
             workers.push(worker);
         }
 
@@ -356,19 +304,10 @@ impl Drop for RenderWorker {
 }
 
 fn render_worker_main(
-    path: PathBuf,
-    doc_id: u64,
-    shared_pdf_bytes: Result<Arc<Vec<u8>>, String>,
+    doc: SharedPdfBackend,
     request_rx: Arc<Mutex<UnboundedReceiver<RenderWorkerRequest>>>,
-    loader: Arc<dyn RenderPdfLoader>,
     result_tx: UnboundedSender<RenderResultEvent>,
 ) {
-    let doc = match shared_pdf_bytes {
-        Ok(bytes) => loader.open_with_shared_bytes(&path, bytes),
-        Err(message) => Err(AppError::unsupported(format!(
-            "render worker failed to load shared document bytes: {message}"
-        ))),
-    };
     loop {
         let request = match request_rx.lock() {
             Ok(mut request_rx) => request_rx.blocking_recv(),
@@ -387,20 +326,13 @@ fn render_worker_main(
             } => {
                 let key = RenderedPageKey::new(task.doc_id, task.page, task.scale);
                 let started = Instant::now();
-                let result = match &doc {
-                    Ok(doc) => {
-                        if doc.doc_id() != doc_id || task.doc_id != doc_id {
-                            Err(AppError::invalid_argument(
-                                "render task does not match active document",
-                            ))
-                        } else {
-                            doc.render_page(task.page, task.scale)
-                                .map_err(|err| AppError::pdf_render(task.page, err))
-                        }
-                    }
-                    Err(err) => Err(AppError::unsupported(format!(
-                        "render worker failed to open active document: {err}"
-                    ))),
+                let result = if doc.doc_id() != task.doc_id {
+                    Err(AppError::invalid_argument(
+                        "render task does not match active document",
+                    ))
+                } else {
+                    doc.render_page(task.page, task.scale)
+                        .map_err(|err| AppError::pdf_render(task.page, err))
                 };
 
                 let event = RenderResultEvent {
@@ -425,11 +357,12 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
     use std::process;
+    use std::sync::Arc;
     use std::thread;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     use super::RenderWorker;
-    use crate::backend::PdfDoc;
+    use crate::backend::{PdfBackend, PdfDoc, SharedPdfBackend};
     use crate::render::cache::RenderedPageKey;
     use crate::render::scheduler::{RenderPriority, RenderTask};
 
@@ -437,14 +370,14 @@ mod tests {
     fn current_enqueue_preempts_prefetch_when_worker_is_full() {
         let file = unique_temp_path("render_worker_preempt_current.pdf");
         fs::write(&file, build_pdf(&["p1", "p2"])).expect("test pdf should be created");
-        let doc = PdfDoc::open(&file).expect("pdf should open");
-        let mut worker = spawn_worker(file.clone(), doc.doc_id(), 1);
+        let doc = Arc::new(PdfDoc::open(&file).expect("pdf should open"));
+        let mut worker = spawn_worker(Arc::clone(&doc), 1);
         let old_key = RenderedPageKey::new(doc.doc_id(), 1, 1.0);
         let current_key = RenderedPageKey::new(doc.doc_id(), 0, 1.0);
 
-        assert!(worker.enqueue(render_task(&doc, 1, RenderPriority::Background, 1)));
+        assert!(worker.enqueue(render_task(doc.as_ref(), 1, RenderPriority::Background, 1)));
         let (enqueued, preempted) = worker.enqueue_current_with_preemption(
-            render_task(&doc, 0, RenderPriority::CriticalCurrent, 2),
+            render_task(doc.as_ref(), 0, RenderPriority::CriticalCurrent, 2),
             2,
             &[current_key],
         );
@@ -461,7 +394,12 @@ mod tests {
         }
 
         assert!(!completed.contains(&old_key));
-        assert!(worker.enqueue(render_task(&doc, 0, RenderPriority::CriticalCurrent, 2)));
+        assert!(worker.enqueue(render_task(
+            doc.as_ref(),
+            0,
+            RenderPriority::CriticalCurrent,
+            2
+        )));
         let deadline = Instant::now() + Duration::from_secs(2);
         while worker.in_flight_len() > 0 && Instant::now() < deadline {
             completed.extend(drain_render_results(&mut worker));
@@ -475,14 +413,14 @@ mod tests {
     fn enqueue_current_with_preemption_does_not_exceed_inflight_limit() {
         let file = unique_temp_path("render_worker_preempt_limit.pdf");
         fs::write(&file, build_pdf(&["p1", "p2"])).expect("test pdf should be created");
-        let doc = PdfDoc::open(&file).expect("pdf should open");
-        let mut worker = spawn_worker(file.clone(), doc.doc_id(), 1);
+        let doc = Arc::new(PdfDoc::open(&file).expect("pdf should open"));
+        let mut worker = spawn_worker(Arc::clone(&doc), 1);
         let keep_key = RenderedPageKey::new(doc.doc_id(), 0, 1.0);
 
-        assert!(worker.enqueue(render_task(&doc, 1, RenderPriority::Background, 1)));
+        assert!(worker.enqueue(render_task(doc.as_ref(), 1, RenderPriority::Background, 1)));
         for _ in 0..8 {
             let _ = worker.enqueue_current_with_preemption(
-                render_task(&doc, 0, RenderPriority::CriticalCurrent, 2),
+                render_task(doc.as_ref(), 0, RenderPriority::CriticalCurrent, 2),
                 2,
                 &[keep_key],
             );
@@ -496,14 +434,29 @@ mod tests {
     fn cancel_stale_prefetch_drops_results_for_old_generation_prefetch() {
         let file = unique_temp_path("render_worker_cancel_stale.pdf");
         fs::write(&file, build_pdf(&["p1", "p2", "p3", "p4"])).expect("test pdf should be created");
-        let doc = PdfDoc::open(&file).expect("pdf should open");
-        let mut worker = spawn_worker(file.clone(), doc.doc_id(), 4);
+        let doc = Arc::new(PdfDoc::open(&file).expect("pdf should open"));
+        let mut worker = spawn_worker(Arc::clone(&doc), 4);
         let current_key = RenderedPageKey::new(doc.doc_id(), 0, 1.0);
 
-        assert!(worker.enqueue(render_task(&doc, 0, RenderPriority::CriticalCurrent, 1)));
-        assert!(worker.enqueue(render_task(&doc, 1, RenderPriority::DirectionalLead, 1)));
-        assert!(worker.enqueue(render_task(&doc, 2, RenderPriority::Background, 1)));
-        assert!(worker.enqueue(render_task(&doc, 3, RenderPriority::GuardReverse, 1)));
+        assert!(worker.enqueue(render_task(
+            doc.as_ref(),
+            0,
+            RenderPriority::CriticalCurrent,
+            1
+        )));
+        assert!(worker.enqueue(render_task(
+            doc.as_ref(),
+            1,
+            RenderPriority::DirectionalLead,
+            1
+        )));
+        assert!(worker.enqueue(render_task(doc.as_ref(), 2, RenderPriority::Background, 1)));
+        assert!(worker.enqueue(render_task(
+            doc.as_ref(),
+            3,
+            RenderPriority::GuardReverse,
+            1
+        )));
 
         let canceled = worker.cancel_stale_prefetch_except(2, &[current_key]);
         assert_eq!(canceled, 2);
@@ -523,7 +476,7 @@ mod tests {
     }
 
     fn render_task(
-        doc: &PdfDoc,
+        doc: &dyn PdfBackend,
         page: usize,
         priority: RenderPriority,
         generation: u64,
@@ -538,8 +491,9 @@ mod tests {
         }
     }
 
-    fn spawn_worker(path: PathBuf, doc_id: u64, worker_threads: usize) -> RenderWorker {
-        RenderWorker::spawn(path, doc_id, worker_threads)
+    fn spawn_worker(doc: Arc<PdfDoc>, worker_threads: usize) -> RenderWorker {
+        let doc: SharedPdfBackend = doc;
+        RenderWorker::spawn(doc, worker_threads)
     }
 
     fn drain_render_results(worker: &mut RenderWorker) -> Vec<RenderedPageKey> {

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -1,4 +1,3 @@
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use tokio::runtime::{Builder, Handle, Runtime};
@@ -7,7 +6,7 @@ use tokio::sync::mpsc::{
 };
 use tokio::task::JoinHandle;
 
-use crate::backend::{PdfBackend, open_default_backend};
+use crate::backend::SharedPdfBackend;
 use crate::error::{AppError, AppResult};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -31,23 +30,10 @@ pub trait SearchMatcher: Send + Sync {
     fn matches_page(&self, page_text: &str, prepared_query: &str) -> bool;
 }
 
-pub trait SearchPdfLoader: Send + Sync {
-    fn load(&self, path: &Path) -> AppResult<Box<dyn PdfBackend>>;
-}
-
-#[derive(Debug, Default)]
-pub struct HayroSearchPdfLoader;
-
-impl SearchPdfLoader for HayroSearchPdfLoader {
-    fn load(&self, path: &Path) -> AppResult<Box<dyn PdfBackend>> {
-        open_default_backend(path)
-    }
-}
-
 #[derive(Clone)]
 struct SearchJob {
     generation: u64,
-    pdf_path: PathBuf,
+    pdf: SharedPdfBackend,
     query: String,
     matcher: Arc<dyn SearchMatcher>,
 }
@@ -112,14 +98,10 @@ impl Default for SearchEngine {
 
 impl SearchEngine {
     pub fn new() -> Self {
-        Self::new_with_loader(Arc::new(HayroSearchPdfLoader))
-    }
-
-    pub fn new_with_loader(loader: Arc<dyn SearchPdfLoader>) -> Self {
         let (request_tx, request_rx) = unbounded_channel();
         let (event_tx, event_rx) = unbounded_channel();
         let runtime = SearchWorkerRuntime::new();
-        let worker = runtime.spawn_blocking(move || worker_main(request_rx, event_tx, loader));
+        let worker = runtime.spawn_blocking(move || worker_main(request_rx, event_tx));
 
         Self {
             request_tx,
@@ -132,7 +114,7 @@ impl SearchEngine {
 
     pub fn submit(
         &mut self,
-        pdf_path: &Path,
+        pdf: SharedPdfBackend,
         query: impl Into<String>,
         matcher: Arc<dyn SearchMatcher>,
     ) -> AppResult<u64> {
@@ -141,7 +123,7 @@ impl SearchEngine {
         let generation = self.next_generation;
         let job = SearchJob {
             generation,
-            pdf_path: pdf_path.to_path_buf(),
+            pdf,
             query: query.into(),
             matcher,
         };
@@ -153,8 +135,8 @@ impl SearchEngine {
         Ok(generation)
     }
 
-    pub fn cancel(&mut self, pdf_path: &Path) -> AppResult<u64> {
-        self.submit(pdf_path, String::new(), Arc::new(CancelMatcher))
+    pub fn cancel(&mut self, pdf: SharedPdfBackend) -> AppResult<u64> {
+        self.submit(pdf, String::new(), Arc::new(CancelMatcher))
     }
 
     pub fn drain_events(&mut self) -> Vec<SearchEvent> {
@@ -197,7 +179,6 @@ impl Drop for SearchEngine {
 fn worker_main(
     mut request_rx: UnboundedReceiver<WorkerRequest>,
     event_tx: UnboundedSender<SearchEvent>,
-    loader: Arc<dyn SearchPdfLoader>,
 ) {
     let mut pending: Option<SearchJob> = None;
 
@@ -210,13 +191,7 @@ fn worker_main(
             },
         };
 
-        match run_job(
-            job,
-            &mut request_rx,
-            &event_tx,
-            &mut pending,
-            loader.as_ref(),
-        ) {
+        match run_job(job, &mut request_rx, &event_tx, &mut pending) {
             WorkerControl::Continue => {}
             WorkerControl::Shutdown => break,
         }
@@ -235,7 +210,6 @@ fn run_job(
     request_rx: &mut UnboundedReceiver<WorkerRequest>,
     event_tx: &UnboundedSender<SearchEvent>,
     pending: &mut Option<SearchJob>,
-    loader: &dyn SearchPdfLoader,
 ) -> WorkerControl {
     let query = job.matcher.prepare_query(job.query.trim());
     if query.is_empty() {
@@ -254,16 +228,7 @@ fn run_job(
         return WorkerControl::Continue;
     }
 
-    let doc = match loader.load(&job.pdf_path) {
-        Ok(doc) => doc,
-        Err(err) => {
-            let _ = event_tx.send(SearchEvent::Failed {
-                generation: job.generation,
-                message: err.to_string(),
-            });
-            return WorkerControl::Continue;
-        }
-    };
+    let doc = job.pdf;
 
     let total_pages = doc.page_count();
 
@@ -337,6 +302,7 @@ mod tests {
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     use super::{SearchEngine, SearchEvent, SearchMatcher};
+    use crate::backend::open_default_backend;
 
     #[derive(Debug)]
     struct ContainsMatcher {
@@ -377,9 +343,10 @@ mod tests {
         fs::write(&file, build_pdf(&["one"])).expect("test file should be created");
 
         let mut engine = SearchEngine::new();
+        let pdf = open_default_backend(&file).expect("pdf should open");
         let gen1 = engine
             .submit(
-                &file,
+                Arc::clone(&pdf),
                 "one",
                 Arc::new(ContainsMatcher {
                     case_sensitive: false,
@@ -388,7 +355,7 @@ mod tests {
             .expect("first submit should succeed");
         let gen2 = engine
             .submit(
-                &file,
+                pdf,
                 "two",
                 Arc::new(ContainsMatcher {
                     case_sensitive: false,
@@ -408,16 +375,17 @@ mod tests {
         fs::write(&file, build_pdf(&["one", "two", "three"])).expect("test file should be created");
 
         let mut engine = SearchEngine::new();
+        let pdf = open_default_backend(&file).expect("pdf should open");
         let running_generation = engine
             .submit(
-                &file,
+                Arc::clone(&pdf),
                 "one",
                 Arc::new(ContainsMatcher {
                     case_sensitive: false,
                 }),
             )
             .expect("submit should succeed");
-        let cancel_generation = engine.cancel(&file).expect("cancel should succeed");
+        let cancel_generation = engine.cancel(pdf).expect("cancel should succeed");
 
         assert_eq!(cancel_generation, running_generation + 1);
         let hits = wait_for_completed_hits(&mut engine, cancel_generation);
@@ -433,9 +401,10 @@ mod tests {
             .expect("test file should be created");
 
         let mut engine = SearchEngine::new();
+        let pdf = open_default_backend(&file).expect("pdf should open");
         let generation = engine
             .submit(
-                &file,
+                pdf,
                 "alpha",
                 Arc::new(ContainsMatcher {
                     case_sensitive: false,
@@ -456,9 +425,10 @@ mod tests {
             .expect("test file should be created");
 
         let mut engine = SearchEngine::new();
+        let pdf = open_default_backend(&file).expect("pdf should open");
         let generation = engine
             .submit(
-                &file,
+                pdf,
                 "alpha",
                 Arc::new(ContainsMatcher {
                     case_sensitive: true,
@@ -482,9 +452,10 @@ mod tests {
         .expect("test file should be created");
 
         let mut engine = SearchEngine::new();
+        let pdf = open_default_backend(&file).expect("pdf should open");
         let generation = engine
             .submit(
-                &file,
+                pdf,
                 "hello world",
                 Arc::new(ContainsMatcher {
                     case_sensitive: false,

--- a/src/search/state.rs
+++ b/src/search/state.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use crossterm::event::KeyCode;
 
 use crate::app::{AppState, PaletteRequest};
-use crate::backend::PdfBackend;
+use crate::backend::SharedPdfBackend;
 use crate::command::{ActionId, Command, CommandOutcome, SearchMatcherKind};
 use crate::error::AppResult;
 use crate::input::{AppInputEvent, InputHookResult};
@@ -37,7 +37,7 @@ impl SearchRuntime {
     pub fn submit(
         &mut self,
         app: &mut AppState,
-        pdf: &dyn PdfBackend,
+        pdf: SharedPdfBackend,
         query: String,
         matcher: SearchMatcherKind,
     ) -> AppResult<CommandOutcome> {
@@ -45,7 +45,7 @@ impl SearchRuntime {
             .submit(app, pdf, &mut self.engine, query, matcher)
     }
 
-    pub fn cancel(&mut self, pdf: &dyn PdfBackend) -> AppResult<bool> {
+    pub fn cancel(&mut self, pdf: SharedPdfBackend) -> AppResult<bool> {
         self.state.cancel(pdf, &mut self.engine)
     }
 
@@ -141,7 +141,7 @@ impl SearchState {
     pub fn submit(
         &mut self,
         app: &mut AppState,
-        pdf: &dyn PdfBackend,
+        pdf: SharedPdfBackend,
         search_engine: &mut SearchEngine,
         query: String,
         matcher: SearchMatcherKind,
@@ -152,7 +152,7 @@ impl SearchState {
 
         let query = self.query.trim().to_string();
         if query.is_empty() {
-            self.generation = search_engine.cancel(pdf.path())?;
+            self.generation = search_engine.cancel(Arc::clone(&pdf))?;
             self.query.clear();
             self.clear_results();
             app.status.message = "search query is empty".to_string();
@@ -160,7 +160,7 @@ impl SearchState {
         }
 
         let matcher = matcher_for_kind(self.matcher);
-        let generation = search_engine.submit(pdf.path(), query.clone(), matcher)?;
+        let generation = search_engine.submit(Arc::clone(&pdf), query.clone(), matcher)?;
 
         self.query = query;
         self.generation = generation;
@@ -185,14 +185,14 @@ impl SearchState {
 
     pub fn cancel(
         &mut self,
-        pdf: &dyn PdfBackend,
+        pdf: SharedPdfBackend,
         search_engine: &mut SearchEngine,
     ) -> AppResult<bool> {
         if self.query.is_empty() {
             return Ok(false);
         }
 
-        self.generation = search_engine.cancel(pdf.path())?;
+        self.generation = search_engine.cancel(pdf)?;
         self.query.clear();
         self.clear_results();
         Ok(true)
@@ -406,11 +406,12 @@ fn remove_whitespace(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use std::path::{Path, PathBuf};
+    use std::sync::Arc;
 
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     use crate::app::AppState;
-    use crate::backend::{PdfBackend, RgbaFrame};
+    use crate::backend::{PdfBackend, RgbaFrame, SharedPdfBackend};
     use crate::command::{CommandOutcome, SearchMatcherKind};
     use crate::search::engine::SearchEngine;
 
@@ -494,13 +495,13 @@ mod tests {
     fn submit_search_marks_search_active() {
         let mut state = SearchState::default();
         let mut app = AppState::default();
-        let pdf = StubPdf::new(5);
+        let pdf = Arc::new(StubPdf::new(5)) as SharedPdfBackend;
         let mut engine = SearchEngine::new();
 
         let outcome = state
             .submit(
                 &mut app,
-                &pdf,
+                Arc::clone(&pdf),
                 &mut engine,
                 "needle".to_string(),
                 SearchMatcherKind::ContainsInsensitive,
@@ -521,13 +522,13 @@ mod tests {
     fn submit_empty_query_clears_search_active() {
         let mut state = SearchState::default();
         let mut app = AppState::default();
-        let pdf = StubPdf::new(2);
+        let pdf = Arc::new(StubPdf::new(2)) as SharedPdfBackend;
         let mut engine = SearchEngine::new();
 
         state
             .submit(
                 &mut app,
-                &pdf,
+                Arc::clone(&pdf),
                 &mut engine,
                 "needle".to_string(),
                 SearchMatcherKind::ContainsInsensitive,
@@ -538,7 +539,7 @@ mod tests {
         let outcome = state
             .submit(
                 &mut app,
-                &pdf,
+                Arc::clone(&pdf),
                 &mut engine,
                 "   ".to_string(),
                 SearchMatcherKind::ContainsInsensitive,
@@ -555,13 +556,13 @@ mod tests {
     fn cancel_clears_active_search_state() {
         let mut state = SearchState::default();
         let mut app = AppState::default();
-        let pdf = StubPdf::new(2);
+        let pdf = Arc::new(StubPdf::new(2)) as SharedPdfBackend;
         let mut engine = SearchEngine::new();
 
         state
             .submit(
                 &mut app,
-                &pdf,
+                Arc::clone(&pdf),
                 &mut engine,
                 "needle".to_string(),
                 SearchMatcherKind::ContainsInsensitive,
@@ -570,7 +571,7 @@ mod tests {
         assert!(state.is_active());
 
         let canceled = state
-            .cancel(&pdf, &mut engine)
+            .cancel(Arc::clone(&pdf), &mut engine)
             .expect("cancel should succeed");
         assert!(canceled);
         assert!(!state.is_active());
@@ -603,13 +604,13 @@ mod tests {
     fn on_background_ignores_synthetic_events_after_cancel() {
         let mut state = SearchState::default();
         let mut app = AppState::default();
-        let pdf = StubPdf::new(2);
+        let pdf = Arc::new(StubPdf::new(2)) as SharedPdfBackend;
         let mut engine = SearchEngine::new();
 
         state
             .submit(
                 &mut app,
-                &pdf,
+                Arc::clone(&pdf),
                 &mut engine,
                 "needle".to_string(),
                 SearchMatcherKind::ContainsInsensitive,
@@ -617,7 +618,7 @@ mod tests {
             .expect("submit should succeed");
         app.status.message = "search canceled".to_string();
         state
-            .cancel(&pdf, &mut engine)
+            .cancel(Arc::clone(&pdf), &mut engine)
             .expect("cancel should succeed");
 
         for _ in 0..20 {


### PR DESCRIPTION
## Summary
- replace per-call PDF reopening with `SharedPdfBackend` handles shared across the app, render worker, and search worker
- update command dispatch, extension/search state, and app runtime to pass shared backend references instead of mutable trait objects
- align tests and entrypoints with the shared backend model and require `PdfBackend: Send + Sync`

## Verification
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured PDF backend architecture for improved document management, rendering, and search functionality. Enhanced command dispatching and event handling systems. Refined render worker and search engine integration. These internal architectural improvements strengthen code maintainability and support long-term application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->