### PR TITLE
refactor(input): normalize shortcut notation formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ cargo run --release -- perf <file.pdf> --scenario page-flip-forward --out report
 | `H` / `J` / `K` / `L` | Pan |
 | `/` | Open search palette |
 | `n` / `N` | Next search hit / Previous search hit |
-| `Ctrl+O` / `Ctrl+I` | History back / History forward |
+| `<c-o>` / `<c-i>` | History back / History forward |
 | `?` | Open help overlay |
 | `:` | Open command palette |
-| `Esc` | Cancel current interactive state |
+| `<esc>` | Cancel current interactive state |
 | `q` | Quit |
 
 ## Common Commands

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -50,22 +50,22 @@ Rules:
   - case-sensitive and case-insensitive matcher modes
   - asynchronous scanning with progress updates
   - compact search status segment in chrome/status bar while active
-  - `Esc` in normal mode cancels active search state after any pending key sequence either consumes `Esc` or clears
+  - `<esc>` in normal mode cancels active search state after any pending key sequence either consumes `<esc>` or clears
   - command form: `cancel-search` cancels active search state when search is active
   - command form: `search` opens the dedicated search palette
   - search palette keeps a recent query history
-  - while search palette is open, `Up` / `Down` navigate query history and `Ctrl+P` / `Ctrl+N` select the matcher
+  - while search palette is open, `<up>` / `<down>` navigate query history and `<c-p>` / `<c-n>` select the matcher
   - `next-search-hit` / `prev-search-hit` are available only while search is active
 
 - Command palette:
   - keeps a recent command input history
-  - while command palette is open, `Up` / `Down` navigate command history and `Ctrl+P` / `Ctrl+N` move the candidate selection
+  - while command palette is open, `<up>` / `<down>` navigate command history and `<c-p>` / `<c-n>` move the candidate selection
 
 - Help:
   - command form: `help` opens the modal shortcut help overlay
   - `?` opens the modal shortcut help overlay
   - the overlay shows the current global keymap bindings
-  - `Esc` closes the help overlay
+  - `<esc>` closes the help overlay
 
 - History:
   - back/forward navigation history
@@ -115,11 +115,11 @@ terminal reports, regardless of which keys produced it.
 | `/`      | Open search palette |
 | `n`      | Next search hit |
 | `N`      | Previous search hit |
-| `Ctrl+O` | History back |
-| `Ctrl+I` | History forward |
+| `<c-o>` | History back |
+| `<c-i>` | History forward |
 | `?`      | Open shortcut help |
 | `q`      | Quit |
-| `Esc`    | Cancel / close current interactive surface |
+| `<esc>`  | Cancel / close current interactive surface |
 
 ## Core runtime composition
 

--- a/docs/palette-provider.md
+++ b/docs/palette-provider.md
@@ -74,11 +74,11 @@ Return `None` to keep the manager's normal first-item behavior.
 
 ## Keyboard semantics
 
-- `Esc`: close current palette.
-- `Ctrl+P` / `Ctrl+N`: move selection.
-- `Up` / `Down`: move input history in command/search palettes; move selection in history/outline palettes.
-- `Tab`: apply provider `on_tab`.
-- `Enter`: apply provider `on_submit`.
+- `<esc>`: close current palette.
+- `<c-p>` / `<c-n>`: move selection.
+- `<up>` / `<down>`: move input history in command/search palettes; move selection in history/outline palettes.
+- `<tab>`: apply provider `on_tab`.
+- `<enter>`: apply provider `on_submit`.
 
 ## Tab effect contract
 
@@ -120,8 +120,8 @@ Return `None` to keep the manager's normal first-item behavior.
 ## Command palette (`PaletteKind::Command`)
 
 - Open shortcut in normal mode: `:`
-- `Up` / `Down` recall recent command inputs
-- `Ctrl+P` / `Ctrl+N` move the candidate selection
+- `<up>` / `<down>` recall recent command inputs
+- `<c-p>` / `<c-n>` move the candidate selection
 - Enter behavior:
   1. If input parses as a valid command with args, dispatch directly.
   2. Else if selected candidate has no required args, dispatch directly.
@@ -149,8 +149,8 @@ Return `None` to keep the manager's normal first-item behavior.
 - Open shortcut in normal mode: `/`
 - Also invocable by command palette command: `search`
 - Input mode: `FreeText`
-- `Up` / `Down` recall recent search queries
-- `Ctrl+P` / `Ctrl+N` move the matcher selection
+- `<up>` / `<down>` recall recent search queries
+- `<c-p>` / `<c-n>` move the matcher selection
 - Candidate list exposes matcher choices:
   - `contains-insensitive` (default)
   - `contains-sensitive`

--- a/src/history/palette.rs
+++ b/src/history/palette.rs
@@ -1,5 +1,6 @@
 use crate::command::Command;
 use crate::error::AppResult;
