### PR TITLE
feat(ui): add shared theme tokens

### DIFF
--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -1,5 +1,4 @@
 use ratatui::Frame;
-use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Wrap};
 use unicode_width::UnicodeWidthStr;
@@ -7,6 +6,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::app::{AppState, Notice, NoticeLevel, PageLayoutMode};
 
 use super::layout::UiLayout;
+use super::{border, error_text, primary_text, warning_text};
 
 #[allow(clippy::too_many_arguments)]
 pub fn draw_chrome(
@@ -28,11 +28,11 @@ pub fn draw_chrome(
     );
     let primary = if let Some(notice) = app.notice.as_ref() {
         Paragraph::new(stylize_notice_line(notice, layout.status.width as usize))
-            .style(Style::default())
+            .style(primary_text())
             .wrap(Wrap { trim: true })
     } else {
         Paragraph::new(stylize_status_line(&status_text))
-            .style(Style::default())
+            .style(primary_text())
             .wrap(Wrap { trim: true })
     };
     if app.debug_status_visible && layout.status.height >= 2 {
@@ -52,7 +52,7 @@ pub fn draw_chrome(
             layout.status.height.saturating_sub(1).max(1),
         );
         let debug = Paragraph::new(presenter_path_text)
-            .style(Style::default())
+            .style(primary_text())
             .wrap(Wrap { trim: true });
         frame.render_widget(debug, bottom);
         return;
@@ -158,12 +158,9 @@ fn stylize_status_line(text: &str) -> Line<'static> {
     let mut spans: Vec<Span<'static>> = Vec::new();
     for (idx, part) in text.split(" | ").enumerate() {
         if idx > 0 {
-            spans.push(Span::styled(
-                " | ".to_string(),
-                Style::default().fg(Color::DarkGray),
-            ));
+            spans.push(Span::styled(" | ".to_string(), border()));
         }
-        spans.push(Span::raw(part.to_string()));
+        spans.push(Span::styled(part.to_string(), primary_text()));
     }
     Line::from(spans)
 }
@@ -174,11 +171,11 @@ fn stylize_notice_line(notice: &Notice, max_width: usize) -> Line<'static> {
         NoticeLevel::Error => "error",
     };
     let accent = match notice.level {
-        NoticeLevel::Warning => Color::Yellow,
-        NoticeLevel::Error => Color::Red,
+        NoticeLevel::Warning => warning_text(),
+        NoticeLevel::Error => error_text(),
     };
     let text = truncate_right_by_width(&format!("{label}: {}", notice.message), max_width);
-    Line::from(vec![Span::styled(text, Style::default().fg(accent))])
+    Line::from(vec![Span::styled(text, accent)])
 }
 
 fn display_width(text: &str) -> usize {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,7 +1,11 @@
 mod chrome;
 mod layout;
 mod overlay;
+mod theme;
 
 pub use chrome::draw_chrome;
 pub use layout::{UiLayout, split_layout};
 pub use overlay::{draw_error_overlay, draw_loading_overlay, draw_palette_overlay};
+pub(crate) use theme::{
+    border, error_text, heading_text, primary_text, secondary_text, warning_text,
+};

--- a/src/ui/overlay.rs
+++ b/src/ui/overlay.rs
@@ -1,6 +1,6 @@
 use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 use unicode_segmentation::UnicodeSegmentation;
@@ -9,6 +9,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::palette::{PaletteItemView, PaletteView};
 
 use super::layout::centered_rect;
+use super::{border, error_text, primary_text, secondary_text};
 
 const PALETTE_ITEM_DECORATION_WIDTH: usize = 3;
 const MIN_VISIBLE_SIDE_WIDTH: usize = 4;
@@ -37,7 +38,7 @@ pub fn draw_loading_overlay(frame: &mut Frame<'_>, area: Rect, label: &str) {
             Constraint::Fill(1),
         ])
         .split(popup)[1];
-    let message = Paragraph::new(message).style(Style::default().fg(Color::White));
+    let message = Paragraph::new(message).style(primary_text());
     frame.render_widget(message, message_area);
 }
 
