### PR TITLE
feat(search): restore last matcher selection in palette

### DIFF
--- a/docs/extension-system.md
+++ b/docs/extension-system.md
@@ -76,7 +76,8 @@ Dispatch rules:
 
 - Palette flow
   - the host exposes `ExtensionUiSnapshot`
-  - current snapshot data includes `search_active` and cached outline entries
+  - current snapshot data includes `search_active`, `search_matcher`, and
+    cached outline entries
 
 ## Current extensions
 

--- a/docs/extension-system.md
+++ b/docs/extension-system.md
@@ -76,8 +76,8 @@ Dispatch rules:
 
 - Palette flow
   - the host exposes `ExtensionUiSnapshot`
-  - current snapshot data includes `search_active`, `search_matcher`, and
-    cached outline entries
+  - current snapshot data includes `search_active`,
+    `search_palette_initial_matcher`, and cached outline entries
 
 ## Current extensions
 

--- a/docs/palette-provider.md
+++ b/docs/palette-provider.md
@@ -152,6 +152,7 @@ current input.
 - `<up>` / `<down>` recall recent search queries
 - `<c-p>` / `<c-n>` select the matcher candidate
 - matcher candidates are `contains-insensitive` and `contains-sensitive`
+- opening the palette selects the last matcher used for search submit
 - search history stores only the query text
 - pressing Enter with empty input reopens for correction
 - successful submit dispatches internal search-submit behavior and closes

--- a/src/extension/host.rs
+++ b/src/extension/host.rs
@@ -16,7 +16,7 @@ use super::traits::Extension;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExtensionUiSnapshot {
     pub search_active: bool,
-    pub search_matcher: SearchMatcherKind,
+    pub search_palette_initial_matcher: SearchMatcherKind,
     pub outline_entries: Arc<[OutlinePaletteEntry]>,
 }
 
