### PR TITLE
fix(help): restore immediate overlay close redraw

### DIFF
--- a/src/app/input_ops.rs
+++ b/src/app/input_ops.rs
@@ -185,12 +185,12 @@ impl InteractionSubsystem {
     }
 
     fn close_palette_overlay(&mut self, state: &mut AppState) -> bool {
-        if !self.palette.manager.close() {
-            return false;
-        }
         let changed = state.mode != Mode::Normal;
-        state.mode = Mode::Normal;
-        self.sync_sequences_with_mode(state);
+        let _ = self.palette.manager.close();
+        if changed {
+            state.mode = Mode::Normal;
+            self.sync_sequences_with_mode(state);
+        }
         changed
     }
 
@@ -680,6 +680,24 @@ mod tests {
         assert_eq!(session.clear_count, 1);
         assert_eq!(app.state.mode, Mode::Normal);
         assert!(needs_redraw);
+        assert!(outcome.commands.is_empty());
+    }
+
+    #[test]
+    fn palette_close_repairs_stale_palette_mode_even_without_active_session() {
+        let mut interaction = InteractionSubsystem::default();
+        let mut state = AppState {
+            mode: Mode::Palette,
+            ..AppState::default()
+        };
+
+        let outcome = interaction
+            .handle_key_event(&mut state, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+            .expect("stale palette close should be handled");
+
+        assert_eq!(state.mode, Mode::Normal);
+        assert!(outcome.redraw);
+        assert!(outcome.clear_terminal);
         assert!(outcome.commands.is_empty());
     }
 

--- a/src/app/input_ops.rs
+++ b/src/app/input_ops.rs
@@ -31,29 +31,8 @@ impl InteractionSubsystem {
     ) -> AppResult<KeyEventOutcome> {
         self.sync_sequences_with_mode(state);
         if key.code == KeyCode::Esc {
-            if state.mode == Mode::Palette {
-                let closed = self.palette.manager.close();
-                if closed {
-                    state.mode = Mode::Normal;
-                    self.sync_sequences_with_mode(state);
-                }
-                return Ok(KeyEventOutcome {
-                    redraw: closed,
-                    clear_terminal: closed,
-                    quit_requested: false,
-                    commands: Vec::new(),
-                });
-            }
-            if state.mode == Mode::Help {
-                return Ok(KeyEventOutcome {
-                    redraw: true,
-                    clear_terminal: true,
-                    quit_requested: false,
-                    commands: vec![CommandRequest::new(
-                        Command::CloseHelp,
-                        CommandInvocationSource::Keymap,
-                    )],
-                });
+            if let Some(outcome) = self.close_active_overlay(state) {
+                return Ok(outcome);
             }
             if self.sequences.resolver.has_pending() {
                 let resolution = self.sequences.resolver.handle_key(key);
@@ -189,6 +168,41 @@ impl InteractionSubsystem {
         self.palette
             .manager
             .handle_key(&self.palette.registry, state, &extensions, key)
+    }
+
+    fn close_active_overlay(&mut self, state: &mut AppState) -> Option<KeyEventOutcome> {
+        let closed = match state.mode {
+            Mode::Palette => self.close_palette_overlay(state),
+            Mode::Help => self.close_help_overlay(state),
+            Mode::Normal => return None,
+        };
+        Some(KeyEventOutcome {
+            redraw: closed,
+            clear_terminal: closed,
+            quit_requested: false,
+            commands: Vec::new(),
+        })
+    }
+
+    fn close_palette_overlay(&mut self, state: &mut AppState) -> bool {
+        if !self.palette.manager.close() {
+            return false;
+        }
+        let changed = state.mode != Mode::Normal;
+        state.mode = Mode::Normal;
+        self.sync_sequences_with_mode(state);
+        changed
+    }
+
+    fn close_help_overlay(&mut self, state: &mut AppState) -> bool {
+        if state.mode != Mode::Help {
+            return false;
+        }
+
+        state.mode = Mode::Normal;
+        state.reset_help_scroll();
+        self.sync_sequences_with_mode(state);
+        true
     }
 
     pub(crate) fn handle_extension_input(
@@ -580,14 +594,9 @@ mod tests {
         let closed = interaction
             .handle_key_event(&mut state, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
             .expect("help close should be handled");
-        assert_eq!(state.mode, crate::app::Mode::Help);
-        assert_eq!(state.help_scroll, 1);
-        assert!(matches!(
-            closed.commands.as_slice(),
-            [request]
-                if request.command == Command::CloseHelp
-                    && request.source == CommandInvocationSource::Keymap
-        ));
+        assert_eq!(state.mode, crate::app::Mode::Normal);
+        assert_eq!(state.help_scroll, 0);
+        assert!(closed.commands.is_empty());
         assert!(closed.redraw);
         assert!(closed.clear_terminal);
     }
@@ -634,15 +643,44 @@ mod tests {
             .expect("help close should be handled");
 
         assert_eq!(session.clear_count, 1);
-        assert_eq!(app.state.mode, Mode::Help);
+        assert_eq!(app.state.mode, Mode::Normal);
         assert_eq!(app.state.help_scroll, 0);
         assert!(needs_redraw);
-        assert!(matches!(
-            outcome.commands.as_slice(),
-            [request]
-                if request.command == Command::CloseHelp
-                    && request.source == CommandInvocationSource::Keymap
-        ));
+        assert!(outcome.commands.is_empty());
+    }
+
+    #[test]
+    fn palette_close_clears_terminal_and_restores_normal_mode() {
+        let mut app = App::new_with_config(PresenterKind::RatatuiImage, Config::default())
+            .expect("app should initialize");
+        app.interaction
+            .palette
+            .pending_requests
+            .push_back(PaletteRequest::Open {
+                kind: PaletteKind::Command,
+                seed: None,
+            });
+        assert!(app.interaction.apply_palette_requests(&mut app.state));
+        assert_eq!(app.state.mode, Mode::Palette);
+
+        let mut session = MockSession::new(80, 24);
+        let mut needs_redraw = false;
+        let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
+        let mut last_input_at = std::time::Instant::now();
+
+        let outcome = app
+            .handle_input_event(
+                crossterm::event::Event::Key(key),
+                &mut session,
+                &mut needs_redraw,
+                &mut last_input_at,
+            )
+            .expect("palette close should be handled");
+
+        assert_eq!(session.clear_count, 1);
+        assert_eq!(app.state.mode, Mode::Normal);
+        assert!(needs_redraw);
+        assert!(outcome.commands.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Problem
PR #55 moved Help close handling onto a deferred command path. That left Help in `Mode::Help` for one redraw after `Esc`, so the overlay could be drawn again before the mode change landed and its text could remain visually stuck over the image area.

Rationale
Overlay close needs to complete in input handling, before the redraw that clears and refreshes the viewer area. Palette already behaved that way, so Help should follow the same model.

Solution
Unify `Esc` overlay close handling in `InteractionSubsystem` so Palette and Help both close immediately, restore `Mode::Normal`, and request clear/redraw without queuing a follow-up close command. Update the affected tests and add a palette close regression test to lock in the shared contract.

Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated overlay-closing logic for more consistent behavior when exiting overlays.

* **Bug Fixes**
  * Pressing Esc now reliably closes help and palette overlays and returns to normal view.
  * Closing help resets help scroll to the top.
  * Closing palette clears the terminal and triggers a redraw without performing extra queued actions.
  * Fixed stale palette state so Esc always restores normal view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->