@@ -54,7 +55,7 @@ pub fn draw_error_overlay(frame: &mut Frame<'_>, area: Rect, message: &str) {
     let block = Block::default()
         .title("Render Error")
         .borders(Borders::ALL)
-        .style(Style::default().fg(Color::Red));
+        .style(error_text());
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -65,7 +66,7 @@ pub fn draw_error_overlay(frame: &mut Frame<'_>, area: Rect, message: &str) {
     let text = truncate_to_width(message, inner.width as usize);
     let paragraph = Paragraph::new(text)
         .alignment(Alignment::Center)
-        .style(Style::default().fg(Color::White));
+        .style(error_text());
     frame.render_widget(paragraph, inner);
 }
 
@@ -83,7 +84,7 @@ pub fn draw_palette_overlay(frame: &mut Frame<'_>, area: Rect, view: &PaletteVie
         .title(format!(" {} ", view.title))
         .borders(Borders::ALL)
         .border_type(ratatui::widgets::BorderType::Rounded)
-        .border_style(Style::default().fg(Color::DarkGray));
+        .border_style(border());
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -106,7 +107,7 @@ pub fn draw_palette_overlay(frame: &mut Frame<'_>, area: Rect, view: &PaletteVie
     frame.set_cursor_position((chunks[0].x + input_layout.cursor_col, chunks[0].y));
 
     // 2. Separator
-    let sep_style = Style::default().fg(Color::DarkGray);
+    let sep_style = secondary_text();
     let sep_char = "─";
     frame.render_widget(
         Paragraph::new(sep_char.repeat(inner.width as usize)).style(sep_style),
@@ -124,7 +125,7 @@ pub fn draw_palette_overlay(frame: &mut Frame<'_>, area: Rect, view: &PaletteVie
     {
         lines.push(Line::from(vec![
             Span::raw("   "),
-            Span::styled(assistive, Style::default().fg(Color::DarkGray)),
+            Span::styled(assistive, secondary_text()),
         ]));
         overhead_lines += 1;
     }
@@ -394,13 +395,13 @@ fn palette_text_style(tone: crate::palette::PaletteTextTone, selected: bool) -> 
     }
 
     match tone {
-        crate::palette::PaletteTextTone::Primary => Style::default(),
-        crate::palette::PaletteTextTone::Secondary => Style::default().fg(Color::DarkGray),
+        crate::palette::PaletteTextTone::Primary => primary_text(),
+        crate::palette::PaletteTextTone::Secondary => secondary_text(),
     }
 }
 
 fn selected_text_style() -> Style {
-    Style::default().add_modifier(Modifier::REVERSED)
+    primary_text().add_modifier(Modifier::REVERSED)
 }
 
 fn truncate_to_width(text: &str, max_width: usize) -> String {
@@ -465,7 +466,7 @@ struct PaletteInputLineLayout {
 fn build_palette_input_line(input: &str, cursor: usize, width: usize) -> PaletteInputLineLayout {
     let prefix_spans = vec![
         Span::raw(" ".to_string()),
-        Span::styled("> ".to_string(), Style::default().fg(Color::White)),
+        Span::styled("> ".to_string(), primary_text()),
     ];
     let prefix_width = 3;
     let max_text_width = width.saturating_sub(prefix_width);

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,0 +1,25 @@
+use ratatui::style::{Color, Modifier, Style};
+
+pub fn primary_text() -> Style {
+    Style::default()
+}
+
+pub fn secondary_text() -> Style {
+    Style::default().fg(Color::Gray)
+}
+
+pub fn heading_text() -> Style {
+    Style::default().add_modifier(Modifier::BOLD)
+}
+
+pub fn border() -> Style {
+    Style::default().fg(Color::Gray)
+}
+
+pub fn warning_text() -> Style {
+    Style::default().fg(Color::LightYellow)
+}
+
+pub fn error_text() -> Style {
+    Style::default().fg(Color::LightRed)
+}


### PR DESCRIPTION
Extract shared UI theme tokens and route chrome/overlay rendering through them so the UI uses one style source.

Verification:
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized UI styling system by introducing shared style helpers for consistent text and border rendering across interface components. Internal styling logic has been standardized and reorganized for improved maintainability, with no visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->