+use crate::input::shortcut::format_shortcut_key;
 use crate::palette::{
     PaletteCandidate, PaletteContext, PaletteInputMode, PaletteKind, PalettePayload,
     PalettePostAction, PaletteProvider, PaletteSearchText, PaletteSubmitEffect, PaletteTextPart,
@@ -99,7 +100,10 @@ impl PaletteProvider for HistoryPaletteProvider {
         _ctx: &PaletteContext<'_>,
         _selected: Option<&PaletteCandidate>,
     ) -> Option<String> {
-        Some("Enter: jump to page".to_string())
+        let enter = format_shortcut_key(crate::input::shortcut::ShortcutKey::key(
+            crossterm::event::KeyCode::Enter,
+        ));
+        Some(format!("{enter} jump to page"))
     }
 
     fn initial_input(&self, _seed: Option<&str>) -> String {
@@ -563,15 +567,15 @@ mod tests {
 
         assert_eq!(
             provider.assistive_text(&ctx, Some(&current)),
-            Some("Enter: jump to page".to_string())
+            Some("<enter> jump to page".to_string())
         );
         assert_eq!(
             provider.assistive_text(&ctx, Some(&other)),
-            Some("Enter: jump to page".to_string())
+            Some("<enter> jump to page".to_string())
         );
         assert_eq!(
             provider.assistive_text(&ctx, None),
-            Some("Enter: jump to page".to_string())
+            Some("<enter> jump to page".to_string())
         );
     }
 

--- a/src/input/sequence.rs
+++ b/src/input/sequence.rs
@@ -230,7 +230,12 @@ impl SequenceResolver {
     pub fn handle_key(&mut self, key: KeyEvent) -> SequenceResolution {
         match normalize_key(key) {
             Some(key) => self.handle_normalized_key(key),
-            None => SequenceResolution::Noop,
+            None if self.state.is_empty() => SequenceResolution::Noop,
+            None if self.state.is_timed_out() => self.confirm_pending(),
+            None => {
+                self.state.clear();
+                SequenceResolution::Cleared
+            }
         }
     }
 
@@ -717,14 +722,22 @@ mod tests {
     fn unsupported_modifier_input_is_ignored() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('k')], Command::PrevPage)
-            .expect("single-key binding should register");
+            .register_static(
+                &[ShortcutKey::char('g'), ShortcutKey::char('g')],
+                Command::LastPage,
+            )
+            .expect("multi-key binding should register");
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
+
+        assert_eq!(
+            resolver.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+            SequenceResolution::Pending
+        );
 
         let resolution =
             resolver.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::SUPER));
 
-        assert_eq!(resolution, SequenceResolution::Noop);
+        assert_eq!(resolution, SequenceResolution::Cleared);
         assert_eq!(resolver.pending_display(), None);
     }
 }

