### PR TITLE
feat(command-palette): improve argument entry

### DIFF
--- a/docs/command-system.md
+++ b/docs/command-system.md
@@ -109,6 +109,10 @@ Command-specific parsing rules:
   - takes no arguments
 - `page-layout-spread [ltr|rtl]`
   - accepts at most one spread direction argument
+  - the argument is optional to keep the common case short to type; users can
+    stop at `page-layout-spread` and let the command use its default direction
+  - omission is therefore not a separate argument value or token; it is just
+    the shorter command form
 - `open-palette <kind> [seed]`
   - parses palette kind first and preserves remaining text as optional seed
 - `submit-search <query> [matcher]`

--- a/docs/command-system.md
+++ b/docs/command-system.md
@@ -36,6 +36,7 @@ Each command has:
 - `id`
 - `title`
 - `args`
+- `arg` UI hints
 - `exposure`
 - `invocation`
 - `availability`
@@ -49,6 +50,8 @@ Rules:
 - typed commands are expected to have a matching registry entry
 - command palette visibility is derived from metadata rather than hand-coded
   per-command UI rules
+- command argument metadata may additionally describe enum-valued arguments for
+  palette completion and assistive text
 
 ## Invocation sources and visibility
 

--- a/docs/command-system.md
+++ b/docs/command-system.md
@@ -36,12 +36,14 @@ Each command has:
 - `id`
 - `title`
 - `args`
-- `arg` UI hints
+- `args[].hint` UI hints
 - `exposure`
 - `invocation`
 - `availability`
 
-`CommandSpec` is the registry-backed metadata type for those fields.
+`CommandSpec` is the registry-backed metadata type for those fields. Per-argument
+UI metadata stays on `ArgSpec::hint`; there is no separate top-level `arg`
+field on `CommandSpec`.
 
 Rules:
 
@@ -50,8 +52,8 @@ Rules:
 - typed commands are expected to have a matching registry entry
 - command palette visibility is derived from metadata rather than hand-coded
   per-command UI rules
-- command argument metadata may additionally describe enum-valued arguments for
-  palette completion and assistive text
+- `args[].hint` may additionally describe enum-valued arguments for palette
+  completion and assistive text
 
 ## Invocation sources and visibility
 

--- a/docs/palette-provider.md
+++ b/docs/palette-provider.md
@@ -115,8 +115,8 @@ Dispatch order:
 - `<c-p>` / `<c-n>` move candidate selection
 - `Tab` autocompletes from the selected candidate and appends one trailing
   space
-- if input contains whitespace, the candidate list is hidden because the user is
-  in argument-entry phase
+- enum-valued arguments keep the candidate list visible during argument entry
+- non-enum arguments still hide the candidate list during argument entry
 - candidate ranking and argument-phase handling are provider-defined rather than
   generic filter-mode behavior
 - internal-only commands are never listed
@@ -124,13 +124,20 @@ Dispatch order:
   met
 - direct typed invocation still enforces the same exposure and availability
   checks
+- assistive text uses English type labels for free-form arguments and literal
+  value lists for enum arguments, such as `integer`, `number`, `text`, or
+  `ltr / rtl`
 
 Enter behavior:
 
 1. dispatch typed input directly when it parses as a valid command
-2. otherwise dispatch the selected command when it needs no arguments
-3. otherwise reopen with the selected command id plus trailing space
-4. otherwise reopen preserving input
+2. otherwise, if an enum candidate is selected, accept that value and dispatch
+   immediately when the resulting command is complete
+3. otherwise, if an enum candidate is selected, reopen with the accepted value
+   so later arguments can be entered
+4. otherwise dispatch the selected command when it needs no arguments
+5. otherwise reopen with the selected command id plus trailing space
+6. otherwise reopen preserving input
 
 ### Search palette
 

--- a/docs/palette-provider.md
+++ b/docs/palette-provider.md
@@ -139,6 +139,10 @@ Enter behavior:
 5. otherwise reopen with the selected command id plus trailing space
 6. otherwise reopen preserving input
 
+During argument entry, `Enter` follows the same submit rules as any other
+palette state: it confirms the current typed input if that input already parses,
+otherwise it acts on the current selection.
+
 ### Search palette
 
 - kind: `PaletteKind::Search`

--- a/docs/palette-provider.md
+++ b/docs/palette-provider.md
@@ -130,18 +130,18 @@ Dispatch order:
 
 Enter behavior:
 
-1. dispatch typed input directly when it parses as a valid command
-2. otherwise, if an enum candidate is selected, accept that value and dispatch
+1. if an enum candidate is selected, accept that value and dispatch
    immediately when the resulting command is complete
-3. otherwise, if an enum candidate is selected, reopen with the accepted value
+2. otherwise, if an enum candidate is selected, reopen with the accepted value
    so later arguments can be entered
+3. otherwise dispatch typed input directly when it parses as a valid command
 4. otherwise dispatch the selected command when it needs no arguments
 5. otherwise reopen with the selected command id plus trailing space
 6. otherwise reopen preserving input
 
 During argument entry, `Enter` follows the same submit rules as any other
-palette state: it confirms the current typed input if that input already parses,
-otherwise it acts on the current selection.
+palette state: selected enum candidates take precedence over parsing the
+current input.
 
 ### Search palette
 

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -12,7 +12,8 @@ pub use spec::{
     is_command_visible_in_palette, rejection_message_for_command, validate_command_for_source,
 };
 pub use types::{
-    ActionId, ArgKind, ArgSpec, Command, CommandAvailability, CommandCondition, CommandExposure,
-    CommandInvocationPolicy, CommandInvocationSource, CommandOutcome, CommandRequest, CommandSpec,
-    PageLayoutModeArg, PanAmount, PanDirection, SearchMatcherKind, SpreadDirectionArg,
+    ActionId, ArgHint, ArgKind, ArgSpec, Command, CommandAvailability, CommandCondition,
+    CommandExposure, CommandInvocationPolicy, CommandInvocationSource, CommandOutcome,
+    CommandRequest, CommandSpec, PageLayoutModeArg, PanAmount, PanDirection, SearchMatcherKind,
+    SpreadDirectionArg,
 };

