### PR TITLE
fix(view): show loading overlay during pending renders

### DIFF
--- a/docs/rendering-pipeline.md
+++ b/docs/rendering-pipeline.md
@@ -147,6 +147,7 @@ UI contract:
   - image content,
   - loading overlay,
   - error overlay.
+- When the current page is pending and an older image is still visible, the loading overlay is drawn on top of that existing image instead of suppressing it.
 
 ## Pending redraw timer behavior
 

--- a/src/app/view_ops.rs
+++ b/src/app/view_ops.rs
@@ -410,11 +410,7 @@ fn decide_viewer_display(
                 show_loading = true;
             }
         }
-        PresenterFeedback::Pending => {
-            if !viewer_has_image || outcome.drew_image {
-                show_loading = true;
-            }
-        }
+        PresenterFeedback::Pending => show_loading = true,
         PresenterFeedback::Failed => show_error = true,
     }
     ViewerDisplayDecision {
@@ -692,7 +688,7 @@ mod tests {
     }
 
     #[test]
-    fn display_decision_keeps_previous_image_when_pending_and_viewer_has_image() {
+    fn display_decision_overlays_loading_when_pending_and_viewer_has_image() {
         let decision = decide_viewer_display(
             PresenterRenderOutcome {
                 drew_image: false,
@@ -705,7 +701,7 @@ mod tests {
             decision,
             ViewerDisplayDecision {
                 clear: false,
-                show_loading: false,
+                show_loading: true,
                 show_error: false,
             }
         );


### PR DESCRIPTION
Restores the intended loading behavior during page switches.

Pending renders now always show the loading overlay, even when an older image is still visible.

Verification:
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Loading overlay now consistently appears on top of existing images when awaiting new page content, providing improved visual feedback and clearer indication of loading states during page transitions.

* **Documentation**
  * Updated rendering pipeline documentation to specify UI display behavior and contract requirements for content loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->