--- a/src/input/sequence.rs
+++ b/src/input/sequence.rs
@@ -228,7 +228,10 @@ impl SequenceResolver {
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> SequenceResolution {
-        self.handle_normalized_key(normalize_key(key))
+        match normalize_key(key) {
+            Some(key) => self.handle_normalized_key(key),
+            None => SequenceResolution::Noop,
+        }
     }
 
     fn handle_normalized_key(&mut self, key: ShortcutKey) -> SequenceResolution {
@@ -252,11 +255,11 @@ impl SequenceResolver {
                 };
             }
 
-            if key.code == KeyCode::Esc {
+            if key.code() == KeyCode::Esc {
                 self.state.clear();
                 return SequenceResolution::Cleared;
             }
-            if key.code == KeyCode::Enter {
+            if key.code() == KeyCode::Enter {
                 return self.confirm_pending();
             }
         }
@@ -352,8 +355,8 @@ fn match_numeric_prefix(
     let mut index = 0;
 
     while let Some(key) = buffer.get(index) {
-        if let KeyCode::Char(ch) = key.code
-            && key.modifiers == KeyModifiers::NONE
+        if let KeyCode::Char(ch) = key.code()
+            && key.modifiers() == KeyModifiers::NONE
             && ch.is_ascii_digit()
         {
             digits.push(ch);
@@ -381,15 +384,17 @@ fn match_numeric_prefix(
     }
 }
 
-fn normalize_key(key: KeyEvent) -> ShortcutKey {
-    normalize_shortcut_key(ShortcutKey::new(key.code, key.modifiers))
+fn normalize_key(key: KeyEvent) -> Option<ShortcutKey> {
+    ShortcutKey::try_new(key.code, key.modifiers)
+        .ok()
+        .map(normalize_shortcut_key)
 }
 
 fn canonicalize_binding_key(key: ShortcutKey) -> Result<ShortcutKey, SequenceRegistrationError> {
-    if matches!(key.code, KeyCode::Char(_))
-        && key.modifiers.contains(KeyModifiers::SHIFT)
+    if matches!(key.code(), KeyCode::Char(_))
+        && key.modifiers().contains(KeyModifiers::SHIFT)
         && !key
-            .modifiers
+            .modifiers()
             .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
     {
         return Err(SequenceRegistrationError::ShiftCharBindingUnsupported);
@@ -399,9 +404,9 @@ fn canonicalize_binding_key(key: ShortcutKey) -> Result<ShortcutKey, SequenceReg
 }
 
 fn normalize_shortcut_key(key: ShortcutKey) -> ShortcutKey {
-    match key.code {
+    match key.code() {
         KeyCode::Char(ch) => {
-            let mut modifiers = key.modifiers;
+            let mut modifiers = key.modifiers();
             if modifiers.intersects(KeyModifiers::SHIFT | KeyModifiers::CONTROL | KeyModifiers::ALT)
             {
                 modifiers.remove(KeyModifiers::SHIFT);
@@ -417,16 +422,16 @@ fn normalize_shortcut_key(key: ShortcutKey) -> ShortcutKey {
 
             ShortcutKey::new(KeyCode::Char(normalized_char), modifiers)
         }
-        _ => ShortcutKey::new(key.code, key.modifiers),
+        _ => ShortcutKey::new(key.code(), key.modifiers()),
     }
 }
 
 fn is_reserved_sequence_key(key: ShortcutKey) -> bool {
-    matches!(key.code, KeyCode::Enter | KeyCode::Esc)
+    matches!(key.code(), KeyCode::Enter | KeyCode::Esc)
 }
 
 fn is_digit_key(key: ShortcutKey) -> bool {
-    matches!(key.code, KeyCode::Char(ch) if key.modifiers == KeyModifiers::NONE && ch.is_ascii_digit())
+    matches!(key.code(), KeyCode::Char(ch) if key.modifiers() == KeyModifiers::NONE && ch.is_ascii_digit())
 }
 
 fn format_pending_buffer(buffer: &[ShortcutKey]) -> String {
@@ -434,8 +439,8 @@ fn format_pending_buffer(buffer: &[ShortcutKey]) -> String {
     let mut previous_was_plain_char = false;
 
     for key in buffer {
-        let (part, is_plain_char) = match key.code {
-            KeyCode::Char(ch) if key.modifiers == KeyModifiers::NONE => (ch.to_string(), true),
+        let (part, is_plain_char) = match key.code() {
+            KeyCode::Char(ch) if key.modifiers() == KeyModifiers::NONE => (ch.to_string(), true),
             _ => (format_shortcut_key(*key), false),
         };
 
@@ -706,5 +711,20 @@ mod tests {
             resolution,
             SequenceResolution::Dispatch(Command::HistoryBack)
         );
+    }
+
+    #[test]
+    fn unsupported_modifier_input_is_ignored() {
+        let mut registry = SequenceRegistry::new();
+        registry
+            .register_static(&[ShortcutKey::char('k')], Command::PrevPage)
+            .expect("single-key binding should register");
+        let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
+
+        let resolution =
+            resolver.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::SUPER));
+
+        assert_eq!(resolution, SequenceResolution::Noop);
+        assert_eq!(resolver.pending_display(), None);
     }
 }

--- a/src/input/shortcut.rs
+++ b/src/input/shortcut.rs
@@ -7,28 +7,31 @@ pub struct ShortcutKey {
 }
 
 impl ShortcutKey {
-    pub const fn new(code: KeyCode, modifiers: KeyModifiers) -> Self {
+    pub fn new(code: KeyCode, modifiers: KeyModifiers) -> Self {
+        assert_supported_modifiers(modifiers);
         Self { code, modifiers }
     }
 
-    pub const fn key(code: KeyCode) -> Self {
+    pub fn key(code: KeyCode) -> Self {
         Self::new(code, KeyModifiers::NONE)
     }
 
-    pub const fn ctrl(ch: char) -> Self {
+    pub fn ctrl(ch: char) -> Self {
         Self::new(KeyCode::Char(ch), KeyModifiers::CONTROL)
     }
 
-    pub const fn alt(ch: char) -> Self {
+    pub fn alt(ch: char) -> Self {
         Self::new(KeyCode::Char(ch), KeyModifiers::ALT)
     }
 
-    pub const fn char(ch: char) -> Self {
+    pub fn char(ch: char) -> Self {
         Self::key(KeyCode::Char(ch))
     }
 }
 
 pub fn format_shortcut_key(key: ShortcutKey) -> String {
+    assert_supported_modifiers(key.modifiers);
+
     let is_back_tab = key.code == KeyCode::BackTab;
 
     if let KeyCode::Char(ch) = key.code
@@ -65,6 +68,13 @@ pub fn format_shortcut_key(key: ShortcutKey) -> String {
     }
 
     format!("<{}-{key_text}>", modifiers.join("-"))
+}
+
+fn assert_supported_modifiers(modifiers: KeyModifiers) {
+    assert!(
+        !modifiers.intersects(KeyModifiers::SUPER | KeyModifiers::HYPER | KeyModifiers::META),
+        "ShortcutKey does not support SUPER, HYPER, or META modifiers",
+    );
 }
 
 pub fn format_shortcut_sequence(keys: &[ShortcutKey]) -> String {
@@ -150,6 +160,14 @@ mod tests {
             "<s-tab>"
         );
         assert_eq!(
+            format_shortcut_key(ShortcutKey::new(KeyCode::BackTab, KeyModifiers::CONTROL)),
+            "<c-s-tab>"
+        );
+        assert_eq!(
+            format_shortcut_key(ShortcutKey::new(KeyCode::BackTab, KeyModifiers::ALT)),
+            "<m-s-tab>"
+        );
+        assert_eq!(
             format_shortcut_key(ShortcutKey::new(
                 KeyCode::BackTab,
                 KeyModifiers::CONTROL | KeyModifiers::SHIFT
@@ -182,5 +200,11 @@ mod tests {
         let text =
             format_shortcut_alternatives_tight(&[ShortcutKey::ctrl('p'), ShortcutKey::ctrl('n')]);
         assert_eq!(text, "<c-p>/<c-n>");
+    }
+
+    #[test]
+    #[should_panic(expected = "ShortcutKey does not support SUPER, HYPER, or META modifiers")]
+    fn rejects_unsupported_modifiers() {
+        let _ = ShortcutKey::new(KeyCode::Char('k'), KeyModifiers::SUPER);
     }
 }

--- a/src/input/shortcut.rs
+++ b/src/input/shortcut.rs
@@ -105,7 +105,7 @@ fn base_key_text(key: ShortcutKey) -> String {
         KeyCode::F(n) => format!("f{n}"),
         KeyCode::Char(' ') => "space".to_string(),
         KeyCode::Char(ch) => ch.to_ascii_lowercase().to_string(),
-        _ => format!("{:?}", key.code),
+        _ => format!("{:?}", key.code).to_ascii_lowercase(),
     }
 }
 
@@ -127,6 +127,10 @@ mod tests {
         assert_eq!(
             format_shortcut_key(ShortcutKey::key(KeyCode::PageDown)),
             "<pgdn>"
+        );
+        assert_eq!(
+            format_shortcut_key(ShortcutKey::key(KeyCode::CapsLock)),
+            "<capslock>"
         );
         assert_eq!(
             format_shortcut_key(ShortcutKey::new(KeyCode::Char('O'), KeyModifiers::CONTROL)),

--- a/src/input/shortcut.rs
+++ b/src/input/shortcut.rs
@@ -29,9 +29,7 @@ impl ShortcutKey {
 }
 
 pub fn format_shortcut_key(key: ShortcutKey) -> String {
-    if key.code == KeyCode::BackTab {
-        return "<s-tab>".to_string();
-    }
+    let is_back_tab = key.code == KeyCode::BackTab;
 
     if let KeyCode::Char(ch) = key.code
         && !key
@@ -41,10 +39,15 @@ pub fn format_shortcut_key(key: ShortcutKey) -> String {
         return ch.to_string();
     }
 
-    let has_modifier = key
-        .modifiers
-        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT);
-    let key_text = base_key_text(key);
+    let has_modifier = is_back_tab
+        || key
+            .modifiers
+            .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT);
+    let key_text = if is_back_tab {
+        "tab".to_string()
+    } else {
+        base_key_text(key)
+    };
     if !has_modifier {
         return format!("<{key_text}>");
     }
@@ -56,7 +59,7 @@ pub fn format_shortcut_key(key: ShortcutKey) -> String {
     if key.modifiers.contains(KeyModifiers::ALT) {
         modifiers.push("m");
     }
-    if key.modifiers.contains(KeyModifiers::SHIFT) {
+    if is_back_tab || key.modifiers.contains(KeyModifiers::SHIFT) {
         modifiers.push("s");
     }
 
@@ -138,6 +141,20 @@ mod tests {
         assert_eq!(
             format_shortcut_key(ShortcutKey::key(KeyCode::BackTab)),
             "<s-tab>"
+        );
+        assert_eq!(
+            format_shortcut_key(ShortcutKey::new(
+                KeyCode::BackTab,
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT
+            )),
+            "<c-s-tab>"
+        );
+        assert_eq!(
+            format_shortcut_key(ShortcutKey::new(
+                KeyCode::BackTab,
+                KeyModifiers::ALT | KeyModifiers::SHIFT
+            )),
+            "<m-s-tab>"
         );
     }
 

--- a/src/input/shortcut.rs
+++ b/src/input/shortcut.rs
@@ -2,14 +2,24 @@ use crossterm::event::{KeyCode, KeyModifiers};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ShortcutKey {
-    pub code: KeyCode,
-    pub modifiers: KeyModifiers,
+    code: KeyCode,
+    modifiers: KeyModifiers,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShortcutKeyError {
+    UnsupportedModifiers,
 }
 
 impl ShortcutKey {
     pub fn new(code: KeyCode, modifiers: KeyModifiers) -> Self {
-        assert_supported_modifiers(modifiers);
-        Self { code, modifiers }
+        Self::try_new(code, modifiers)
+            .expect("ShortcutKey does not support SUPER, HYPER, or META modifiers")
+    }
+
+    pub fn try_new(code: KeyCode, modifiers: KeyModifiers) -> Result<Self, ShortcutKeyError> {
+        validate_modifiers(modifiers)?;
+        Ok(Self { code, modifiers })
     }
 
     pub fn key(code: KeyCode) -> Self {
@@ -27,16 +37,22 @@ impl ShortcutKey {
     pub fn char(ch: char) -> Self {
         Self::key(KeyCode::Char(ch))
     }
+
+    pub fn code(self) -> KeyCode {
+        self.code
+    }
+
+    pub fn modifiers(self) -> KeyModifiers {
+        self.modifiers
+    }
 }
 
 pub fn format_shortcut_key(key: ShortcutKey) -> String {
-    assert_supported_modifiers(key.modifiers);
+    let is_back_tab = key.code() == KeyCode::BackTab;
 
-    let is_back_tab = key.code == KeyCode::BackTab;
-
-    if let KeyCode::Char(ch) = key.code
+    if let KeyCode::Char(ch) = key.code()
         && !key
-            .modifiers
+            .modifiers()
             .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT)
         && ch != ' '
     {
@@ -45,7 +61,7 @@ pub fn format_shortcut_key(key: ShortcutKey) -> String {
 
     let has_modifier = is_back_tab
         || key
-            .modifiers
+            .modifiers()
             .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT);
     let key_text = if is_back_tab {
         "tab".to_string()
@@ -57,24 +73,24 @@ pub fn format_shortcut_key(key: ShortcutKey) -> String {
     }
 
     let mut modifiers = Vec::new();
-    if key.modifiers.contains(KeyModifiers::CONTROL) {
+    if key.modifiers().contains(KeyModifiers::CONTROL) {
         modifiers.push("c");
     }
-    if key.modifiers.contains(KeyModifiers::ALT) {
+    if key.modifiers().contains(KeyModifiers::ALT) {
         modifiers.push("m");
     }
-    if is_back_tab || key.modifiers.contains(KeyModifiers::SHIFT) {
+    if is_back_tab || key.modifiers().contains(KeyModifiers::SHIFT) {
         modifiers.push("s");
     }
 
     format!("<{}-{key_text}>", modifiers.join("-"))
 }
 
-fn assert_supported_modifiers(modifiers: KeyModifiers) {
-    assert!(
-        !modifiers.intersects(KeyModifiers::SUPER | KeyModifiers::HYPER | KeyModifiers::META),
-        "ShortcutKey does not support SUPER, HYPER, or META modifiers",
-    );
+fn validate_modifiers(modifiers: KeyModifiers) -> Result<(), ShortcutKeyError> {
+    if modifiers.intersects(KeyModifiers::SUPER | KeyModifiers::HYPER | KeyModifiers::META) {
+        return Err(ShortcutKeyError::UnsupportedModifiers);
+    }
+    Ok(())
 }
 
 pub fn format_shortcut_sequence(keys: &[ShortcutKey]) -> String {
@@ -97,7 +113,7 @@ fn format_shortcut_keys(keys: &[ShortcutKey], separator: &str) -> String {
 }
 
 fn base_key_text(key: ShortcutKey) -> String {
-    match key.code {
+    match key.code() {
         KeyCode::Backspace => "backspace".to_string(),
         KeyCode::Enter => "enter".to_string(),
         KeyCode::Left => "left".to_string(),
@@ -115,7 +131,7 @@ fn base_key_text(key: ShortcutKey) -> String {
         KeyCode::F(n) => format!("f{n}"),
         KeyCode::Char(' ') => "space".to_string(),
         KeyCode::Char(ch) => ch.to_ascii_lowercase().to_string(),
-        _ => format!("{:?}", key.code).to_ascii_lowercase(),
+        _ => format!("{:?}", key.code()).to_ascii_lowercase(),
     }
 }
 
@@ -124,8 +140,8 @@ mod tests {
     use crossterm::event::{KeyCode, KeyModifiers};
 
     use super::{
-        ShortcutKey, format_shortcut_alternatives, format_shortcut_alternatives_tight,
-        format_shortcut_key, format_shortcut_sequence,
+        ShortcutKey, ShortcutKeyError, format_shortcut_alternatives,
+        format_shortcut_alternatives_tight, format_shortcut_key, format_shortcut_sequence,
     };
 
     #[test]
@@ -203,8 +219,10 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "ShortcutKey does not support SUPER, HYPER, or META modifiers")]
-    fn rejects_unsupported_modifiers() {
-        let _ = ShortcutKey::new(KeyCode::Char('k'), KeyModifiers::SUPER);
+    fn try_new_rejects_unsupported_modifiers() {
+        assert_eq!(
+            ShortcutKey::try_new(KeyCode::Char('k'), KeyModifiers::SUPER),
+            Err(ShortcutKeyError::UnsupportedModifiers)
+        );
     }
 }

--- a/src/input/shortcut.rs
+++ b/src/input/shortcut.rs
@@ -35,6 +35,7 @@ pub fn format_shortcut_key(key: ShortcutKey) -> String {
         && !key
             .modifiers
             .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT)
+        && ch != ' '
     {
         return ch.to_string();
     }
@@ -102,6 +103,7 @@ fn base_key_text(key: ShortcutKey) -> String {
         KeyCode::Insert => "ins".to_string(),
         KeyCode::Esc => "esc".to_string(),
         KeyCode::F(n) => format!("f{n}"),
+        KeyCode::Char(' ') => "space".to_string(),
         KeyCode::Char(ch) => ch.to_ascii_lowercase().to_string(),
         _ => format!("{:?}", key.code),
     }
@@ -119,6 +121,7 @@ mod tests {
     #[test]
     fn formats_regular_and_modified_keys() {
         assert_eq!(format_shortcut_key(ShortcutKey::ctrl('o')), "<c-o>");
+        assert_eq!(format_shortcut_key(ShortcutKey::char(' ')), "<space>");
         assert_eq!(format_shortcut_key(ShortcutKey::char('?')), "?");
         assert_eq!(format_shortcut_key(ShortcutKey::char('A')), "A");
         assert_eq!(

--- a/src/input/shortcut.rs
+++ b/src/input/shortcut.rs
@@ -29,89 +29,134 @@ impl ShortcutKey {
 }
 
 pub fn format_shortcut_key(key: ShortcutKey) -> String {
-    let mut parts = Vec::new();
+    if key.code == KeyCode::BackTab {
+        return "<s-tab>".to_string();
+    }
+
+    if let KeyCode::Char(ch) = key.code
+        && !key
+            .modifiers
+            .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT)
+    {
+        return ch.to_string();
+    }
+
+    let has_modifier = key
+        .modifiers
+        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT);
+    let key_text = base_key_text(key);
+    if !has_modifier {
+        return format!("<{key_text}>");
+    }
+
+    let mut modifiers = Vec::new();
     if key.modifiers.contains(KeyModifiers::CONTROL) {
-        parts.push("Ctrl");
+        modifiers.push("c");
     }
     if key.modifiers.contains(KeyModifiers::ALT) {
-        parts.push("Alt");
+        modifiers.push("m");
     }
     if key.modifiers.contains(KeyModifiers::SHIFT) {
-        parts.push("Shift");
+        modifiers.push("s");
     }
 
-    let key_text = match key.code {
-        KeyCode::Backspace => "Backspace".to_string(),
-        KeyCode::Enter => "Enter".to_string(),
-        KeyCode::Left => "Left".to_string(),
-        KeyCode::Right => "Right".to_string(),
-        KeyCode::Up => "Up".to_string(),
-        KeyCode::Down => "Down".to_string(),
-        KeyCode::Home => "Home".to_string(),
-        KeyCode::End => "End".to_string(),
-        KeyCode::PageUp => "PgUp".to_string(),
-        KeyCode::PageDown => "PgDn".to_string(),
-        KeyCode::Tab => "Tab".to_string(),
-        KeyCode::BackTab => "BackTab".to_string(),
-        KeyCode::Delete => "Delete".to_string(),
-        KeyCode::Insert => "Insert".to_string(),
-        KeyCode::Esc => "Esc".to_string(),
-        KeyCode::F(n) => format!("F{n}"),
-        KeyCode::Char(ch) => {
-            if (key.modifiers.contains(KeyModifiers::CONTROL)
-                || key.modifiers.contains(KeyModifiers::ALT)
-                || key.modifiers.contains(KeyModifiers::SHIFT))
-                && ch.is_ascii_alphabetic()
-            {
-                ch.to_ascii_uppercase().to_string()
-            } else {
-                ch.to_string()
-            }
-        }
-        _ => format!("{:?}", key.code),
-    };
-
-    if parts.is_empty() {
-        key_text
-    } else {
-        let mut text = parts.join("+");
-        text.push('+');
-        text.push_str(&key_text);
-        text
-    }
+    format!("<{}-{key_text}>", modifiers.join("-"))
 }
 
 pub fn format_shortcut_sequence(keys: &[ShortcutKey]) -> String {
+    format_shortcut_keys(keys, "")
+}
+
+pub fn format_shortcut_alternatives(keys: &[ShortcutKey]) -> String {
+    format_shortcut_keys(keys, " / ")
+}
+
+pub fn format_shortcut_alternatives_tight(keys: &[ShortcutKey]) -> String {
+    format_shortcut_keys(keys, "/")
+}
+
+fn format_shortcut_keys(keys: &[ShortcutKey], separator: &str) -> String {
     keys.iter()
         .map(|key| format_shortcut_key(*key))
         .collect::<Vec<_>>()
-        .join(" / ")
+        .join(separator)
+}
+
+fn base_key_text(key: ShortcutKey) -> String {
+    match key.code {
+        KeyCode::Backspace => "backspace".to_string(),
+        KeyCode::Enter => "enter".to_string(),
+        KeyCode::Left => "left".to_string(),
+        KeyCode::Right => "right".to_string(),
+        KeyCode::Up => "up".to_string(),
+        KeyCode::Down => "down".to_string(),
+        KeyCode::Home => "home".to_string(),
+        KeyCode::End => "end".to_string(),
+        KeyCode::PageUp => "pgup".to_string(),
+        KeyCode::PageDown => "pgdn".to_string(),
+        KeyCode::Tab => "tab".to_string(),
+        KeyCode::Delete => "del".to_string(),
+        KeyCode::Insert => "ins".to_string(),
+        KeyCode::Esc => "esc".to_string(),
+        KeyCode::F(n) => format!("f{n}"),
+        KeyCode::Char(ch) => ch.to_ascii_lowercase().to_string(),
+        _ => format!("{:?}", key.code),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crossterm::event::{KeyCode, KeyModifiers};
 
-    use super::{ShortcutKey, format_shortcut_key, format_shortcut_sequence};
+    use super::{
+        ShortcutKey, format_shortcut_alternatives, format_shortcut_alternatives_tight,
+        format_shortcut_key, format_shortcut_sequence,
+    };
 
     #[test]
     fn formats_regular_and_modified_keys() {
-        assert_eq!(format_shortcut_key(ShortcutKey::ctrl('o')), "Ctrl+O");
+        assert_eq!(format_shortcut_key(ShortcutKey::ctrl('o')), "<c-o>");
         assert_eq!(format_shortcut_key(ShortcutKey::char('?')), "?");
         assert_eq!(format_shortcut_key(ShortcutKey::char('A')), "A");
         assert_eq!(
             format_shortcut_key(ShortcutKey::key(KeyCode::PageDown)),
-            "PgDn"
+            "<pgdn>"
         );
         assert_eq!(
             format_shortcut_key(ShortcutKey::new(KeyCode::Char('O'), KeyModifiers::CONTROL)),
-            "Ctrl+O"
+            "<c-o>"
+        );
+        assert_eq!(
+            format_shortcut_key(ShortcutKey::new(KeyCode::Char('x'), KeyModifiers::ALT)),
+            "<m-x>"
+        );
+        assert_eq!(format_shortcut_key(ShortcutKey::key(KeyCode::Esc)), "<esc>");
+        assert_eq!(
+            format_shortcut_key(ShortcutKey::key(KeyCode::Enter)),
+            "<enter>"
+        );
+        assert_eq!(
+            format_shortcut_key(ShortcutKey::key(KeyCode::BackTab)),
+            "<s-tab>"
         );
     }
 
     #[test]
     fn formats_shortcut_sequences() {
         let text = format_shortcut_sequence(&[ShortcutKey::char('j'), ShortcutKey::char('k')]);
-        assert_eq!(text, "j / k");
+        assert_eq!(text, "jk");
+    }
+
+    #[test]
+    fn formats_shortcut_alternatives() {
+        let text = format_shortcut_alternatives(&[ShortcutKey::ctrl('p'), ShortcutKey::ctrl('n')]);
+        assert_eq!(text, "<c-p> / <c-n>");
+    }
+
+    #[test]
+    fn formats_tight_shortcut_alternatives() {
+        let text =
+            format_shortcut_alternatives_tight(&[ShortcutKey::ctrl('p'), ShortcutKey::ctrl('n')]);
+        assert_eq!(text, "<c-p>/<c-n>");
     }
 }

--- a/src/outline/palette.rs
+++ b/src/outline/palette.rs
@@ -1,5 +1,6 @@
 use crate::command::Command;
 use crate::error::AppResult;
+use crate::input::shortcut::format_shortcut_key;
 use crate::palette::{
     PaletteCandidate, PaletteContext, PaletteInputMode, PaletteKind, PalettePayload,
     PalettePostAction, PaletteProvider, PaletteSearchText, PaletteSubmitEffect, PaletteTextPart,
@@ -103,7 +104,10 @@ impl PaletteProvider for OutlinePaletteProvider {
         if ctx.extensions.outline_entries.is_empty() {
             Some("No outline entries in this document".to_string())
         } else {
-            Some("Enter: jump to page".to_string())
+            let enter = format_shortcut_key(crate::input::shortcut::ShortcutKey::key(
+                crossterm::event::KeyCode::Enter,
+            ));
+            Some(format!("{enter} jump to page"))
         }
     }
 }
@@ -315,4 +319,5 @@ mod tests {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].left[0].text.trim(), "Überblick");
     }
+
 }

--- a/src/outline/palette.rs
+++ b/src/outline/palette.rs
@@ -319,5 +319,4 @@ mod tests {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].left[0].text.trim(), "Überblick");
     }
-
 }

--- a/src/palette/providers/command.rs
+++ b/src/palette/providers/command.rs
@@ -7,7 +7,9 @@ use crate::command::parse_invocable_command_text;
 use crate::command::{CommandConditionContext, CommandInvocationSource};
 use crate::error::AppResult;
 use crate::input::InputHistoryRecord;
-use crate::input::shortcut::{ShortcutKey, format_shortcut_sequence};
+use crate::input::shortcut::{
+    ShortcutKey, format_shortcut_alternatives_tight, format_shortcut_key,
+};
 use crate::palette::{
     PaletteCandidate, PaletteContext, PaletteInputMode, PaletteKind, PalettePayload,
     PalettePostAction, PaletteProvider, PaletteSearchText, PaletteSubmitEffect, PaletteTabEffect,
@@ -147,13 +149,14 @@ impl PaletteProvider for CommandPaletteProvider {
         ctx: &PaletteContext<'_>,
         _selected: Option<&PaletteCandidate>,
     ) -> Option<String> {
-        let enter = format_shortcut_sequence(&[ShortcutKey::key(crossterm::event::KeyCode::Enter)]);
-        let selection = format_shortcut_sequence(&[ShortcutKey::ctrl('p'), ShortcutKey::ctrl('n')]);
-        let history = format_shortcut_sequence(&[
+        let enter = format_shortcut_key(ShortcutKey::key(crossterm::event::KeyCode::Enter));
+        let selection =
+            format_shortcut_alternatives_tight(&[ShortcutKey::ctrl('p'), ShortcutKey::ctrl('n')]);
+        let history = format_shortcut_alternatives_tight(&[
             ShortcutKey::key(crossterm::event::KeyCode::Up),
             ShortcutKey::key(crossterm::event::KeyCode::Down),
         ]);
-        let default_hint = format!("{enter}: run  {selection}: select  {history}: history");
+        let default_hint = format!("{enter} run   {selection} select   {history} history");
         let trimmed = ctx.input.trim();
         if trimmed.is_empty() {
             return Some(default_hint);

--- a/src/search/palette.rs
+++ b/src/search/palette.rs
@@ -1,6 +1,9 @@
 use crate::command::{Command, SearchMatcherKind};
 use crate::error::AppResult;
 use crate::input::InputHistoryRecord;
+use crate::input::shortcut::{
+    ShortcutKey, format_shortcut_alternatives_tight, format_shortcut_key,
+};
 use crate::palette::{
     PaletteCandidate, PaletteContext, PaletteInputMode, PaletteKind, PalettePayload,
     PalettePostAction, PaletteProvider, PaletteSearchText, PaletteSubmitEffect, PaletteTextPart,
@@ -91,6 +94,15 @@ impl PaletteProvider for SearchPaletteProvider {
         _ctx: &PaletteContext<'_>,
         _selected: Option<&PaletteCandidate>,
     ) -> Option<String> {
-        Some("Enter: search  Up/Down: history  Ctrl+P/N: matcher".to_string())
+        let enter = format_shortcut_key(ShortcutKey::key(crossterm::event::KeyCode::Enter));
+        let history = format_shortcut_alternatives_tight(&[
+            ShortcutKey::key(crossterm::event::KeyCode::Up),
+            ShortcutKey::key(crossterm::event::KeyCode::Down),
+        ]);
+        let matcher =
+            format_shortcut_alternatives_tight(&[ShortcutKey::ctrl('p'), ShortcutKey::ctrl('n')]);
+        Some(format!(
+            "{enter} search   {history} history   {matcher} matcher"
+        ))
     }
 }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -289,15 +289,15 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n");
-        assert!(text.contains("Ctrl+O"));
+        assert!(text.contains("<c-o>"));
         assert!(text.contains("Help"));
         assert!(text.contains("Reset zoom"));
-        assert!(text.contains("g / g"));
+        assert!(text.contains("gg"));
         assert!(text.contains("[count]G"));
         assert!(text.contains("H / J / K / L"));
-        assert!(!text.contains("Ctrl+N"));
-        assert!(!text.contains("Alt+X"));
-        assert!(!text.contains("PgDn"));
+        assert!(!text.contains("<c-n>"));
+        assert!(!text.contains("<m-x>"));
+        assert!(!text.contains("<pgdn>"));
     }
 
     #[test]


### PR DESCRIPTION
## Why
Normalize shortcut labels across help text, palette hints, and docs so the UI presents a single consistent notation.

## What Changed
- switch shortcut formatting to normalized angle-bracket notation such as `<c-o>`, `<esc>`, and `<enter>`
- keep literal printable sequences compact, for example `gg`, while formatting alternatives as `<c-p>/<c-n>` where needed
- update command/search/history/outline palette assistive text, help output, and documentation to match the new notation
- add formatter coverage for the new notation rules

## Verification
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI/UX**
  * Standardized shortcut displays to angle-bracketed lowercase notation (e.g., <esc>, <c-o>, <c-p>, <enter>) and refined assistive hint wording, spacing, and sequencing across palettes and the help overlay.

* **Documentation**
  * Updated docs and README to use the new shortcut display format in keybinding and keyboard-semantics sections.

* **Tests**
  * Updated test expectations to match the new shortcut encodings and sequence/alternative formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->