--- a/src/command/spec.rs
+++ b/src/command/spec.rs
@@ -3,50 +3,59 @@ use crate::error::{AppError, AppResult};
 use crate::extension::ExtensionUiSnapshot;
 
 use super::types::{
-    ArgKind, ArgSpec, Command, CommandAvailability, CommandCondition, CommandExposure,
+    ArgHint, ArgKind, ArgSpec, Command, CommandAvailability, CommandCondition, CommandExposure,
     CommandInvocationPolicy, CommandInvocationSource, CommandSpec,
 };
 
 const NO_ARGS: [ArgSpec; 0] = [];
 const NO_CONDITIONS: [CommandCondition; 0] = [];
 const REQUIRES_SEARCH_ACTIVE: [CommandCondition; 1] = [CommandCondition::SearchActive];
+const PAN_DIRECTION_VALUES: [&str; 4] = ["left", "right", "up", "down"];
+const SPREAD_DIRECTION_VALUES: [&str; 2] = ["ltr", "rtl"];
 const ARGS_GOTO_PAGE: [ArgSpec; 1] = [ArgSpec {
     name: "page",
     kind: ArgKind::I32,
     required: true,
+    hint: ArgHint::None,
 }];
 const ARGS_ZOOM: [ArgSpec; 1] = [ArgSpec {
     name: "value",
     kind: ArgKind::F32,
     required: true,
+    hint: ArgHint::None,
 }];
 const ARGS_PAN: [ArgSpec; 2] = [
     ArgSpec {
         name: "direction",
         kind: ArgKind::String,
         required: true,
+        hint: ArgHint::Enum(&PAN_DIRECTION_VALUES),
     },
     ArgSpec {
         name: "amount",
         kind: ArgKind::I32,
         required: false,
+        hint: ArgHint::None,
     },
 ];
 const ARGS_PAGE_LAYOUT_SPREAD: [ArgSpec; 1] = [ArgSpec {
     name: "direction",
     kind: ArgKind::String,
     required: false,
+    hint: ArgHint::Enum(&SPREAD_DIRECTION_VALUES),
 }];
 const ARGS_OPEN_PALETTE: [ArgSpec; 2] = [
     ArgSpec {
         name: "kind",
         kind: ArgKind::String,
         required: true,
+        hint: ArgHint::None,
     },
     ArgSpec {
         name: "seed",
         kind: ArgKind::String,
         required: false,
+        hint: ArgHint::None,
     },
 ];
 const ARGS_SUBMIT_SEARCH: [ArgSpec; 2] = [
@@ -54,28 +63,33 @@ const ARGS_SUBMIT_SEARCH: [ArgSpec; 2] = [
         name: "query",
         kind: ArgKind::String,
         required: true,
+        hint: ArgHint::None,
     },
     ArgSpec {
         name: "matcher",
         kind: ArgKind::String,
         required: false,
+        hint: ArgHint::None,
     },
 ];
 const ARGS_HISTORY_GOTO: [ArgSpec; 1] = [ArgSpec {
     name: "page",
     kind: ArgKind::I32,
     required: true,
+    hint: ArgHint::None,
 }];
 const ARGS_OUTLINE_GOTO: [ArgSpec; 2] = [
     ArgSpec {
         name: "page",
         kind: ArgKind::I32,
         required: true,
+        hint: ArgHint::None,
     },
     ArgSpec {
         name: "title",
         kind: ArgKind::String,
         required: true,
+        hint: ArgHint::None,
     },
 ];
 

--- a/src/command/spec.rs
+++ b/src/command/spec.rs
@@ -4,14 +4,13 @@ use crate::extension::ExtensionUiSnapshot;
 
 use super::types::{
     ArgHint, ArgKind, ArgSpec, Command, CommandAvailability, CommandCondition, CommandExposure,
-    CommandInvocationPolicy, CommandInvocationSource, CommandSpec,
+    CommandInvocationPolicy, CommandInvocationSource, CommandSpec, PanDirection,
+    SpreadDirectionArg,
 };
 
 const NO_ARGS: [ArgSpec; 0] = [];
 const NO_CONDITIONS: [CommandCondition; 0] = [];
 const REQUIRES_SEARCH_ACTIVE: [CommandCondition; 1] = [CommandCondition::SearchActive];