@@ -24,7 +24,7 @@ impl Default for ExtensionUiSnapshot {
     fn default() -> Self {
         Self {
             search_active: false,
-            search_matcher: SearchMatcherKind::ContainsInsensitive,
+            search_palette_initial_matcher: SearchMatcherKind::ContainsInsensitive,
             outline_entries: Arc::from([]),
         }
     }
@@ -34,7 +34,7 @@ impl ExtensionUiSnapshot {
     pub fn with_search_active(search_active: bool) -> Self {
         Self {
             search_active,
-            search_matcher: SearchMatcherKind::ContainsInsensitive,
+            search_palette_initial_matcher: SearchMatcherKind::ContainsInsensitive,
             outline_entries: Arc::from([]),
         }
     }
@@ -187,7 +187,7 @@ impl ExtensionHost {
     pub fn ui_snapshot(&self) -> ExtensionUiSnapshot {
         ExtensionUiSnapshot {
             search_active: self.search.is_active(),
-            search_matcher: self.search.matcher(),
+            search_palette_initial_matcher: self.search.matcher(),
             outline_entries: self.outline.palette_entries(),
         }
     }

--- a/src/extension/host.rs
+++ b/src/extension/host.rs
@@ -13,16 +13,28 @@ use crate::search::{SearchExtension, SearchRuntime};
 
 use super::traits::Extension;
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExtensionUiSnapshot {
     pub search_active: bool,
+    pub search_matcher: SearchMatcherKind,
     pub outline_entries: Arc<[OutlinePaletteEntry]>,
+}
+
+impl Default for ExtensionUiSnapshot {
+    fn default() -> Self {
+        Self {
+            search_active: false,
+            search_matcher: SearchMatcherKind::ContainsInsensitive,
+            outline_entries: Arc::from([]),
+        }
+    }
 }
 
 impl ExtensionUiSnapshot {
     pub fn with_search_active(search_active: bool) -> Self {
         Self {
             search_active,
+            search_matcher: SearchMatcherKind::ContainsInsensitive,
             outline_entries: Arc::from([]),
         }
     }
@@ -175,6 +187,7 @@ impl ExtensionHost {
     pub fn ui_snapshot(&self) -> ExtensionUiSnapshot {
         ExtensionUiSnapshot {
             search_active: self.search.is_active(),
+            search_matcher: self.search.matcher(),
             outline_entries: self.outline.palette_entries(),
         }
     }

--- a/src/search/palette.rs
+++ b/src/search/palette.rs
@@ -132,8 +132,10 @@ mod tests {
     #[test]
     fn initial_selection_uses_last_search_matcher() {
         let provider = SearchPaletteProvider;
-        let mut extensions = ExtensionUiSnapshot::default();
-        extensions.search_matcher = SearchMatcherKind::ContainsSensitive;
+        let extensions = ExtensionUiSnapshot {
+            search_matcher: SearchMatcherKind::ContainsSensitive,
+            ..ExtensionUiSnapshot::default()
+        };
         let app = crate::app::AppState::default();
         let ctx = PaletteContext {
             app: &app,

--- a/src/search/palette.rs
+++ b/src/search/palette.rs
@@ -59,6 +59,20 @@ impl PaletteProvider for SearchPaletteProvider {
         ])
     }
 
+    fn initial_selected_candidate(
+        &self,
+        ctx: &PaletteContext<'_>,
+        candidates: &[PaletteCandidate],
+    ) -> Option<usize> {
+        let selected_matcher = ctx.extensions.search_matcher.id();
+        candidates
+            .iter()
+            .position(|candidate| match &candidate.payload {
+                PalettePayload::Opaque(id) => id == selected_matcher,
+                PalettePayload::None => false,
+            })
+    }
+
     fn on_submit(
         &self,
         ctx: &PaletteContext<'_>,
@@ -104,5 +118,39 @@ impl PaletteProvider for SearchPaletteProvider {
         Some(format!(
             "{enter} search   {history} history   {matcher} matcher"
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::command::SearchMatcherKind;
+    use crate::extension::ExtensionUiSnapshot;
+    use crate::palette::{PaletteContext, PaletteKind, PaletteProvider};
+
+    use super::SearchPaletteProvider;
+
+    #[test]
+    fn initial_selection_uses_last_search_matcher() {
+        let provider = SearchPaletteProvider;
+        let mut extensions = ExtensionUiSnapshot::default();
+        extensions.search_matcher = SearchMatcherKind::ContainsSensitive;
+        let app = crate::app::AppState::default();
+        let ctx = PaletteContext {
+            app: &app,
+            extensions: &extensions,
+            kind: PaletteKind::Search,
+            input: "needle",
+            seed: Some("needle"),
+        };
+
+        let candidates = provider.list(&ctx).expect("search candidates should build");
+        let selected = provider
+            .initial_selected_candidate(&ctx, &candidates)
+            .expect("matching candidate should exist");
+
+        assert_eq!(
+            candidates[selected].id,
+            SearchMatcherKind::ContainsSensitive.id()
+        );
     }
 }

--- a/src/search/palette.rs
+++ b/src/search/palette.rs
@@ -64,7 +64,7 @@ impl PaletteProvider for SearchPaletteProvider {
         ctx: &PaletteContext<'_>,
         candidates: &[PaletteCandidate],
     ) -> Option<usize> {
-        let selected_matcher = ctx.extensions.search_matcher.id();
+        let selected_matcher = ctx.extensions.search_palette_initial_matcher.id();
         candidates
             .iter()
             .position(|candidate| match &candidate.payload {
@@ -133,7 +133,7 @@ mod tests {
     fn initial_selection_uses_last_search_matcher() {
         let provider = SearchPaletteProvider;
         let extensions = ExtensionUiSnapshot {
-            search_matcher: SearchMatcherKind::ContainsSensitive,
+            search_palette_initial_matcher: SearchMatcherKind::ContainsSensitive,
             ..ExtensionUiSnapshot::default()
         };
         let app = crate::app::AppState::default();


### PR DESCRIPTION
## Summary
Search palette reopening now preserves the last matcher used for search submit, so changing only the matcher is more direct when the previous query is already restored.

The implementation keeps matcher ownership in the search extension state and exposes only a palette-oriented snapshot value for initial selection.

## Verification
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search palette now defaults to the last matcher used for previous searches, improving search workflow efficiency.

* **Documentation**
  * Updated extension system documentation to reflect expanded snapshot payload for palettes.
  * Updated palette provider documentation to clarify keyboard semantics for search matcher selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->