-const PAN_DIRECTION_VALUES: [&str; 4] = ["left", "right", "up", "down"];
-const SPREAD_DIRECTION_VALUES: [&str; 2] = ["ltr", "rtl"];
 const ARGS_GOTO_PAGE: [ArgSpec; 1] = [ArgSpec {
     name: "page",
     kind: ArgKind::I32,
@@ -29,7 +28,7 @@ const ARGS_PAN: [ArgSpec; 2] = [
         name: "direction",
         kind: ArgKind::String,
         required: true,
-        hint: ArgHint::Enum(&PAN_DIRECTION_VALUES),
+        hint: ArgHint::Enum(PanDirection::values),
     },
     ArgSpec {
         name: "amount",
@@ -42,7 +41,7 @@ const ARGS_PAGE_LAYOUT_SPREAD: [ArgSpec; 1] = [ArgSpec {
     name: "direction",
     kind: ArgKind::String,
     required: false,
-    hint: ArgHint::Enum(&SPREAD_DIRECTION_VALUES),
+    hint: ArgHint::Enum(SpreadDirectionArg::values),
 }];
 const ARGS_OPEN_PALETTE: [ArgSpec; 2] = [
     ArgSpec {

--- a/src/command/types.rs
+++ b/src/command/types.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use crate::palette::PaletteKind;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -7,19 +9,37 @@ pub enum SearchMatcherKind {
 }
 
 impl SearchMatcherKind {
-    pub fn id(self) -> &'static str {
+    const VARIANTS: [Self; 2] = [Self::ContainsInsensitive, Self::ContainsSensitive];
+
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::ContainsInsensitive => "contains-insensitive",
             Self::ContainsSensitive => "contains-sensitive",
         }
     }
 
+    pub fn id(self) -> &'static str {
+        self.as_str()
+    }
+
     pub fn parse(value: &str) -> Option<Self> {
-        match value {
-            "contains-insensitive" => Some(Self::ContainsInsensitive),
-            "contains-sensitive" => Some(Self::ContainsSensitive),
-            _ => None,
-        }
+        Self::VARIANTS
+            .iter()
+            .copied()
+            .find(|candidate| candidate.as_str() == value)
+    }
+
+    pub fn values() -> &'static [&'static str] {
+        static VALUES: OnceLock<Box<[&'static str]>> = OnceLock::new();
+
+        VALUES
+            .get_or_init(|| {
+                SearchMatcherKind::VARIANTS
+                    .iter()
+                    .map(|candidate| candidate.as_str())
+                    .collect()
+            })
+            .as_ref()
     }
 }
 
@@ -30,19 +50,37 @@ pub enum PageLayoutModeArg {
 }
 
 impl PageLayoutModeArg {
-    pub fn id(self) -> &'static str {
+    const VARIANTS: [Self; 2] = [Self::Single, Self::Spread];
+
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::Single => "single",
             Self::Spread => "spread",
         }
     }
 
+    pub fn id(self) -> &'static str {
+        self.as_str()
+    }
+
     pub fn parse(value: &str) -> Option<Self> {
-        match value {
-            "single" => Some(Self::Single),
-            "spread" => Some(Self::Spread),
-            _ => None,
-        }
+        Self::VARIANTS
+            .iter()
+            .copied()
+            .find(|candidate| candidate.as_str() == value)
+    }
+
+    pub fn values() -> &'static [&'static str] {
+        static VALUES: OnceLock<Box<[&'static str]>> = OnceLock::new();
+
+        VALUES
+            .get_or_init(|| {
+                PageLayoutModeArg::VARIANTS
+                    .iter()
+                    .map(|candidate| candidate.as_str())
+                    .collect()
+            })
+            .as_ref()
     }
 }
 
@@ -53,19 +91,37 @@ pub enum SpreadDirectionArg {
 }
 
 impl SpreadDirectionArg {
-    pub fn id(self) -> &'static str {
+    const VARIANTS: [Self; 2] = [Self::Ltr, Self::Rtl];
+
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::Ltr => "ltr",
             Self::Rtl => "rtl",
         }
     }
 
+    pub fn id(self) -> &'static str {
+        self.as_str()
+    }
+
     pub fn parse(value: &str) -> Option<Self> {
-        match value {
-            "ltr" => Some(Self::Ltr),
-            "rtl" => Some(Self::Rtl),
-            _ => None,
-        }
+        Self::VARIANTS
+            .iter()
+            .copied()
+            .find(|candidate| candidate.as_str() == value)
+    }
+
+    pub fn values() -> &'static [&'static str] {
+        static VALUES: OnceLock<Box<[&'static str]>> = OnceLock::new();
+
+        VALUES
+            .get_or_init(|| {
+                SpreadDirectionArg::VARIANTS
+                    .iter()
+                    .map(|candidate| candidate.as_str())
+                    .collect()
+            })
+            .as_ref()
     }
 }
 
@@ -78,14 +134,35 @@ pub enum PanDirection {
 }
 
 impl PanDirection {
-    pub fn parse(value: &str) -> Option<Self> {
-        match value {
-            "left" => Some(Self::Left),
-            "right" => Some(Self::Right),
-            "up" => Some(Self::Up),
-            "down" => Some(Self::Down),
-            _ => None,
+    const VARIANTS: [Self; 4] = [Self::Left, Self::Right, Self::Up, Self::Down];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Left => "left",
+            Self::Right => "right",
+            Self::Up => "up",
+            Self::Down => "down",
         }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Self::VARIANTS
+            .iter()
+            .copied()
+            .find(|candidate| candidate.as_str() == value)
+    }
+
+    pub fn values() -> &'static [&'static str] {
+        static VALUES: OnceLock<Box<[&'static str]>> = OnceLock::new();
+
+        VALUES
+            .get_or_init(|| {
+                PanDirection::VARIANTS
+                    .iter()
+                    .map(|candidate| candidate.as_str())
+                    .collect()
+            })
+            .as_ref()
     }
 }
 
@@ -371,6 +448,70 @@ mod tests {
     };
 
     #[test]
+    fn enum_command_arguments_round_trip_through_strings() {
+        for direction in [
+            PanDirection::Left,
+            PanDirection::Right,
+            PanDirection::Up,
+            PanDirection::Down,
+        ] {
+            assert_eq!(PanDirection::parse(direction.as_str()), Some(direction));
+        }
+
+        for direction in [SpreadDirectionArg::Ltr, SpreadDirectionArg::Rtl] {
+            assert_eq!(
+                SpreadDirectionArg::parse(direction.as_str()),
+                Some(direction)
+            );
+        }
+
+        for matcher in [
+            SearchMatcherKind::ContainsInsensitive,
+            SearchMatcherKind::ContainsSensitive,
+        ] {
+            assert_eq!(SearchMatcherKind::parse(matcher.as_str()), Some(matcher));
+        }
+
+        for mode in [PageLayoutModeArg::Single, PageLayoutModeArg::Spread] {
+            assert_eq!(PageLayoutModeArg::parse(mode.as_str()), Some(mode));
+        }
+    }
+
+    #[test]
+    fn enum_value_lists_are_derived_from_variant_strings() {
+        assert_eq!(
+            PanDirection::values(),
+            &[
+                PanDirection::Left.as_str(),
+                PanDirection::Right.as_str(),
+                PanDirection::Up.as_str(),
+                PanDirection::Down.as_str(),
+            ]
+        );
+        assert_eq!(
+            SpreadDirectionArg::values(),
+            &[
+                SpreadDirectionArg::Ltr.as_str(),
+                SpreadDirectionArg::Rtl.as_str(),
+            ]
+        );
+        assert_eq!(
+            SearchMatcherKind::values(),
+            &[
+                SearchMatcherKind::ContainsInsensitive.as_str(),
+                SearchMatcherKind::ContainsSensitive.as_str(),
+            ]
+        );
+        assert_eq!(
+            PageLayoutModeArg::values(),
+            &[
+                PageLayoutModeArg::Single.as_str(),
+                PageLayoutModeArg::Spread.as_str(),
+            ]
+        );
+    }
+
+    #[test]
     fn command_action_id_maps_search_and_history_variants() {
         assert_eq!(Command::OpenSearch.action_id(), ActionId::Search);
         assert_eq!(
@@ -429,11 +570,23 @@ pub enum ArgKind {
     String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
 pub enum ArgHint {
     None,
-    Enum(&'static [&'static str]),
+    Enum(fn() -> &'static [&'static str]),
 }
+
+impl PartialEq for ArgHint {
+    fn eq(&self, other: &Self) -> bool {
+        match (*self, *other) {
+            (Self::None, Self::None) => true,
+            (Self::Enum(lhs), Self::Enum(rhs)) => std::ptr::fn_addr_eq(lhs, rhs),
+            _ => false,
+        }
+    }
+}
+
+impl Eq for ArgHint {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ArgSpec {

--- a/src/command/types.rs
+++ b/src/command/types.rs
@@ -430,10 +430,17 @@ pub enum ArgKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArgHint {
+    None,
+    Enum(&'static [&'static str]),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ArgSpec {
     pub name: &'static str,
     pub kind: ArgKind,
     pub required: bool,
+    pub hint: ArgHint,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/palette/providers/command.rs
+++ b/src/palette/providers/command.rs
@@ -4,7 +4,7 @@ use crate::command::first_token;
 use crate::command::is_command_visible_in_palette;
 use crate::command::parse_command_text;
 use crate::command::parse_invocable_command_text;
-use crate::command::{CommandConditionContext, CommandInvocationSource};
+use crate::command::{ArgHint, ArgKind, ArgSpec, CommandConditionContext, CommandInvocationSource};
 use crate::error::AppResult;
 use crate::input::InputHistoryRecord;
 use crate::input::shortcut::{
@@ -36,30 +36,41 @@ impl PaletteProvider for CommandPaletteProvider {
     }
 
     fn list(&self, ctx: &PaletteContext<'_>) -> AppResult<Vec<PaletteCandidate>> {
-        if has_argument_phase(ctx.input) {
-            return Ok(Vec::new());
+        let analysis = analyze_command_input(ctx.input);
+        match analysis.active_argument {
+            Some(argument) if argument.is_enum() => {
+                let mut candidates = argument
+                    .values()
+                    .iter()
+                    .map(|value| enum_value_candidate(value))
+                    .collect::<Vec<_>>();
+                rank_enum_candidates(argument.token, &mut candidates);
+                Ok(candidates)
+            }
+            Some(_) => Ok(Vec::new()),
+            None => {
+                let mut candidates = all_command_specs()
+                    .into_iter()
+                    .filter(|spec| {
+                        let command_ctx = CommandConditionContext {
+                            app: ctx.app,
+                            extensions: ctx.extensions,
+                            source: CommandInvocationSource::CommandPaletteInput,
+                        };
+                        is_command_visible_in_palette(*spec, &command_ctx)
+                    })
+                    .map(|spec| PaletteCandidate {
+                        id: spec.id.to_string(),
+                        left: format_left(spec.id, spec.args),
+                        right: vec![PaletteTextPart::secondary(spec.title)],
+                        search_texts: format_search_texts(spec.id, spec.title, spec.args),
+                        payload: PalettePayload::Opaque(spec.id.to_string()),
+                    })
+                    .collect::<Vec<_>>();
+                rank_command_candidates(ctx.input, &mut candidates);
+                Ok(candidates)
+            }
         }
-
-        let mut candidates = all_command_specs()
-            .into_iter()
-            .filter(|spec| {
-                let command_ctx = CommandConditionContext {
-                    app: ctx.app,
-                    extensions: ctx.extensions,
-                    source: CommandInvocationSource::CommandPaletteInput,
-                };
-                is_command_visible_in_palette(*spec, &command_ctx)
-            })
-            .map(|spec| PaletteCandidate {
-                id: spec.id.to_string(),
-                left: format_left(spec.id, spec.args),
-                right: vec![PaletteTextPart::secondary(spec.title)],
-                search_texts: format_search_texts(spec.id, spec.title, spec.args),
-                payload: PalettePayload::Opaque(spec.id.to_string()),
-            })
-            .collect::<Vec<_>>();
-        rank_command_candidates(ctx.input, &mut candidates);
-        Ok(candidates)
     }
 
     fn on_submit(
@@ -69,7 +80,11 @@ impl PaletteProvider for CommandPaletteProvider {
     ) -> AppResult<PaletteSubmitEffect> {
         let input = ctx.input.trim();
 
-        // 1. If the user typed an explicit command form, prefer that over candidate fallback.
+        if let Some(effect) = submit_selected_enum_candidate(ctx, selected)? {
+            return Ok(effect);
+        }
+
+        let mut deferred_error = None;
         if !input.is_empty() {
             match parse_invocable_command_text(
                 input,
@@ -84,11 +99,8 @@ impl PaletteProvider for CommandPaletteProvider {
                         next: PalettePostAction::Close,
                     });
                 }
-                Err(err)
-                    if has_argument_phase(input)
-                        || find_command_spec(first_token(input)).is_some() =>
-                {
-                    return Err(err);
+                Err(err) if find_command_spec(first_token(input)).is_some() => {
+                    deferred_error = Some(err);
                 }
                 Err(_) => {}
             }
@@ -116,6 +128,10 @@ impl PaletteProvider for CommandPaletteProvider {
             }
         }
 
+        if let Some(err) = deferred_error {
+            return Err(err);
+        }
+
         // 3. Fallback: reopen preserving current input.
         Ok(PaletteSubmitEffect::Reopen {
             kind: self.kind(),
@@ -125,12 +141,20 @@ impl PaletteProvider for CommandPaletteProvider {
 
     fn on_tab(
         &self,
-        _ctx: &PaletteContext<'_>,
+        ctx: &PaletteContext<'_>,
         selected: Option<&PaletteCandidate>,
     ) -> AppResult<PaletteTabEffect> {
         let Some(candidate) = selected else {
             return Ok(PaletteTabEffect::Noop);
         };
+
+        let analysis = analyze_command_input(ctx.input);
+        if let Some(value) = selected_enum_value(&analysis, candidate) {
+            return Ok(PaletteTabEffect::SetInput {
+                value: apply_enum_completion(&analysis, value),
+                move_cursor_to_end: true,
+            });
+        }
 
         let value = match &candidate.payload {
             PalettePayload::Opaque(value) => value.clone(),
@@ -162,32 +186,75 @@ impl PaletteProvider for CommandPaletteProvider {
             return Some(default_hint);
         }
 
-        if has_argument_phase(ctx.input) {
-            let command_id = first_token(trimmed);
-            return match find_command_spec(command_id) {
-                Some(spec) => {
-                    let usage = usage_text(spec.args);
-                    if usage.is_empty() {
-                        Some(format!("{} | {}", spec.id, spec.title))
-                    } else {
-                        Some(format!("{} {} | {}", spec.id, usage, spec.title))
-                    }
-                }
-                None => Some(default_hint),
-            };
+        let analysis = analyze_command_input(ctx.input);
+        match analysis.active_argument {
+            Some(argument) if argument.is_enum() => {
+                return Some(format!(
+                    "{} {} | {}: {}",
+                    argument.spec.id,
+                    usage_text(argument.spec.args),
+                    argument.arg.name,
+                    argument.values().join(" / ")
+                ));
+            }
+            Some(argument) => {
+                return Some(format!(
+                    "{} {} | {}: {}",
+                    argument.spec.id,
+                    usage_text(argument.spec.args),
+                    argument.arg.name,
+                    ui_type_label(argument.arg.kind)
+                ));
+            }
+            None => {}
+        }
+
+        if let Some(spec) = analysis.command_spec {
+            let usage = usage_text(spec.args);
+            if usage.is_empty() {
+                return Some(format!("{} | {}", spec.id, spec.title));
+            }
+            return Some(format!("{} {} | {}", spec.id, usage, spec.title));
         }
 
         if let Some(spec) = find_command_spec(trimmed) {
             let usage = usage_text(spec.args);
             if usage.is_empty() {
                 return Some(format!("{} | {}", spec.id, spec.title));
-            } else {
-                return Some(format!("{} {} | {}", spec.id, usage, spec.title));
             }
+            return Some(format!("{} {} | {}", spec.id, usage, spec.title));
         }
 
         Some(default_hint)
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ActiveArgument<'a> {
+    spec: crate::command::CommandSpec,
+    arg: ArgSpec,
+    index: usize,
+    token: &'a str,
+}
+
+impl ActiveArgument<'_> {
+    fn is_enum(self) -> bool {
+        matches!(self.arg.hint, ArgHint::Enum(_))
+    }
+
+    fn values(self) -> &'static [&'static str] {
+        match self.arg.hint {
+            ArgHint::Enum(values) => values,
+            ArgHint::None => &[],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CommandInputAnalysis<'a> {
+    trimmed_input: &'a str,
+    command_spec: Option<crate::command::CommandSpec>,
+    active_argument: Option<ActiveArgument<'a>>,
 }
 
 fn format_left(command_id: &str, args: &[crate::command::ArgSpec]) -> Vec<PaletteTextPart> {
@@ -222,16 +289,148 @@ fn usage_text(args: &[crate::command::ArgSpec]) -> String {
     usage
 }
 
-fn has_argument_phase(input: &str) -> bool {
-    let trimmed = input.trim_start();
-    if trimmed.is_empty() {
-        return false;
-    }
-    trimmed.contains(char::is_whitespace)
-}
-
 fn command_requires_argument_input(spec: crate::command::CommandSpec) -> bool {
     spec.args.iter().any(|arg| arg.required)
+}
+
+fn ui_type_label(kind: ArgKind) -> &'static str {
+    match kind {
+        ArgKind::I32 => "integer",
+        ArgKind::F32 => "number",
+        ArgKind::String => "text",
+    }
+}
+
+fn enum_value_candidate(value: &str) -> PaletteCandidate {
+    PaletteCandidate {
+        id: value.to_string(),
+        left: vec![PaletteTextPart::primary(value)],
+        right: Vec::new(),
+        search_texts: vec![PaletteSearchText::new(value)],
+        payload: PalettePayload::Opaque(value.to_string()),
+    }
+}
+
+fn analyze_command_input(input: &str) -> CommandInputAnalysis<'_> {
+    let trimmed = input.trim_start();
+    if trimmed.is_empty() {
+        return CommandInputAnalysis {
+            trimmed_input: trimmed,
+            command_spec: None,
+            active_argument: None,
+        };
+    }
+
+    let Some(spec) = find_command_spec(first_token(trimmed)) else {
+        return CommandInputAnalysis {
+            trimmed_input: trimmed,
+            command_spec: None,
+            active_argument: None,
+        };
+    };
+
+    CommandInputAnalysis {
+        trimmed_input: trimmed,
+        command_spec: Some(spec),
+        active_argument: active_argument(trimmed, spec),
+    }
+}
+
+fn active_argument<'a>(
+    input: &'a str,
+    spec: crate::command::CommandSpec,
+) -> Option<ActiveArgument<'a>> {
+    let trimmed = input.trim_start();
+    let split_idx = trimmed.find(char::is_whitespace)?;
+    let args_text = trimmed[split_idx..].trim_start();
+    let has_trailing_whitespace = trimmed.chars().last().is_some_and(char::is_whitespace);
+
+    let tokens = args_text.split_whitespace().collect::<Vec<_>>();
+    let active_index = if has_trailing_whitespace {
+        tokens.len()
+    } else {
+        tokens.len().checked_sub(1)?
+    };
+    let arg = *spec.args.get(active_index)?;
+    let token = if has_trailing_whitespace {
+        ""
+    } else {
+        tokens.get(active_index).copied().unwrap_or("")
+    };
+
+    Some(ActiveArgument {
+        spec,
+        arg,
+        index: active_index,
+        token,
+    })
+}
+
+fn selected_enum_value<'a>(
+    analysis: &CommandInputAnalysis<'_>,
+    candidate: &'a PaletteCandidate,
+) -> Option<&'a str> {
+    analysis
+        .active_argument
+        .is_some_and(ActiveArgument::is_enum)
+    .then_some(match &candidate.payload {
+        PalettePayload::Opaque(value) => value.as_str(),
+        PalettePayload::None => "",
+    })
+    .filter(|value| !value.is_empty())
+}
+
+fn apply_enum_completion(analysis: &CommandInputAnalysis<'_>, value: &str) -> String {
+    let Some(spec) = analysis.command_spec else {
+        return format!("{value} ");
+    };
+    let Some(active_argument) = analysis.active_argument else {
+        return format!("{value} ");
+    };
+
+    let mut parts = vec![spec.id];
+    let existing_args = analysis
+        .trimmed_input
+        .split_whitespace()
+        .skip(1)
+        .take(active_argument.index)
+        .collect::<Vec<_>>();
+    parts.extend(existing_args);
+    parts.push(value);
+
+    format!("{} ", parts.join(" "))
+}
+
+fn submit_selected_enum_candidate(
+    ctx: &PaletteContext<'_>,
+    selected: Option<&PaletteCandidate>,
+) -> AppResult<Option<PaletteSubmitEffect>> {
+    let Some(candidate) = selected else {
+        return Ok(None);
+    };
+    let analysis = analyze_command_input(ctx.input);
+    let Some(value) = selected_enum_value(&analysis, candidate) else {
+        return Ok(None);
+    };
+
+    let synthesized = apply_enum_completion(&analysis, value);
+    let synthesized_trimmed = synthesized.trim();
+    match parse_invocable_command_text(
+        synthesized_trimmed,
+        CommandInvocationSource::CommandPaletteInput,
+        ctx.app,
+        ctx.extensions,
+    ) {
+        Ok(command) => Ok(Some(PaletteSubmitEffect::Dispatch {
+            command,
+            history_record: Some(InputHistoryRecord::Command(synthesized_trimmed.to_string())),
+            next: PalettePostAction::Close,
+        })),
+        Err(_) => Ok(Some(PaletteSubmitEffect::Reopen {
+            kind: PaletteKind::Command,
+            seed: Some(synthesized),
+        })),
+    }
 }
 
 const SCORE_ID_EXACT: i32 = 10_000;
@@ -250,6 +449,35 @@ struct CandidateScore {
 }
 
 fn rank_command_candidates(input: &str, candidates: &mut Vec<PaletteCandidate>) {
+    let query = input.trim().to_ascii_lowercase();
+    if query.is_empty() {
+        return;
+    }
+
+    let mut scored = candidates
+        .drain(..)
+        .filter_map(|candidate| {
+            score_command_candidate(&query, &candidate).map(|meta| (candidate, meta))
+        })
+        .collect::<Vec<_>>();
+
+    scored.sort_by(
+        |(left_candidate, left_meta), (right_candidate, right_meta)| {
+            right_meta
+                .score
+                .cmp(&left_meta.score)
+                .then_with(|| left_meta.tie_len.cmp(&right_meta.tie_len))
+                .then_with(|| left_candidate.id.cmp(&right_candidate.id))
+        },
+    );
+
+    *candidates = scored
+        .into_iter()
+        .map(|(candidate, _meta)| candidate)
+        .collect();
+}
+
+fn rank_enum_candidates(input: &str, candidates: &mut Vec<PaletteCandidate>) {
     let query = input.trim().to_ascii_lowercase();
     if query.is_empty() {
         return;
@@ -461,6 +689,20 @@ mod tests {
             .expect("tab should succeed")
     }
 
+    fn assistive_text_for_input(input: &str, search_active: bool) -> Option<String> {
+        let provider = CommandPaletteProvider;
+        let app = AppState::default();
+        let extensions = ExtensionUiSnapshot::with_search_active(search_active);
+        let ctx = PaletteContext {
+            app: &app,
+            extensions: &extensions,
+            kind: PaletteKind::Command,
+            input,
+            seed: None,
+        };
+        provider.assistive_text(&ctx, None)
+    }
+
     #[test]
     fn list_hides_search_hit_navigation_when_search_is_inactive() {
         let provider = CommandPaletteProvider;
@@ -515,8 +757,26 @@ mod tests {
     }
 
     #[test]
-    fn argument_phase_still_hides_candidates() {
+    fn non_enum_argument_phase_hides_candidates() {
         let list = command_list_for_input("goto-page ", false);
+        assert!(list.is_empty());
+    }
+
+    #[test]
+    fn enum_argument_phase_lists_values() {
+        let list = command_list_for_input("page-layout-spread ", false);
+        assert_eq!(ids(&list), vec!["ltr".to_string(), "rtl".to_string()]);
+    }
+
+    #[test]
+    fn enum_argument_phase_filters_values() {
+        let list = command_list_for_input("page-layout-spread r", false);
+        assert_eq!(ids(&list), vec!["rtl".to_string(), "ltr".to_string()]);
+    }
+
+    #[test]
+    fn trailing_non_enum_argument_phase_hides_enum_candidates() {
+        let list = command_list_for_input("pan left ", false);
         assert!(list.is_empty());
     }
 
@@ -670,6 +930,76 @@ mod tests {
                 value: "quit ".to_string(),
                 move_cursor_to_end: true,
             }
+        );
+    }
+
+    #[test]
+    fn tab_completion_replaces_enum_argument_and_appends_space() {
+        let effect = command_tab_effect("page-layout-spread r", "rtl", false);
+        assert_eq!(
+            effect,
+            PaletteTabEffect::SetInput {
+                value: "page-layout-spread rtl ".to_string(),
+                move_cursor_to_end: true,
+            }
+        );
+    }
+
+    #[test]
+    fn submit_dispatches_selected_enum_argument_when_result_is_complete() {
+        let effect = command_submit_effect("page-layout-spread ", "rtl", false);
+        assert_eq!(
+            effect,
+            PaletteSubmitEffect::Dispatch {
+                command: Command::SetPageLayout {
+                    mode: crate::command::PageLayoutModeArg::Spread,
+                    direction: Some(crate::command::SpreadDirectionArg::Rtl),
+                },
+                history_record: Some(InputHistoryRecord::Command(
+                    "page-layout-spread rtl".to_string(),
+                )),
+                next: PalettePostAction::Close,
+            }
+        );
+    }
+
+    #[test]
+    fn assistive_text_uses_enum_values_for_enum_arguments() {
+        assert_eq!(
+            assistive_text_for_input("page-layout-spread ", false),
+            Some("page-layout-spread [direction] | direction: ltr / rtl".to_string())
+        );
+    }
+
+    #[test]
+    fn assistive_text_uses_integer_label_for_integer_arguments() {
+        assert_eq!(
+            assistive_text_for_input("goto-page ", false),
+            Some("goto-page <page> | page: integer".to_string())
+        );
+    }
+
+    #[test]
+    fn assistive_text_uses_number_label_for_float_arguments() {
+        assert_eq!(
+            assistive_text_for_input("zoom ", false),
+            Some("zoom <value> | value: number".to_string())
+        );
+    }
+
+    #[test]
+    fn assistive_text_shows_title_when_all_arguments_are_complete() {
+        assert_eq!(
+            assistive_text_for_input("pan left 1 ", false),
+            Some("pan <direction> [amount] | Pan".to_string())
+        );
+    }
+
+    #[test]
+    fn assistive_text_shows_title_for_complete_no_argument_command() {
+        assert_eq!(
+            assistive_text_for_input("quit ", false),
+            Some("quit | Quit".to_string())
         );
     }
 

--- a/src/palette/providers/command.rs
+++ b/src/palette/providers/command.rs
@@ -44,7 +44,7 @@ impl PaletteProvider for CommandPaletteProvider {
                     .iter()
                     .map(|value| enum_value_candidate(value))
                     .collect::<Vec<_>>();
-                rank_enum_candidates(argument.token, &mut candidates);
+                filter_enum_candidates(argument.token, &mut candidates);
                 Ok(candidates)
             }
             Some(_) => Ok(Vec::new()),
@@ -477,33 +477,21 @@ fn rank_command_candidates(input: &str, candidates: &mut Vec<PaletteCandidate>) 
         .collect();
 }
 
-fn rank_enum_candidates(input: &str, candidates: &mut Vec<PaletteCandidate>) {
+fn filter_enum_candidates(input: &str, candidates: &mut Vec<PaletteCandidate>) {
     let query = input.trim().to_ascii_lowercase();
     if query.is_empty() {
         return;
     }
 
-    let mut scored = candidates
-        .drain(..)
-        .filter_map(|candidate| {
-            score_command_candidate(&query, &candidate).map(|meta| (candidate, meta))
-        })
-        .collect::<Vec<_>>();
-
-    scored.sort_by(
-        |(left_candidate, left_meta), (right_candidate, right_meta)| {
-            right_meta
-                .score
-                .cmp(&left_meta.score)
-                .then_with(|| left_meta.tie_len.cmp(&right_meta.tie_len))
-                .then_with(|| left_candidate.id.cmp(&right_candidate.id))
-        },
-    );
-
-    *candidates = scored
-        .into_iter()
-        .map(|(candidate, _meta)| candidate)
+    let filtered: Vec<_> = candidates
+        .iter()
+        .filter(|candidate| score_command_candidate(&query, candidate).is_some())
+        .cloned()
         .collect();
+
+    if !filtered.is_empty() {
+        *candidates = filtered;
+    }
 }
 
 fn score_command_candidate(query: &str, candidate: &PaletteCandidate) -> Option<CandidateScore> {
@@ -771,7 +759,44 @@ mod tests {
     #[test]
     fn enum_argument_phase_filters_values() {
         let list = command_list_for_input("page-layout-spread r", false);
-        assert_eq!(ids(&list), vec!["rtl".to_string(), "ltr".to_string()]);
+        assert_eq!(ids(&list), vec!["ltr".to_string(), "rtl".to_string()]);
+    }
+
+    #[test]
+    fn enum_argument_candidates_keep_definition_order() {
+        let list = command_list_for_input("pan ", false);
+        assert_eq!(
+            ids(&list),
+            vec![
+                "left".to_string(),
+                "right".to_string(),
+                "up".to_string(),
+                "down".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn enum_argument_candidates_filter_without_reordering() {
+        let list = command_list_for_input("pan t", false);
+        assert_eq!(ids(&list), vec!["left".to_string(), "right".to_string()]);
+
+        let list = command_list_for_input("page-layout-spread rt", false);
+        assert_eq!(ids(&list), vec!["rtl".to_string()]);
+    }
+
+    #[test]
+    fn enum_argument_candidates_fall_back_to_full_list_when_no_match() {
+        let list = command_list_for_input("pan z", false);
+        assert_eq!(
+            ids(&list),
+            vec![
+                "left".to_string(),
+                "right".to_string(),
+                "up".to_string(),
+                "down".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/src/palette/providers/command.rs
+++ b/src/palette/providers/command.rs
@@ -244,7 +244,7 @@ impl ActiveArgument<'_> {
 
     fn values(self) -> &'static [&'static str] {
         match self.arg.hint {
-            ArgHint::Enum(values) => values,
+            ArgHint::Enum(values) => values(),
             ArgHint::None => &[],
         }
     }
@@ -373,11 +373,11 @@ fn selected_enum_value<'a>(
     analysis
         .active_argument
         .is_some_and(ActiveArgument::is_enum)
-    .then_some(match &candidate.payload {
-        PalettePayload::Opaque(value) => value.as_str(),
-        PalettePayload::None => "",
-    })
-    .filter(|value| !value.is_empty())
+        .then_some(match &candidate.payload {
+            PalettePayload::Opaque(value) => value.as_str(),
+            PalettePayload::None => "",
+        })
+        .filter(|value| !value.is_empty())
 }
 
 fn apply_enum_completion(analysis: &CommandInputAnalysis<'_>, value: &str) -> String {
@@ -904,6 +904,38 @@ mod tests {
             PaletteSubmitEffect::Dispatch {
                 command: Command::Quit,
                 history_record: Some(InputHistoryRecord::Command("quit".to_string())),
+                next: PalettePostAction::Close,
+            }
+        );
+    }
+
+    #[test]
+    fn submit_dispatches_typed_optional_enum_command_without_argument() {
+        let provider = CommandPaletteProvider;
+        let app = AppState::default();
+        let extensions = ExtensionUiSnapshot::default();
+        let ctx = PaletteContext {
+            app: &app,
+            extensions: &extensions,
+            kind: PaletteKind::Command,
+            input: "page-layout-spread",
+            seed: None,
+        };
+
+        let effect = provider
+            .on_submit(&ctx, None)
+            .expect("typed command submit should succeed");
+
+        assert_eq!(
+            effect,
+            PaletteSubmitEffect::Dispatch {
+                command: Command::SetPageLayout {
+                    mode: crate::command::PageLayoutModeArg::Spread,
+                    direction: None,
+                },
+                history_record: Some(InputHistoryRecord::Command(
+                    "page-layout-spread".to_string(),
+                )),
                 next: PalettePostAction::Close,
             }
         );

--- a/src/palette/providers/command.rs
+++ b/src/palette/providers/command.rs
@@ -217,14 +217,6 @@ impl PaletteProvider for CommandPaletteProvider {
             return Some(format!("{} {} | {}", spec.id, usage, spec.title));
         }
 
-        if let Some(spec) = find_command_spec(trimmed) {
-            let usage = usage_text(spec.args);
-            if usage.is_empty() {
-                return Some(format!("{} | {}", spec.id, spec.title));
-            }
-            return Some(format!("{} {} | {}", spec.id, usage, spec.title));
-        }
-
         Some(default_hint)
     }
 }


### PR DESCRIPTION
Problem
The command palette made argument entry harder than necessary, especially for enum-valued arguments. Once input entered argument phase, candidates disappeared entirely, assistive text was too generic, and completing enum values required remembering the accepted strings.

Solution
- add enum argument hints to command metadata
- keep enum candidates visible during argument entry
- make Tab complete enum values and let Enter accept the selected enum value before executing or advancing
- update assistive text to show English type/value guidance such as integer, number, text, or enum value lists
- update the command and palette specs to match the new behavior

Risk and impact
This changes command-palette interaction only. Parsing and command dispatch remain the source of truth, so invalid inputs still fail through the existing validation path.

Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Per-argument UI hints with selectable enum value lists; tab-complete inserts enum values and appends a trailing space.
  - Enter prioritizes selected enum candidates, accepting values and continuing argument entry when appropriate.

* **Bug Fixes**
  - Fixed Enter/candidate submission ordering and candidate visibility for consistent enum argument behavior.
  - Improved parsing/reopen behavior after enum selection.

* **Documentation**
  - Updated command-system and palette-provider docs, clarifying optional direction argument semantics and assistive-text rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->