### PR TITLE
feat(search): add highlight extraction and warning notice

### DIFF
--- a/docs/rendering-pipeline.md
+++ b/docs/rendering-pipeline.md
@@ -130,7 +130,6 @@ Encode rules:
 
 L2 cache rules:
 
-- key: `TerminalFrameKey { rendered_page, viewport, pan }`
 - key: `TerminalFrameKey { rendered_page, viewport, pan, overlay_stamp }`
 - states:
   - `PendingFrame`

--- a/docs/rendering-pipeline.md
+++ b/docs/rendering-pipeline.md
@@ -20,10 +20,11 @@ This document owns:
 1. Open the PDF backend document.
 2. Rasterize the visible page or pages into `RgbaFrame`.
 3. Store raster output in the L1 rendered-page cache.
-4. Compose spread output and crop to the current viewport when needed.
-5. Prepare terminal-frame entries in the L2 cache.
-6. Encode the image for the active terminal protocol.
-7. Draw a ready terminal frame through the presenter.
+4. Apply current-view highlight overlays without mutating cached raster output.
+5. Compose spread output and crop to the current viewport when needed.
+6. Prepare terminal-frame entries in the L2 cache.
+7. Encode the image for the active terminal protocol.
+8. Draw a ready terminal frame through the presenter.
 
 Cold start may additionally render a lower-resolution preview for the current
 view before the full-resolution image is ready.
@@ -36,6 +37,9 @@ Primary backend API:
 fn render_page(&self, page: usize, scale: f32) -> AppResult<RgbaFrame>
 ```
 
+Search and overlay extraction use a separate text-page path that exposes glyph
+rectangles in page coordinates.
+
 Rules:
 
 - raster output uses RGBA pixel storage
@@ -43,6 +47,7 @@ Rules:
   identity
 - render-worker page tasks use layout tag `0` for source-page identity
 - text extraction is a separate backend path used by search
+- raw render cache entries do not include highlight overlays
 
 ## L1 rendered-page cache
 
@@ -97,6 +102,16 @@ Scheduling rules:
 
 ## Presenter encode and L2 cache
 
+Overlay rules:
+
+- highlight overlays are source-agnostic decorations applied after raw raster
+  retrieval and before presenter preparation
+- search is currently one overlay producer, but the pipeline does not depend on
+  search-specific types
+- search-hit rectangle merging uses glyph geometry in page coordinates; the
+  inferred merge axis is a screen-space layout heuristic, not a writing-mode classification
+- overlay differences do not affect L1 rendered-page cache identity
+
 Encode input:
 
 ```rust
@@ -116,6 +131,7 @@ Encode rules:
 L2 cache rules:
 
 - key: `TerminalFrameKey { rendered_page, viewport, pan }`
+- key: `TerminalFrameKey { rendered_page, viewport, pan, overlay_stamp }`
 - states:
   - `PendingFrame`
   - `Encoding`
@@ -125,8 +141,8 @@ L2 cache rules:
   entry may temporarily coexist with the currently visible ready frame to avoid
   regressing to a blank viewer
 
-`viewport` and `pan` are part of the L2 key because terminal output depends on
-both.
+`viewport`, `pan`, and `overlay_stamp` are part of the L2 key because terminal
+output depends on all three.
 
 ## Presenter draw contract
 

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -61,6 +61,8 @@ Rules:
   - search runs asynchronously and reports progress while active
   - visible search hits are highlighted through the generic highlight overlay
     layer
+  - if highlight extraction fails for matched pages, search results are kept and
+    a concise warning notice is shown
   - `search` opens the search palette
   - `next-search-hit` and `prev-search-hit` are available only while search is
     active

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -59,6 +59,8 @@ Rules:
   - full-text substring search supports case-insensitive and case-sensitive
     matchers
   - search runs asynchronously and reports progress while active
+  - visible search hits are highlighted through the generic highlight overlay
+    layer
   - `search` opens the search palette
   - `next-search-hit` and `prev-search-hit` are available only while search is
     active

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -46,6 +46,7 @@ struct LoopRuntime<S> {
 
 struct LoopStep {
     current_scale: f32,
+    overlay_stamp: u64,
     prefetch_viewport: Option<Viewport>,
     base_pan: PanOffset,
     enable_crop: bool,
@@ -398,6 +399,7 @@ impl App {
             PrefetchDispatchContext {
                 required_keys: step.required_render_keys.clone(),
                 current_cached: step.current_cached,
+                overlay_stamp: step.overlay_stamp,
                 prefetch_viewport: step.prefetch_viewport,
                 base_pan: step.base_pan,
                 enable_crop: step.enable_crop,
@@ -458,6 +460,12 @@ impl App {
         let visible_pages = self.state.visible_page_slots(pdf.page_count());
         let current_scale =
             self.compute_current_scale(pdf, visible_pages.anchor_page, prefetch_viewport);
+        let overlay_stamp = self
+            .interaction
+            .extensions
+            .host
+            .highlight_overlay_for(visible_pages.existing_pages())
+            .stamp;
         let base_pan = self.current_pan();
         let enable_crop = self.state.zoom > 1.0;
         let interactive = input_actor.is_interactive(prefetch_pause_after_input);
@@ -497,6 +505,7 @@ impl App {
 
         LoopStep {
             current_scale,
+            overlay_stamp,
             prefetch_viewport,
             base_pan,
             enable_crop,

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -591,6 +591,11 @@ impl App {
                     current_scale: step.current_scale,
                     initial_preview: step.initial_preview.clone(),
                     presenter_key: step.presenter_key,
+                    highlight_overlay: self
+                        .interaction
+                        .extensions
+                        .host
+                        .highlight_overlay_for(step.visible_pages.existing_pages()),
                     generation: runtime.render_actor.generation(),
                     nav_streak: runtime.render_actor.nav_streak(),
                 },
@@ -918,6 +923,7 @@ mod tests {
             _frame: &crate::backend::RgbaFrame,
             _viewport: Viewport,
             _pan: PanOffset,
+            _overlay_stamp: u64,
             _generation: u64,
         ) -> crate::error::AppResult<()> {
             Ok(())

--- a/src/app/frame_ops.rs
+++ b/src/app/frame_ops.rs
@@ -1,6 +1,7 @@
 use std::sync::OnceLock;
 
-use crate::backend::{PixelBuffer, PixelBufferPool, RgbaFrame};
+use crate::backend::{PdfRect, PixelBuffer, PixelBufferPool, RgbaFrame};
+use crate::highlight::{HighlightOverlaySnapshot, HighlightSpan};
 use crate::presenter::{PanOffset, Viewport};
 use crate::work::WorkClass;
 
@@ -10,6 +11,44 @@ static FRAME_OPS_PIXEL_POOL: OnceLock<PixelBufferPool> = OnceLock::new();
 
 fn frame_ops_pixel_pool() -> &'static PixelBufferPool {
     FRAME_OPS_PIXEL_POOL.get_or_init(PixelBufferPool::default)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct PageRenderSpace {
+    pub(crate) page: usize,
+    pub(crate) origin_x_px: u32,
+    pub(crate) origin_y_px: u32,
+    pub(crate) width_px: u32,
+    pub(crate) height_px: u32,
+    pub(crate) width_pt: f32,
+    pub(crate) height_pt: f32,
+}
+
+pub(crate) fn apply_highlight_overlay(
+    frame: &RgbaFrame,
+    overlay: &HighlightOverlaySnapshot,
+    pages: &[PageRenderSpace],
+) -> RgbaFrame {
+    if overlay.is_empty() || pages.is_empty() {
+        return frame.clone();
+    }
+
+    let mut pixels = frame_ops_pixel_pool().take(frame.byte_len());
+    pixels.copy_from_slice(&frame.pixels);
+    for span in &overlay.spans {
+        for page in pages {
+            if page.page != span.page {
+                continue;
+            }
+            draw_span(&mut pixels, frame.width, frame.height, span, *page);
+        }
+    }
+
+    RgbaFrame {
+        width: frame.width,
+        height: frame.height,
+        pixels: PixelBuffer::from_pooled_vec(pixels, frame_ops_pixel_pool()),
+    }
 }
 
 pub(crate) fn prepare_presenter_frame(
@@ -163,6 +202,75 @@ fn blit_side(
         let src_start = row * src_stride;
         let src_end = src_start + row_bytes;
         out_pixels[out_start..out_end].copy_from_slice(&src.pixels[src_start..src_end]);
+    }
+}
+
+fn draw_span(
+    pixels: &mut [u8],
+    frame_width: u32,
+    frame_height: u32,
+    span: &HighlightSpan,
+    page: PageRenderSpace,
+) {
+    for rect in &span.rects {
+        let Some((x0, y0, x1, y1)) = rect_to_pixels(*rect, page, frame_width, frame_height) else {
+            continue;
+        };
+        fill_rect(
+            pixels,
+            frame_width as usize,
+            x0,
+            y0,
+            x1,
+            y1,
+            span.style.fill_rgba,
+        );
+    }
+}
+
+fn rect_to_pixels(
+    rect: PdfRect,
+    page: PageRenderSpace,
+    frame_width: u32,
+    frame_height: u32,
+) -> Option<(u32, u32, u32, u32)> {
+    if page.width_px == 0 || page.height_px == 0 || page.width_pt <= 0.0 || page.height_pt <= 0.0 {
+        return None;
+    }
+
+    let scale_x = page.width_px as f32 / page.width_pt;
+    let scale_y = page.height_px as f32 / page.height_pt;
+    let x0 = page.origin_x_px + (rect.x0.max(0.0) * scale_x).floor().max(0.0) as u32;
+    let y0 = page.origin_y_px + (rect.y0.max(0.0) * scale_y).floor().max(0.0) as u32;
+    let x1 = page.origin_x_px + (rect.x1.max(0.0) * scale_x).ceil().max(0.0) as u32;
+    let y1 = page.origin_y_px + (rect.y1.max(0.0) * scale_y).ceil().max(0.0) as u32;
+    let x0 = x0.min(frame_width);
+    let y0 = y0.min(frame_height);
+    let x1 = x1.min(frame_width);
+    let y1 = y1.min(frame_height);
+    (x1 > x0 && y1 > y0).then_some((x0, y0, x1, y1))
+}
+
+fn fill_rect(
+    pixels: &mut [u8],
+    stride_width: usize,
+    x0: u32,
+    y0: u32,
+    x1: u32,
+    y1: u32,
+    color: [u8; 4],
+) {
+    let alpha = color[3] as u16;
+    for y in y0 as usize..y1 as usize {
+        for x in x0 as usize..x1 as usize {
+            let idx = (y * stride_width + x) * 4;
+            for (channel, value) in color.iter().take(3).enumerate() {
+                let base = pixels[idx + channel] as u16;
+                let fill = *value as u16;
+                pixels[idx + channel] = (((base * (255 - alpha)) + (fill * alpha)) / 255) as u8;
+            }
+            pixels[idx + 3] = 255;
+        }
     }
 }
 

--- a/src/app/render_ops.rs
+++ b/src/app/render_ops.rs
@@ -23,6 +23,7 @@ pub(crate) struct CurrentTaskContext {
 pub(crate) struct PrefetchDispatchContext {
     pub(crate) required_keys: Vec<RenderedPageKey>,
     pub(crate) current_cached: bool,
+    pub(crate) overlay_stamp: u64,
     pub(crate) prefetch_viewport: Option<Viewport>,
     pub(crate) base_pan: PanOffset,
     pub(crate) enable_crop: bool,
@@ -251,6 +252,7 @@ impl RenderSubsystem {
                         viewport,
                         key,
                         &mut prefetch_pan,
+                        ctx.overlay_stamp,
                         presenter_caps.cell_px,
                         ctx.enable_crop,
                         encode_work_class_for_completed_render(task.class),

--- a/src/app/render_ops.rs
+++ b/src/app/render_ops.rs
@@ -65,6 +65,7 @@ impl RenderSubsystem {
                         &frame,
                         viewport,
                         pan_for_presenter,
+                        0,
                         encode_work_class_for_completed_render(completed.class),
                         completed.generation,
                     ) {
@@ -291,6 +292,7 @@ mod tests {
             _frame: &RgbaFrame,
             _viewport: Viewport,
             _pan: PanOffset,
+            _overlay_stamp: u64,
             _generation: u64,
         ) -> AppResult<()> {
             Ok(())
@@ -315,6 +317,7 @@ mod tests {
             _frame: &RgbaFrame,
             _viewport: Viewport,
             _pan: PanOffset,
+            _overlay_stamp: u64,
             _class: crate::work::WorkClass,
             _generation: u64,
         ) -> AppResult<()> {

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -268,11 +268,15 @@ impl RenderRuntime {
         viewport: Viewport,
         key: RenderedPageKey,
         pan: &mut PanOffset,
+        overlay_stamp: u64,
         cell_px: Option<(u16, u16)>,
         enable_crop: bool,
         class: WorkClass,
         generation: u64,
     ) -> AppResult<bool> {
+        if overlay_stamp != 0 {
+            return Ok(false);
+        }
         let prepared = if let Some(frame) = self.l1_cache.get(&key) {
             let (frame, pan_for_presenter) =
                 prepare_presenter_frame(frame, viewport, pan, cell_px, enable_crop);
@@ -281,7 +285,7 @@ impl RenderRuntime {
                 &frame,
                 viewport,
                 pan_for_presenter,
-                0,
+                overlay_stamp,
                 class,
                 generation,
             )?;

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -276,6 +276,8 @@ impl RenderRuntime {
         generation: u64,
     ) -> AppResult<bool> {
         if overlay_stamp != 0 {
+            // Prefetch encoding has no overlay snapshot to apply, so skip it while highlights are
+            // active instead of caching an undecorated frame under the highlighted identity.
             return Ok(false);
         }
         let prepared = if let Some(frame) = self.l1_cache.get(&key) {
@@ -439,8 +441,9 @@ fn spread_render_spaces(
     gap_px: u32,
 ) -> AppResult<Vec<PageRenderSpace>> {
     let mut pages = Vec::new();
-    if let (Some(page), Some(frame)) = (slots.left_page, left_frame) {
-        let (width_pt, height_pt) = doc.page_dimensions(page)?;
+    if let (Some(page), Some(frame)) = (slots.left_page, left_frame)
+        && let Ok((width_pt, height_pt)) = doc.page_dimensions(page)
+    {
         pages.push(PageRenderSpace {
             page,
             origin_x_px: 0,
@@ -453,16 +456,17 @@ fn spread_render_spaces(
     }
     if let (Some(page), Some(frame)) = (slots.right_page, right_frame) {
         let origin_x_px = spread_left_slot_width_px(left_frame, right_frame).saturating_add(gap_px);
-        let (width_pt, height_pt) = doc.page_dimensions(page)?;
-        pages.push(PageRenderSpace {
-            page,
-            origin_x_px,
-            origin_y_px: 0,
-            width_px: frame.width,
-            height_px: frame.height,
-            width_pt,
-            height_pt,
-        });
+        if let Ok((width_pt, height_pt)) = doc.page_dimensions(page) {
+            pages.push(PageRenderSpace {
+                page,
+                origin_x_px,
+                origin_y_px: 0,
+                width_px: frame.width,
+                height_px: frame.height,
+                width_pt,
+                height_pt,
+            });
+        }
     }
     Ok(pages)
 }
@@ -558,5 +562,89 @@ mod tests {
         assert_eq!(spaces.len(), 1);
         assert_eq!(spaces[0].page, 1);
         assert_eq!(spaces[0].origin_x_px, 128);
+    }
+
+    #[derive(Debug)]
+    struct PartialDimensionsBackend {
+        path: PathBuf,
+    }
+
+    impl Default for PartialDimensionsBackend {
+        fn default() -> Self {
+            Self {
+                path: PathBuf::from("partial-dimensions.pdf"),
+            }
+        }
+    }
+
+    impl PdfBackend for PartialDimensionsBackend {
+        fn path(&self) -> &Path {
+            &self.path
+        }
+
+        fn doc_id(&self) -> u64 {
+            2
+        }
+
+        fn page_count(&self) -> usize {
+            2
+        }
+
+        fn page_dimensions(&self, page: usize) -> AppResult<(f32, f32)> {
+            match page {
+                0 => Err(AppError::unsupported("missing page dimensions")),
+                1 => Ok((120.0, 240.0)),
+                _ => Err(AppError::invalid_argument("unexpected page")),
+            }
+        }
+
+        fn render_page(&self, _page: usize, _scale: f32) -> AppResult<RgbaFrame> {
+            Err(AppError::unsupported("not needed in runtime test"))
+        }
+
+        fn extract_text(&self, _page: usize) -> AppResult<String> {
+            Err(AppError::unsupported("not needed in runtime test"))
+        }
+
+        fn extract_positioned_text(&self, _page: usize) -> AppResult<TextPage> {
+            Err(AppError::unsupported("not needed in runtime test"))
+        }
+
+        fn extract_outline(&self) -> AppResult<Vec<OutlineNode>> {
+            Err(AppError::unsupported("not needed in runtime test"))
+        }
+    }
+
+    #[test]
+    fn spread_render_spaces_skips_page_dimension_failures_per_page() {
+        let doc = PartialDimensionsBackend::default();
+        let left = RgbaFrame {
+            width: 100,
+            height: 200,
+            pixels: vec![0; 100 * 200 * 4].into(),
+        };
+        let right = RgbaFrame {
+            width: 120,
+            height: 240,
+            pixels: vec![0; 120 * 240 * 4].into(),
+        };
+
+        let spaces = spread_render_spaces(
+            &doc,
+            VisiblePageSlots {
+                anchor_page: 0,
+                trailing_page: Some(1),
+                left_page: Some(0),
+                right_page: Some(1),
+            },
+            Some(&left),
+            Some(&right),
+            8,
+        )
+        .expect("spread spaces should still resolve when one page fails");
+
+        assert_eq!(spaces.len(), 1);
+        assert_eq!(spaces[0].page, 1);
+        assert_eq!(spaces[0].origin_x_px, 108);
     }
 }

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -124,7 +124,7 @@ impl RenderRuntime {
             reason: "current-page",
         };
         let frame = self.resolve_task_frame(doc, &task)?;
-        let frame = decorate_single_page_frame(doc, task.page, &frame, overlay);
+        let (frame, overlay_stamp) = decorate_single_page_frame(doc, task.page, &frame, overlay);
         let (frame, pan_for_presenter) =
             prepare_presenter_frame(&frame, viewport, pan, cell_px, enable_crop);
         presenter.prepare(
@@ -132,7 +132,7 @@ impl RenderRuntime {
             &frame,
             viewport,
             pan_for_presenter,
-            overlay.stamp,
+            overlay_stamp,
             task.generation,
         )?;
         Ok(())
@@ -180,7 +180,7 @@ impl RenderRuntime {
         generation: u64,
     ) -> AppResult<bool> {
         let prepared = if let Some(frame) = self.l1_cache.get(&key) {
-            let frame = decorate_single_page_frame(doc, key.page, frame, overlay);
+            let (frame, overlay_stamp) = decorate_single_page_frame(doc, key.page, frame, overlay);
             let (frame, pan_for_presenter) =
                 prepare_presenter_frame(&frame, viewport, pan, cell_px, enable_crop);
             presenter.prepare(
@@ -188,7 +188,7 @@ impl RenderRuntime {
                 &frame,
                 viewport,
                 pan_for_presenter,
-                overlay.stamp,
+                overlay_stamp,
                 generation,
             )?;
             true
@@ -247,7 +247,8 @@ impl RenderRuntime {
             Some(_) => trailing_frame.as_ref(),
             None => None,
         };
-        let decorated = decorate_spread_frame(doc, slots, left_frame, right_frame, gap_px, overlay);
+        let (decorated, overlay_stamp) =
+            decorate_spread_frame(doc, slots, left_frame, right_frame, gap_px, overlay);
         let (frame, pan_for_presenter) =
             prepare_presenter_frame(&decorated, viewport, pan, cell_px, enable_crop);
         presenter.prepare(
@@ -255,7 +256,7 @@ impl RenderRuntime {
             &frame,
             viewport,
             pan_for_presenter,
-            overlay.stamp,
+            overlay_stamp,
             generation,
         )?;
         Ok(true)
@@ -381,10 +382,13 @@ fn decorate_single_page_frame(
     page: usize,
     frame: &RgbaFrame,
     overlay: &HighlightOverlaySnapshot,
-) -> RgbaFrame {
+) -> (RgbaFrame, u64) {
+    if overlay.is_empty() {
+        return (frame.clone(), 0);
+    }
     match page_render_space(doc, page, frame, 0) {
-        Ok(page_space) => decorate_frame(frame, overlay, &[page_space]),
-        Err(_) => frame.clone(),
+        Ok(page_space) => (decorate_frame(frame, overlay, &[page_space]), overlay.stamp),
+        Err(_) => (frame.clone(), 0),
     }
 }
 
@@ -395,11 +399,17 @@ fn decorate_spread_frame(
     right_frame: Option<&RgbaFrame>,
     gap_px: u32,
     overlay: &HighlightOverlaySnapshot,
-) -> RgbaFrame {
+) -> (RgbaFrame, u64) {
     let spread_frame = compose_spread_frame(left_frame, right_frame, gap_px);
+    if overlay.is_empty() {
+        return (spread_frame, 0);
+    }
     match spread_render_spaces(doc, slots, left_frame, right_frame, gap_px) {
-        Ok(pages) => decorate_frame(&spread_frame, overlay, &pages),
-        Err(_) => spread_frame,
+        Ok(pages) if !pages.is_empty() => (
+            decorate_frame(&spread_frame, overlay, &pages),
+            overlay.stamp,
+        ),
+        _ => (spread_frame, 0),
     }
 }
 

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 use crate::backend::{PdfBackend, RgbaFrame};
 use crate::config::CacheConfig;
 use crate::error::{AppError, AppResult};
+use crate::highlight::HighlightOverlaySnapshot;
 use crate::perf::PerfStats;
 use crate::presenter::{ImagePresenter, PanOffset, Viewport};
 use crate::render::cache::{RenderedPageCache, RenderedPageKey};
@@ -11,7 +12,9 @@ use crate::render::scheduler::{
 };
 use crate::work::WorkClass;
 
-use super::frame_ops::{compose_spread_frame, prepare_presenter_frame};
+use super::frame_ops::{
+    PageRenderSpace, apply_highlight_overlay, compose_spread_frame, prepare_presenter_frame,
+};
 use super::state::VisiblePageSlots;
 
 #[derive(Debug, Default)]
@@ -110,6 +113,7 @@ impl RenderRuntime {
         pan: &mut PanOffset,
         cell_px: Option<(u16, u16)>,
         enable_crop: bool,
+        overlay: &HighlightOverlaySnapshot,
     ) -> AppResult<()> {
         let task = RenderTask {
             doc_id: doc.doc_id(),
@@ -120,6 +124,8 @@ impl RenderRuntime {
             reason: "current-page",
         };
         let frame = self.resolve_task_frame(doc, &task)?;
+        let page_space = page_render_space(doc, task.page, &frame, 0);
+        let frame = decorate_frame(&frame, overlay, &[page_space]);
         let (frame, pan_for_presenter) =
             prepare_presenter_frame(&frame, viewport, pan, cell_px, enable_crop);
         presenter.prepare(
@@ -127,6 +133,7 @@ impl RenderRuntime {
             &frame,
             viewport,
             pan_for_presenter,
+            overlay.stamp,
             task.generation,
         )?;
         Ok(())
@@ -143,16 +150,19 @@ impl RenderRuntime {
         pan: &mut PanOffset,
         cell_px: Option<(u16, u16)>,
         enable_crop: bool,
+        overlay: &HighlightOverlaySnapshot,
         generation: u64,
     ) -> AppResult<bool> {
         let key = RenderedPageKey::new(doc.doc_id(), page, scale);
         self.try_prepare_cached_page_from_cache(
+            doc,
             presenter,
             viewport,
             key,
             pan,
             cell_px,
             enable_crop,
+            overlay,
             generation,
         )
     }
@@ -160,18 +170,29 @@ impl RenderRuntime {
     #[allow(clippy::too_many_arguments)]
     pub fn try_prepare_cached_page_from_cache(
         &mut self,
+        doc: &dyn PdfBackend,
         presenter: &mut dyn ImagePresenter,
         viewport: Viewport,
         key: RenderedPageKey,
         pan: &mut PanOffset,
         cell_px: Option<(u16, u16)>,
         enable_crop: bool,
+        overlay: &HighlightOverlaySnapshot,
         generation: u64,
     ) -> AppResult<bool> {
         let prepared = if let Some(frame) = self.l1_cache.get(&key) {
+            let page_space = page_render_space(doc, key.page, frame, 0);
+            let frame = decorate_frame(frame, overlay, &[page_space]);
             let (frame, pan_for_presenter) =
-                prepare_presenter_frame(frame, viewport, pan, cell_px, enable_crop);
-            presenter.prepare(key, &frame, viewport, pan_for_presenter, generation)?;
+                prepare_presenter_frame(&frame, viewport, pan, cell_px, enable_crop);
+            presenter.prepare(
+                key,
+                &frame,
+                viewport,
+                pan_for_presenter,
+                overlay.stamp,
+                generation,
+            )?;
             true
         } else {
             false
@@ -192,6 +213,7 @@ impl RenderRuntime {
         pan: &mut PanOffset,
         cell_px: Option<(u16, u16)>,
         enable_crop: bool,
+        overlay: &HighlightOverlaySnapshot,
         generation: u64,
         gap_px: u32,
     ) -> AppResult<bool> {
@@ -228,13 +250,19 @@ impl RenderRuntime {
             None => None,
         };
         let spread_frame = compose_spread_frame(left_frame, right_frame, gap_px);
+        let decorated = decorate_frame(
+            &spread_frame,
+            overlay,
+            &spread_render_spaces(doc, slots, left_frame, right_frame, gap_px)?,
+        );
         let (frame, pan_for_presenter) =
-            prepare_presenter_frame(&spread_frame, viewport, pan, cell_px, enable_crop);
+            prepare_presenter_frame(&decorated, viewport, pan, cell_px, enable_crop);
         presenter.prepare(
             presenter_key,
             &frame,
             viewport,
             pan_for_presenter,
+            overlay.stamp,
             generation,
         )?;
         Ok(true)
@@ -260,6 +288,7 @@ impl RenderRuntime {
                 &frame,
                 viewport,
                 pan_for_presenter,
+                0,
                 class,
                 generation,
             )?;
@@ -336,4 +365,72 @@ impl RenderRuntime {
             self.perf_stats.absorb_presenter_metrics(&snapshot);
         }
     }
+}
+
+fn decorate_frame(
+    frame: &RgbaFrame,
+    overlay: &HighlightOverlaySnapshot,
+    pages: &[PageRenderSpace],
+) -> RgbaFrame {
+    if overlay.is_empty() {
+        frame.clone()
+    } else {
+        apply_highlight_overlay(frame, overlay, pages)
+    }
+}
+
+fn page_render_space(
+    doc: &dyn PdfBackend,
+    page: usize,
+    frame: &RgbaFrame,
+    origin_x_px: u32,
+) -> PageRenderSpace {
+    let (width_pt, height_pt) = doc.page_dimensions(page).unwrap_or((1.0, 1.0));
+    PageRenderSpace {
+        page,
+        origin_x_px,
+        origin_y_px: 0,
+        width_px: frame.width,
+        height_px: frame.height,
+        width_pt,
+        height_pt,
+    }
+}
+
+fn spread_render_spaces(
+    doc: &dyn PdfBackend,
+    slots: VisiblePageSlots,
+    left_frame: Option<&RgbaFrame>,
+    right_frame: Option<&RgbaFrame>,
+    gap_px: u32,
+) -> AppResult<Vec<PageRenderSpace>> {
+    let mut pages = Vec::new();
+    if let (Some(page), Some(frame)) = (slots.left_page, left_frame) {
+        let (width_pt, height_pt) = doc.page_dimensions(page)?;
+        pages.push(PageRenderSpace {
+            page,
+            origin_x_px: 0,
+            origin_y_px: 0,
+            width_px: frame.width,
+            height_px: frame.height,
+            width_pt,
+            height_pt,
+        });
+    }
+    if let (Some(page), Some(frame)) = (slots.right_page, right_frame) {
+        let origin_x_px = left_frame
+            .map(|left| left.width.saturating_add(gap_px))
+            .unwrap_or(0);
+        let (width_pt, height_pt) = doc.page_dimensions(page)?;
+        pages.push(PageRenderSpace {
+            page,
+            origin_x_px,
+            origin_y_px: 0,
+            width_px: frame.width,
+            height_px: frame.height,
+            width_pt,
+            height_pt,
+        });
+    }
+    Ok(pages)
 }

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -124,8 +124,7 @@ impl RenderRuntime {
             reason: "current-page",
         };
         let frame = self.resolve_task_frame(doc, &task)?;
-        let page_space = page_render_space(doc, task.page, &frame, 0);
-        let frame = decorate_frame(&frame, overlay, &[page_space]);
+        let frame = decorate_single_page_frame(doc, task.page, &frame, overlay);
         let (frame, pan_for_presenter) =
             prepare_presenter_frame(&frame, viewport, pan, cell_px, enable_crop);
         presenter.prepare(
@@ -181,8 +180,7 @@ impl RenderRuntime {
         generation: u64,
     ) -> AppResult<bool> {
         let prepared = if let Some(frame) = self.l1_cache.get(&key) {
-            let page_space = page_render_space(doc, key.page, frame, 0);
-            let frame = decorate_frame(frame, overlay, &[page_space]);
+            let frame = decorate_single_page_frame(doc, key.page, frame, overlay);
             let (frame, pan_for_presenter) =
                 prepare_presenter_frame(&frame, viewport, pan, cell_px, enable_crop);
             presenter.prepare(
@@ -249,12 +247,7 @@ impl RenderRuntime {
             Some(_) => trailing_frame.as_ref(),
             None => None,
         };
-        let spread_frame = compose_spread_frame(left_frame, right_frame, gap_px);
-        let decorated = decorate_frame(
-            &spread_frame,
-            overlay,
-            &spread_render_spaces(doc, slots, left_frame, right_frame, gap_px)?,
-        );
+        let decorated = decorate_spread_frame(doc, slots, left_frame, right_frame, gap_px, overlay);
         let (frame, pan_for_presenter) =
             prepare_presenter_frame(&decorated, viewport, pan, cell_px, enable_crop);
         presenter.prepare(
@@ -379,14 +372,41 @@ fn decorate_frame(
     }
 }
 
+fn decorate_single_page_frame(
+    doc: &dyn PdfBackend,
+    page: usize,
+    frame: &RgbaFrame,
+    overlay: &HighlightOverlaySnapshot,
+) -> RgbaFrame {
+    match page_render_space(doc, page, frame, 0) {
+        Ok(page_space) => decorate_frame(frame, overlay, &[page_space]),
+        Err(_) => frame.clone(),
+    }
+}
+
+fn decorate_spread_frame(
+    doc: &dyn PdfBackend,
+    slots: VisiblePageSlots,
+    left_frame: Option<&RgbaFrame>,
+    right_frame: Option<&RgbaFrame>,
+    gap_px: u32,
+    overlay: &HighlightOverlaySnapshot,
+) -> RgbaFrame {
+    let spread_frame = compose_spread_frame(left_frame, right_frame, gap_px);
+    match spread_render_spaces(doc, slots, left_frame, right_frame, gap_px) {
+        Ok(pages) => decorate_frame(&spread_frame, overlay, &pages),
+        Err(_) => spread_frame,
+    }
+}
+
 fn page_render_space(
     doc: &dyn PdfBackend,
     page: usize,
     frame: &RgbaFrame,
     origin_x_px: u32,
-) -> PageRenderSpace {
-    let (width_pt, height_pt) = doc.page_dimensions(page).unwrap_or((1.0, 1.0));
-    PageRenderSpace {
+) -> AppResult<PageRenderSpace> {
+    let (width_pt, height_pt) = doc.page_dimensions(page)?;
+    Ok(PageRenderSpace {
         page,
         origin_x_px,
         origin_y_px: 0,
@@ -394,7 +414,7 @@ fn page_render_space(
         height_px: frame.height,
         width_pt,
         height_pt,
-    }
+    })
 }
 
 fn spread_render_spaces(

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -418,9 +418,7 @@ fn spread_render_spaces(
         });
     }
     if let (Some(page), Some(frame)) = (slots.right_page, right_frame) {
-        let origin_x_px = left_frame
-            .map(|left| left.width.saturating_add(gap_px))
-            .unwrap_or(0);
+        let origin_x_px = spread_left_slot_width_px(left_frame, right_frame).saturating_add(gap_px);
         let (width_pt, height_pt) = doc.page_dimensions(page)?;
         pages.push(PageRenderSpace {
             page,
@@ -433,4 +431,98 @@ fn spread_render_spaces(
         });
     }
     Ok(pages)
+}
+
+fn spread_left_slot_width_px(
+    left_frame: Option<&RgbaFrame>,
+    right_frame: Option<&RgbaFrame>,
+) -> u32 {
+    left_frame
+        .map(|frame| frame.width)
+        .or_else(|| right_frame.map(|frame| frame.width))
+        .unwrap_or(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use super::spread_render_spaces;
+    use crate::app::state::VisiblePageSlots;
+    use crate::backend::{OutlineNode, PdfBackend, RgbaFrame, TextPage};
+    use crate::error::{AppError, AppResult};
+
+    #[derive(Debug)]
+    struct StubBackend {
+        path: PathBuf,
+    }
+
+    impl Default for StubBackend {
+        fn default() -> Self {
+            Self {
+                path: PathBuf::from("stub.pdf"),
+            }
+        }
+    }
+
+    impl PdfBackend for StubBackend {
+        fn path(&self) -> &Path {
+            &self.path
+        }
+
+        fn doc_id(&self) -> u64 {
+            1
+        }
+
+        fn page_count(&self) -> usize {
+            2
+        }
+
+        fn page_dimensions(&self, _page: usize) -> AppResult<(f32, f32)> {
+            Ok((100.0, 200.0))
+        }
+
+        fn render_page(&self, _page: usize, _scale: f32) -> AppResult<RgbaFrame> {
+            Err(AppError::unsupported("not needed in runtime test"))
+        }
+
+        fn extract_text(&self, _page: usize) -> AppResult<String> {
+            Err(AppError::unsupported("not needed in runtime test"))
+        }
+
+        fn extract_positioned_text(&self, _page: usize) -> AppResult<TextPage> {
+            Err(AppError::unsupported("not needed in runtime test"))
+        }
+
+        fn extract_outline(&self) -> AppResult<Vec<OutlineNode>> {
+            Err(AppError::unsupported("not needed in runtime test"))
+        }
+    }
+
+    #[test]
+    fn spread_render_spaces_offsets_right_page_after_blank_left_slot() {
+        let doc = StubBackend::default();
+        let right = RgbaFrame {
+            width: 120,
+            height: 240,
+            pixels: vec![0; 120 * 240 * 4].into(),
+        };
+        let spaces = spread_render_spaces(
+            &doc,
+            VisiblePageSlots {
+                anchor_page: 1,
+                trailing_page: None,
+                left_page: None,
+                right_page: Some(1),
+            },
+            None,
+            Some(&right),
+            8,
+        )
+        .expect("spread spaces should resolve");
+
+        assert_eq!(spaces.len(), 1);
+        assert_eq!(spaces[0].page, 1);
+        assert_eq!(spaces[0].origin_x_px, 128);
+    }
 }

--- a/src/app/tests/runtime_worker.rs
+++ b/src/app/tests/runtime_worker.rs
@@ -12,6 +12,7 @@ use ratatui::layout::Rect;
 use super::super::runtime::RenderRuntime;
 use crate::backend::{PdfBackend, PdfDoc, RgbaFrame, SharedPdfBackend};
 use crate::error::AppResult;
+use crate::highlight::HighlightOverlaySnapshot;
 use crate::perf::PerfStats;
 use crate::presenter::{
     ImagePresenter, PanOffset, PresenterCaps, PresenterFeedback, PresenterRenderOptions,
@@ -37,6 +38,7 @@ impl ImagePresenter for TestPresenter {
         _frame: &RgbaFrame,
         _viewport: Viewport,
         _pan: PanOffset,
+        _overlay_stamp: u64,
         _generation: u64,
     ) -> AppResult<()> {
         self.prepare_calls += 1;
@@ -66,6 +68,7 @@ impl ImagePresenter for TestPresenter {
         _frame: &RgbaFrame,
         _viewport: Viewport,
         _pan: PanOffset,
+        _overlay_stamp: u64,
         _class: WorkClass,
         _generation: u64,
     ) -> AppResult<()> {
@@ -150,6 +153,7 @@ fn prepare_current_page_updates_l1_and_presenter_metrics() {
             &mut pan,
             None,
             false,
+            &HighlightOverlaySnapshot::default(),
         )
         .expect("first prepare should succeed");
     runtime
@@ -162,6 +166,7 @@ fn prepare_current_page_updates_l1_and_presenter_metrics() {
             &mut pan,
             None,
             false,
+            &HighlightOverlaySnapshot::default(),
         )
         .expect("second prepare should succeed");
     let backend = TestBackend::new(80, 24);

--- a/src/app/tests/runtime_worker.rs
+++ b/src/app/tests/runtime_worker.rs
@@ -254,6 +254,7 @@ fn prefetch_encode_from_cache_invokes_presenter() {
             viewport,
             key,
             &mut pan,
+            0,
             None,
             false,
             WorkClass::DirectionalLead,
@@ -262,6 +263,45 @@ fn prefetch_encode_from_cache_invokes_presenter() {
         .expect("prefetch from cache should succeed");
     assert!(prefetched);
     assert_eq!(presenter.prefetch_calls, 1);
+}
+
+#[test]
+fn prefetch_encode_from_cache_skips_when_overlay_active() {
+    let mut runtime = RenderRuntime::default();
+    let mut presenter = TestPresenter::default();
+    let key = RenderedPageKey::new(5, 2, 1.0);
+    runtime.l1_cache.insert(
+        key,
+        RgbaFrame {
+            width: 2,
+            height: 2,
+            pixels: vec![255; 16].into(),
+        },
+        false,
+    );
+    let viewport = Viewport {
+        x: 0,
+        y: 0,
+        width: 80,
+        height: 24,
+    };
+    let mut pan = PanOffset::default();
+
+    let prefetched = runtime
+        .try_prefetch_encode_from_cache(
+            &mut presenter,
+            viewport,
+            key,
+            &mut pan,
+            1,
+            None,
+            false,
+            WorkClass::DirectionalLead,
+            1,
+        )
+        .expect("prefetch from cache should succeed");
+    assert!(!prefetched);
+    assert_eq!(presenter.prefetch_calls, 0);
 }
 
 #[test]

--- a/src/app/tests/runtime_worker.rs
+++ b/src/app/tests/runtime_worker.rs
@@ -10,9 +10,9 @@ use ratatui::backend::TestBackend;
 use ratatui::layout::Rect;
 
 use super::super::runtime::RenderRuntime;
-use crate::backend::{PdfBackend, PdfDoc, RgbaFrame, SharedPdfBackend};
-use crate::error::AppResult;
-use crate::highlight::HighlightOverlaySnapshot;
+use crate::backend::{OutlineNode, PdfBackend, PdfDoc, PdfRect, RgbaFrame, SharedPdfBackend};
+use crate::error::{AppError, AppResult};
+use crate::highlight::{HighlightOverlaySnapshot, HighlightSource, HighlightSpan, HighlightStyle};
 use crate::perf::PerfStats;
 use crate::presenter::{
     ImagePresenter, PanOffset, PresenterCaps, PresenterFeedback, PresenterRenderOptions,
@@ -28,6 +28,7 @@ struct TestPresenter {
     prepare_calls: usize,
     prefetch_calls: usize,
     render_calls: usize,
+    last_prepare_overlay_stamp: Option<u64>,
     stats: PerfStats,
 }
 
@@ -38,10 +39,11 @@ impl ImagePresenter for TestPresenter {
         _frame: &RgbaFrame,
         _viewport: Viewport,
         _pan: PanOffset,
-        _overlay_stamp: u64,
+        overlay_stamp: u64,
         _generation: u64,
     ) -> AppResult<()> {
         self.prepare_calls += 1;
+        self.last_prepare_overlay_stamp = Some(overlay_stamp);
         self.stats.record_convert(Duration::from_millis(4));
         self.stats.set_l2_hit_rate(0.5);
         Ok(())
@@ -87,6 +89,46 @@ impl ImagePresenter for TestPresenter {
 
     fn perf_snapshot(&self) -> Option<PerfStats> {
         Some(self.stats.clone())
+    }
+}
+
+struct PageDimensionFailingPdf;
+
+impl PdfBackend for PageDimensionFailingPdf {
+    fn path(&self) -> &std::path::Path {
+        std::path::Path::new("page-dimension-failing.pdf")
+    }
+
+    fn doc_id(&self) -> u64 {
+        7
+    }
+
+    fn page_count(&self) -> usize {
+        1
+    }
+
+    fn page_dimensions(&self, _page: usize) -> AppResult<(f32, f32)> {
+        Err(AppError::invalid_argument("page dimensions unavailable"))
+    }
+
+    fn render_page(&self, _page: usize, _scale: f32) -> AppResult<RgbaFrame> {
+        Ok(RgbaFrame {
+            width: 4,
+            height: 4,
+            pixels: vec![255; 64].into(),
+        })
+    }
+
+    fn extract_text(&self, _page: usize) -> AppResult<String> {
+        Err(AppError::unsupported("not needed in runtime test"))
+    }
+
+    fn extract_positioned_text(&self, _page: usize) -> AppResult<crate::backend::TextPage> {
+        Err(AppError::unsupported("not needed in runtime test"))
+    }
+
+    fn extract_outline(&self) -> AppResult<Vec<OutlineNode>> {
+        Err(AppError::unsupported("not needed in runtime test"))
     }
 }
 
@@ -194,6 +236,47 @@ fn prepare_current_page_updates_l1_and_presenter_metrics() {
     assert_eq!(runtime.perf_stats.cache_hit_rate_l2, 0.5);
 
     fs::remove_file(&file).expect("test pdf should be removed");
+}
+
+#[test]
+fn prepare_current_page_uses_zero_overlay_stamp_when_decoration_falls_back() {
+    let doc = PageDimensionFailingPdf;
+    let mut runtime = RenderRuntime::default();
+    let mut presenter = TestPresenter::default();
+    let mut pan = PanOffset::default();
+    let viewport = Viewport {
+        x: 0,
+        y: 0,
+        width: 80,
+        height: 24,
+    };
+    let overlay = HighlightOverlaySnapshot::new(vec![HighlightSpan {
+        source: HighlightSource::Search,
+        page: 0,
+        rects: vec![PdfRect {
+            x0: 0.0,
+            y0: 0.0,
+            x1: 10.0,
+            y1: 10.0,
+        }],
+        style: HighlightStyle::SEARCH_HIT,
+    }]);
+
+    runtime
+        .prepare_current_page(
+            &doc,
+            &mut presenter,
+            viewport,
+            0,
+            1.0,
+            &mut pan,
+            None,
+            false,
+            &overlay,
+        )
+        .expect("prepare should succeed");
+
+    assert_eq!(presenter.last_prepare_overlay_stamp, Some(0));
 }
 
 #[test]

--- a/src/app/view_ops.rs
+++ b/src/app/view_ops.rs
@@ -641,6 +641,7 @@ mod tests {
                 width_pt: 612.0,
                 height_pt: 792.0,
                 glyphs: Vec::new(),
+                dropped_glyphs: 0,
             })
         }
 

--- a/src/app/view_ops.rs
+++ b/src/app/view_ops.rs
@@ -4,6 +4,7 @@ use crate::app::PageLayoutMode;
 use crate::backend::PdfBackend;
 use crate::config::Config;
 use crate::error::AppResult;
+use crate::highlight::HighlightOverlaySnapshot;
 use crate::input::sequence::SequenceRegistrySnapshot;
 use crate::palette::PaletteView;
 use crate::presenter::{
@@ -40,6 +41,7 @@ pub(super) struct RenderFramePlan {
     pub(super) current_scale: f32,
     pub(super) initial_preview: Option<InitialPreviewPlan>,
     pub(super) presenter_key: RenderedPageKey,
+    pub(super) highlight_overlay: HighlightOverlaySnapshot,
     pub(super) generation: u64,
     pub(super) nav_streak: usize,
 }
@@ -112,6 +114,7 @@ impl RenderSubsystem {
         pan: &mut PanOffset,
         cell_px: Option<(u16, u16)>,
         enable_crop: bool,
+        highlight_overlay: &HighlightOverlaySnapshot,
         generation: u64,
     ) -> AppResult<Option<PresenterRenderMode>> {
         if self.runtime.try_prepare_current_page_from_cache(
@@ -123,6 +126,7 @@ impl RenderSubsystem {
             pan,
             cell_px,
             enable_crop,
+            highlight_overlay,
             generation,
         )? {
             return Ok(Some(PresenterRenderMode::Full));
@@ -133,12 +137,14 @@ impl RenderSubsystem {
         };
 
         if self.runtime.try_prepare_cached_page_from_cache(
+            pdf,
             self.presenter.as_mut(),
             viewport,
             preview_plan.page_keys[0],
             pan,
             cell_px,
             enable_crop,
+            highlight_overlay,
             generation,
         )? {
             return Ok(Some(PresenterRenderMode::InitialPreview));
@@ -159,6 +165,7 @@ impl RenderSubsystem {
         pan: &mut PanOffset,
         cell_px: Option<(u16, u16)>,
         enable_crop: bool,
+        highlight_overlay: &HighlightOverlaySnapshot,
         generation: u64,
         spread_gap_px: u32,
     ) -> AppResult<Option<PresenterRenderMode>> {
@@ -172,6 +179,7 @@ impl RenderSubsystem {
             pan,
             cell_px,
             enable_crop,
+            highlight_overlay,
             generation,
             spread_gap_px,
         )? {
@@ -192,6 +200,7 @@ impl RenderSubsystem {
             pan,
             cell_px,
             enable_crop,
+            highlight_overlay,
             generation,
             spread_gap_px,
         )? {
@@ -218,6 +227,7 @@ impl RenderSubsystem {
             current_scale,
             initial_preview,
             presenter_key,
+            highlight_overlay,
             generation,
             nav_streak: _nav_streak,
         } = plan;
@@ -280,6 +290,7 @@ impl RenderSubsystem {
                     &mut pan,
                     presenter_caps.cell_px,
                     enable_crop,
+                    &highlight_overlay,
                     generation,
                 ),
                 PageLayoutMode::Spread => self.prepare_spread_or_preview_from_cache(
@@ -292,6 +303,7 @@ impl RenderSubsystem {
                     &mut pan,
                     presenter_caps.cell_px,
                     enable_crop,
+                    &highlight_overlay,
                     generation,
                     spread_gap_px,
                 ),
@@ -574,7 +586,7 @@ mod tests {
         resolve_layout_dimensions, sync_render_notice,
     };
     use crate::app::{AppState, PageLayoutMode, VisiblePageSlots};
-    use crate::backend::{PdfBackend, RgbaFrame};
+    use crate::backend::{PdfBackend, RgbaFrame, TextPage};
     use crate::presenter::{PresenterFeedback, PresenterRenderMode, PresenterRenderOutcome};
     use crate::render::cache::RenderedPageKey;
 
@@ -620,8 +632,12 @@ mod tests {
             })
         }
 
-        fn extract_text(&self, _page: usize) -> crate::error::AppResult<String> {
-            Ok(String::new())
+        fn extract_text_page(&self, _page: usize) -> crate::error::AppResult<TextPage> {
+            Ok(TextPage {
+                width_pt: 612.0,
+                height_pt: 792.0,
+                glyphs: Vec::new(),
+            })
         }
 
         fn extract_outline(&self) -> crate::error::AppResult<Vec<crate::backend::OutlineNode>> {

--- a/src/app/view_ops.rs
+++ b/src/app/view_ops.rs
@@ -632,7 +632,11 @@ mod tests {
             })
         }
 
-        fn extract_text_page(&self, _page: usize) -> crate::error::AppResult<TextPage> {
+        fn extract_text(&self, _page: usize) -> crate::error::AppResult<String> {
+            Ok(String::new())
+        }
+
+        fn extract_positioned_text(&self, _page: usize) -> crate::error::AppResult<TextPage> {
             Ok(TextPage {
                 width_pt: 612.0,
                 height_pt: 792.0,

--- a/src/backend/hayro.rs
+++ b/src/backend/hayro.rs
@@ -54,8 +54,12 @@ impl PdfBackend for PdfDoc {
         PdfDoc::render_page(self, page, scale)
     }
 
-    fn extract_text_page(&self, page: usize) -> AppResult<TextPage> {
-        PdfDoc::extract_text_page(self, page)
+    fn extract_text(&self, page: usize) -> AppResult<String> {
+        PdfDoc::extract_text(self, page)
+    }
+
+    fn extract_positioned_text(&self, page: usize) -> AppResult<TextPage> {
+        PdfDoc::extract_positioned_text(self, page)
     }
 
     fn extract_outline(&self) -> AppResult<Vec<OutlineNode>> {
@@ -173,7 +177,7 @@ impl PdfDoc {
         })
     }
 
-    pub fn extract_text_page(&self, page: usize) -> AppResult<TextPage> {
+    pub fn extract_text(&self, page: usize) -> AppResult<String> {
         if page >= self.page_count() {
             return Err(AppError::invalid_argument("page index is out of range"));
         }
@@ -184,7 +188,21 @@ impl PdfDoc {
             .get(page)
             .ok_or(AppError::invalid_argument("page index is out of range"))?;
 
-        Ok(extract_text_page_with_device(page_ref))
+        Ok(extract_text_with_device(page_ref).trim().to_owned())
+    }
+
+    pub fn extract_positioned_text(&self, page: usize) -> AppResult<TextPage> {
+        if page >= self.page_count() {
+            return Err(AppError::invalid_argument("page index is out of range"));
+        }
+
+        let page_ref = self
+            .pdf
+            .pages()
+            .get(page)
+            .ok_or(AppError::invalid_argument("page index is out of range"))?;
+
+        Ok(extract_positioned_text_with_device(page_ref))
     }
 
     pub fn extract_outline(&self) -> AppResult<Vec<OutlineNode>> {
@@ -588,7 +606,114 @@ impl<'a> NamedDestination<'a> {
     }
 }
 
-fn extract_text_page_with_device(page: &Page<'_>) -> TextPage {
+fn extract_text_with_device(page: &Page<'_>) -> String {
+    let mut context = Context::new(
+        page.initial_transform(true),
+        page.intersected_crop_box().to_kurbo(),
+        page.xref(),
+        InterpreterSettings::default(),
+    );
+    let mut device = PlainTextExtractDevice::default();
+    interpret_page(page, &mut context, &mut device);
+    device.finish()
+}
+
+#[derive(Default)]
+struct PlainTextExtractDevice {
+    text: String,
+    last_point: Option<Point>,
+    last_glyph: Option<(char, i32, i32)>,
+}
+
+impl PlainTextExtractDevice {
+    fn finish(self) -> String {
+        self.text
+    }
+
+    fn push_char(&mut self, ch: char, x: f64, y: f64) {
+        if ch == '\n' || ch == '\r' {
+            push_plain_newline(&mut self.text);
+            self.last_point = Some(Point::new(x, y));
+            return;
+        }
+        if ch.is_whitespace() {
+            push_plain_space(&mut self.text);
+            self.last_point = Some(Point::new(x, y));
+            return;
+        }
+
+        if let Some(last) = self.last_point
+            && (y - last.y).abs() > PLAIN_TEXT_LINE_BREAK_THRESHOLD
+        {
+            push_plain_newline(&mut self.text);
+        }
+
+        self.text.push(ch);
+        self.last_point = Some(Point::new(x, y));
+    }
+
+    fn is_duplicate_glyph(&self, ch: char, x: f64, y: f64) -> bool {
+        self.last_glyph == Some((ch, quantize_coord(x), quantize_coord(y)))
+    }
+
+    fn set_last_glyph(&mut self, ch: char, x: f64, y: f64) {
+        self.last_glyph = Some((ch, quantize_coord(x), quantize_coord(y)));
+    }
+}
+
+impl<'a> Device<'a> for PlainTextExtractDevice {
+    fn set_soft_mask(&mut self, _mask: Option<SoftMask<'a>>) {}
+
+    fn set_blend_mode(&mut self, _blend_mode: BlendMode) {}
+
+    fn draw_path(
+        &mut self,
+        _path: &BezPath,
+        _transform: Affine,
+        _paint: &Paint<'a>,
+        _draw_mode: &PathDrawMode,
+    ) {
+    }
+
+    fn push_clip_path(&mut self, _clip_path: &ClipPath) {}
+
+    fn push_transparency_group(
+        &mut self,
+        _opacity: f32,
+        _mask: Option<SoftMask<'a>>,
+        _blend_mode: BlendMode,
+    ) {
+    }
+
+    fn draw_glyph(
+        &mut self,
+        glyph: &Glyph<'a>,
+        transform: Affine,
+        glyph_transform: Affine,
+        _paint: &Paint<'a>,
+        _draw_mode: &GlyphDrawMode,
+    ) {
+        let Some(ch) = glyph.as_unicode() else {
+            return;
+        };
+
+        let position = (transform * glyph_transform) * Point::ORIGIN;
+        if self.is_duplicate_glyph(ch, position.x, position.y) {
+            return;
+        }
+
+        self.set_last_glyph(ch, position.x, position.y);
+        self.push_char(ch, position.x, position.y);
+    }
+
+    fn draw_image(&mut self, _image: Image<'a, '_>, _transform: Affine) {}
+
+    fn pop_clip_path(&mut self) {}
+
+    fn pop_transparency_group(&mut self) {}
+}
+
+fn extract_positioned_text_with_device(page: &Page<'_>) -> TextPage {
     let mut context = Context::new(
         page.initial_transform(true),
         page.intersected_crop_box().to_kurbo(),
@@ -596,18 +721,18 @@ fn extract_text_page_with_device(page: &Page<'_>) -> TextPage {
         InterpreterSettings::default(),
     );
     let (width_pt, height_pt) = page.render_dimensions();
-    let mut device = TextExtractDevice::default();
+    let mut device = PositionedTextExtractDevice::default();
     interpret_page(page, &mut context, &mut device);
     device.finish(width_pt, height_pt)
 }
 
 #[derive(Default)]
-struct TextExtractDevice {
+struct PositionedTextExtractDevice {
     last_glyph: Option<(char, i32, i32)>,
     glyphs: Vec<TextGlyph>,
 }
 
-impl TextExtractDevice {
+impl PositionedTextExtractDevice {
     fn finish(self, width_pt: f32, height_pt: f32) -> TextPage {
         TextPage {
             width_pt,
@@ -625,7 +750,7 @@ impl TextExtractDevice {
     }
 }
 
-impl<'a> Device<'a> for TextExtractDevice {
+impl<'a> Device<'a> for PositionedTextExtractDevice {
     fn set_soft_mask(&mut self, _mask: Option<SoftMask<'a>>) {}
 
     fn set_blend_mode(&mut self, _blend_mode: BlendMode) {}
@@ -683,6 +808,20 @@ fn quantize_coord(value: f64) -> i32 {
     (value * 100.0).round() as i32
 }
 
+const PLAIN_TEXT_LINE_BREAK_THRESHOLD: f64 = 6.0;
+
+fn push_plain_newline(out: &mut String) {
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+}
+
+fn push_plain_space(out: &mut String) {
+    if !out.ends_with([' ', '\n']) {
+        out.push(' ');
+    }
+}
+
 fn glyph_bbox(glyph: &Glyph<'_>, transform: Affine, glyph_transform: Affine) -> Option<PdfRect> {
     let outline = match glyph {
         Glyph::Outline(outline) => outline.outline(),
@@ -726,7 +865,6 @@ mod tests {
 
     use hayro::vello_cpu::Pixmap;
 
-    use crate::backend::PdfBackend;
     use crate::error::AppError;
 
     use super::{PdfDoc, decode_pdf_text_string, pixel_buffer_from_pixmap};

--- a/src/backend/hayro.rs
+++ b/src/backend/hayro.rs
@@ -19,11 +19,11 @@ use hayro::hayro_syntax::page::Page;
 use hayro::vello_cpu::color::palette::css::WHITE;
 use hayro::vello_cpu::{Pixmap, color::PremulRgba8};
 use hayro::{RenderSettings, render};
-use kurbo::{Affine, BezPath, Point};
+use kurbo::{Affine, BezPath, Point, Shape};
 
 use crate::error::{AppError, AppResult};
 
-use super::traits::{OutlineNode, PdfBackend, RgbaFrame};
+use super::traits::{OutlineNode, PdfBackend, PdfRect, RgbaFrame, TextGlyph, TextPage};
 
 pub struct PdfDoc {
     path: PathBuf,
@@ -54,8 +54,8 @@ impl PdfBackend for PdfDoc {
         PdfDoc::render_page(self, page, scale)
     }
 
-    fn extract_text(&self, page: usize) -> AppResult<String> {
-        PdfDoc::extract_text(self, page)
+    fn extract_text_page(&self, page: usize) -> AppResult<TextPage> {
+        PdfDoc::extract_text_page(self, page)
     }
 
     fn extract_outline(&self) -> AppResult<Vec<OutlineNode>> {
@@ -173,7 +173,7 @@ impl PdfDoc {
         })
     }
 
-    pub fn extract_text(&self, page: usize) -> AppResult<String> {
+    pub fn extract_text_page(&self, page: usize) -> AppResult<TextPage> {
         if page >= self.page_count() {
             return Err(AppError::invalid_argument("page index is out of range"));
         }
@@ -184,7 +184,7 @@ impl PdfDoc {
             .get(page)
             .ok_or(AppError::invalid_argument("page index is out of range"))?;
 
-        Ok(extract_text_with_device(page_ref).trim().to_owned())
+        Ok(extract_text_page_with_device(page_ref))
     }
 
     pub fn extract_outline(&self) -> AppResult<Vec<OutlineNode>> {
@@ -588,51 +588,32 @@ impl<'a> NamedDestination<'a> {
     }
 }
 
-fn extract_text_with_device(page: &Page<'_>) -> String {
+fn extract_text_page_with_device(page: &Page<'_>) -> TextPage {
     let mut context = Context::new(
         page.initial_transform(true),
         page.intersected_crop_box().to_kurbo(),
         page.xref(),
         InterpreterSettings::default(),
     );
+    let (width_pt, height_pt) = page.render_dimensions();
     let mut device = TextExtractDevice::default();
     interpret_page(page, &mut context, &mut device);
-    device.finish()
+    device.finish(width_pt, height_pt)
 }
 
 #[derive(Default)]
 struct TextExtractDevice {
-    text: String,
-    last_point: Option<Point>,
     last_glyph: Option<(char, i32, i32)>,
+    glyphs: Vec<TextGlyph>,
 }
 
 impl TextExtractDevice {
-    fn finish(self) -> String {
-        self.text
-    }
-
-    fn push_char(&mut self, ch: char, x: f64, y: f64) {
-        if ch == '\n' || ch == '\r' {
-            push_newline(&mut self.text);
-            self.last_point = Some(Point::new(x, y));
-            return;
+    fn finish(self, width_pt: f32, height_pt: f32) -> TextPage {
+        TextPage {
+            width_pt,
+            height_pt,
+            glyphs: self.glyphs,
         }
-        if ch.is_whitespace() {
-            push_space(&mut self.text);
-            self.last_point = Some(Point::new(x, y));
-            return;
-        }
-
-        if let Some(last) = self.last_point {
-            let y_delta = (y - last.y).abs();
-            if y_delta > LINE_BREAK_THRESHOLD {
-                push_newline(&mut self.text);
-            }
-        }
-
-        self.text.push(ch);
-        self.last_point = Some(Point::new(x, y));
     }
 
     fn is_duplicate_glyph(&self, ch: char, x: f64, y: f64) -> bool {
@@ -686,7 +667,9 @@ impl<'a> Device<'a> for TextExtractDevice {
         }
 
         self.set_last_glyph(ch, position.x, position.y);
-        self.push_char(ch, position.x, position.y);
+        if let Some(bbox) = glyph_bbox(glyph, transform, glyph_transform) {
+            self.glyphs.push(TextGlyph { ch, bbox });
+        }
     }
 
     fn draw_image(&mut self, _image: Image<'a, '_>, _transform: Affine) {}
@@ -700,18 +683,22 @@ fn quantize_coord(value: f64) -> i32 {
     (value * 100.0).round() as i32
 }
 
-const LINE_BREAK_THRESHOLD: f64 = 6.0;
-
-fn push_newline(out: &mut String) {
-    if !out.is_empty() && !out.ends_with('\n') {
-        out.push('\n');
+fn glyph_bbox(glyph: &Glyph<'_>, transform: Affine, glyph_transform: Affine) -> Option<PdfRect> {
+    let outline = match glyph {
+        Glyph::Outline(outline) => outline.outline(),
+        Glyph::Type3(_) => return None,
+    };
+    let bbox = (transform * glyph_transform * outline).bounding_box();
+    if bbox.is_zero_area() {
+        return None;
     }
-}
 
-fn push_space(out: &mut String) {
-    if !out.ends_with([' ', '\n']) {
-        out.push(' ');
-    }
+    Some(PdfRect {
+        x0: bbox.x0 as f32,
+        y0: bbox.y0 as f32,
+        x1: bbox.x1 as f32,
+        y1: bbox.y1 as f32,
+    })
 }
 
 fn calculate_doc_id(path: &Path, byte_len: usize) -> u64 {
@@ -739,6 +726,7 @@ mod tests {
 
     use hayro::vello_cpu::Pixmap;
 
+    use crate::backend::PdfBackend;
     use crate::error::AppError;
 
     use super::{PdfDoc, decode_pdf_text_string, pixel_buffer_from_pixmap};

--- a/src/backend/hayro.rs
+++ b/src/backend/hayro.rs
@@ -730,6 +730,7 @@ fn extract_positioned_text_with_device(page: &Page<'_>) -> TextPage {
 struct PositionedTextExtractDevice {
     last_glyph: Option<(char, i32, i32)>,
     glyphs: Vec<TextGlyph>,
+    dropped_glyphs: usize,
 }
 
 impl PositionedTextExtractDevice {
@@ -738,6 +739,7 @@ impl PositionedTextExtractDevice {
             width_pt,
             height_pt,
             glyphs: self.glyphs,
+            dropped_glyphs: self.dropped_glyphs,
         }
     }
 
@@ -794,6 +796,8 @@ impl<'a> Device<'a> for PositionedTextExtractDevice {
         self.set_last_glyph(ch, position.x, position.y);
         if let Some(bbox) = glyph_bbox(glyph, transform, glyph_transform) {
             self.glyphs.push(TextGlyph { ch, bbox });
+        } else {
+            self.dropped_glyphs += 1;
         }
     }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -7,7 +7,9 @@ mod hayro;
 mod traits;
 
 pub use hayro::{HayroPdfBackend, PdfDoc};
-pub use traits::{OutlineNode, PdfBackend, PixelBuffer, PixelBufferPool, RgbaFrame};
+pub use traits::{
+    OutlineNode, PdfBackend, PdfRect, PixelBuffer, PixelBufferPool, RgbaFrame, TextGlyph, TextPage,
+};
 
 pub type SharedPdfBackend = Arc<dyn PdfBackend>;
 

--- a/src/backend/traits.rs
+++ b/src/backend/traits.rs
@@ -226,10 +226,8 @@ pub trait PdfBackend: Send + Sync {
     fn page_count(&self) -> usize;
     fn page_dimensions(&self, page: usize) -> AppResult<(f32, f32)>;
     fn render_page(&self, page: usize, scale: f32) -> AppResult<RgbaFrame>;
-    fn extract_text_page(&self, page: usize) -> AppResult<TextPage>;
-    fn extract_text(&self, page: usize) -> AppResult<String> {
-        Ok(self.extract_text_page(page)?.extracted_text())
-    }
+    fn extract_text(&self, page: usize) -> AppResult<String>;
+    fn extract_positioned_text(&self, page: usize) -> AppResult<TextPage>;
     fn extract_outline(&self) -> AppResult<Vec<OutlineNode>>;
 }
 

--- a/src/backend/traits.rs
+++ b/src/backend/traits.rs
@@ -168,6 +168,7 @@ pub struct TextPage {
     pub width_pt: f32,
     pub height_pt: f32,
     pub glyphs: Vec<TextGlyph>,
+    pub dropped_glyphs: usize,
 }
 
 impl TextPage {
@@ -332,6 +333,7 @@ mod tests {
                     },
                 },
             ],
+            dropped_glyphs: 0,
         };
 
         assert_eq!(page.extracted_text(), "A\nB");

--- a/src/backend/traits.rs
+++ b/src/backend/traits.rs
@@ -139,19 +139,105 @@ pub struct OutlineNode {
     pub children: Vec<OutlineNode>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PdfRect {
+    pub x0: f32,
+    pub y0: f32,
+    pub x1: f32,
+    pub y1: f32,
+}
+
+impl PdfRect {
+    pub fn width(self) -> f32 {
+        (self.x1 - self.x0).max(0.0)
+    }
+
+    pub fn height(self) -> f32 {
+        (self.y1 - self.y0).max(0.0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextGlyph {
+    pub ch: char,
+    pub bbox: PdfRect,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextPage {
+    pub width_pt: f32,
+    pub height_pt: f32,
+    pub glyphs: Vec<TextGlyph>,
+}
+
+impl TextPage {
+    pub fn extracted_text(&self) -> String {
+        let mut out = String::new();
+        let mut last_rect: Option<PdfRect> = None;
+        for glyph in &self.glyphs {
+            push_extracted_char(&mut out, glyph.ch, glyph.bbox, &mut last_rect);
+        }
+        out.trim().to_owned()
+    }
+}
+
+const LINE_BREAK_THRESHOLD: f32 = 6.0;
+
+fn push_extracted_char(out: &mut String, ch: char, bbox: PdfRect, last_rect: &mut Option<PdfRect>) {
+    if ch == '\n' || ch == '\r' {
+        push_newline(out);
+        *last_rect = Some(bbox);
+        return;
+    }
+    if ch.is_whitespace() {
+        push_space(out);
+        *last_rect = Some(bbox);
+        return;
+    }
+
+    if let Some(last) = last_rect
+        && (bbox.y0 - last.y0).abs() > LINE_BREAK_THRESHOLD
+    {
+        push_newline(out);
+    }
+
+    out.push(ch);
+    *last_rect = Some(bbox);
+}
+
+fn push_newline(out: &mut String) {
+    while out.ends_with(' ') {
+        out.pop();
+    }
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+}
+
+fn push_space(out: &mut String) {
+    if !out.ends_with([' ', '\n']) {
+        out.push(' ');
+    }
+}
+
 pub trait PdfBackend: Send + Sync {
     fn path(&self) -> &Path;
     fn doc_id(&self) -> u64;
     fn page_count(&self) -> usize;
     fn page_dimensions(&self, page: usize) -> AppResult<(f32, f32)>;
     fn render_page(&self, page: usize, scale: f32) -> AppResult<RgbaFrame>;
-    fn extract_text(&self, page: usize) -> AppResult<String>;
+    fn extract_text_page(&self, page: usize) -> AppResult<TextPage>;
+    fn extract_text(&self, page: usize) -> AppResult<String> {
+        Ok(self.extract_text_page(page)?.extracted_text())
+    }
     fn extract_outline(&self) -> AppResult<Vec<OutlineNode>>;
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{PdfBackend, PixelBuffer, PixelBufferPool, RgbaFrame};
+    use super::{
+        PdfBackend, PdfRect, PixelBuffer, PixelBufferPool, RgbaFrame, TextGlyph, TextPage,
+    };
 
     #[test]
     fn into_pixels_vec_reuses_unique_allocation() {
@@ -213,4 +299,43 @@ mod tests {
     }
 
     fn _assert_pdf_backend_object_safe(_: &dyn PdfBackend) {}
+
+    #[test]
+    fn text_page_extracted_text_preserves_line_breaks() {
+        let page = TextPage {
+            width_pt: 100.0,
+            height_pt: 100.0,
+            glyphs: vec![
+                TextGlyph {
+                    ch: 'A',
+                    bbox: PdfRect {
+                        x0: 1.0,
+                        y0: 1.0,
+                        x1: 2.0,
+                        y1: 2.0,
+                    },
+                },
+                TextGlyph {
+                    ch: ' ',
+                    bbox: PdfRect {
+                        x0: 3.0,
+                        y0: 1.0,
+                        x1: 4.0,
+                        y1: 2.0,
+                    },
+                },
+                TextGlyph {
+                    ch: 'B',
+                    bbox: PdfRect {
+                        x0: 1.0,
+                        y0: 20.0,
+                        x1: 2.0,
+                        y1: 21.0,
+                    },
+                },
+            ],
+        };
+
+        assert_eq!(page.extracted_text(), "A\nB");
+    }
 }

--- a/src/command/dispatch.rs
+++ b/src/command/dispatch.rs
@@ -255,7 +255,7 @@ mod tests {
 
     use crate::app::scale::zoom_eq;
     use crate::app::{AppState, Notice, NoticeLevel, PaletteRequest};
-    use crate::backend::{PdfBackend, RgbaFrame, SharedPdfBackend};
+    use crate::backend::{PdfBackend, RgbaFrame, SharedPdfBackend, TextPage};
     use crate::command::{
         ActionId, Command, CommandInvocationSource, CommandOutcome, PageLayoutModeArg, PanAmount,
         PanDirection, SearchMatcherKind,
@@ -306,8 +306,12 @@ mod tests {
             })
         }
 
-        fn extract_text(&self, _page: usize) -> crate::error::AppResult<String> {
-            Ok(String::new())
+        fn extract_text_page(&self, _page: usize) -> crate::error::AppResult<TextPage> {
+            Ok(TextPage {
+                width_pt: 612.0,
+                height_pt: 792.0,
+                glyphs: Vec::new(),
+            })
         }
 
         fn extract_outline(&self) -> crate::error::AppResult<Vec<crate::backend::OutlineNode>> {

--- a/src/command/dispatch.rs
+++ b/src/command/dispatch.rs
@@ -315,6 +315,7 @@ mod tests {
                 width_pt: 612.0,
                 height_pt: 792.0,
                 glyphs: Vec::new(),
+                dropped_glyphs: 0,
             })
         }
 

--- a/src/command/dispatch.rs
+++ b/src/command/dispatch.rs
@@ -306,7 +306,11 @@ mod tests {
             })
         }
 
-        fn extract_text_page(&self, _page: usize) -> crate::error::AppResult<TextPage> {
+        fn extract_text(&self, _page: usize) -> crate::error::AppResult<String> {
+            Ok(String::new())
+        }
+
+        fn extract_positioned_text(&self, _page: usize) -> crate::error::AppResult<TextPage> {
             Ok(TextPage {
                 width_pt: 612.0,
                 height_pt: 792.0,

--- a/src/extension/host.rs
+++ b/src/extension/host.rs
@@ -244,7 +244,11 @@ mod tests {
             })
         }
 
-        fn extract_text_page(&self, _page: usize) -> crate::error::AppResult<TextPage> {
+        fn extract_text(&self, _page: usize) -> crate::error::AppResult<String> {
+            Ok(String::new())
+        }
+
+        fn extract_positioned_text(&self, _page: usize) -> crate::error::AppResult<TextPage> {
             Ok(TextPage {
                 width_pt: 612.0,
                 height_pt: 792.0,

--- a/src/extension/host.rs
+++ b/src/extension/host.rs
@@ -6,6 +6,7 @@ use crate::backend::SharedPdfBackend;
 use crate::command::{CommandOutcome, SearchMatcherKind};
 use crate::error::AppResult;
 use crate::event::AppEvent;
+use crate::highlight::HighlightOverlaySnapshot;
 use crate::history::{HistoryExtension, HistoryState};
 use crate::input::{AppInputEvent, InputHookResult};
 use crate::outline::{OutlineExtension, OutlinePaletteEntry, OutlineState};
@@ -178,6 +179,14 @@ impl ExtensionHost {
             outline_entries: self.outline.palette_entries(),
         }
     }
+
+    pub fn highlight_overlay_for(
+        &self,
+        visible_pages: [Option<usize>; 2],
+    ) -> HighlightOverlaySnapshot {
+        self.search
+            .highlight_overlay_for_visible_pages(visible_pages)
+    }
 }
 
 impl Default for ExtensionHost {
@@ -191,7 +200,7 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
 
-    use crate::backend::{PdfBackend, RgbaFrame, SharedPdfBackend};
+    use crate::backend::{PdfBackend, RgbaFrame, SharedPdfBackend, TextPage};
     use crate::command::SearchMatcherKind;
 
     use super::ExtensionHost;
@@ -235,8 +244,12 @@ mod tests {
             })
         }
 
-        fn extract_text(&self, _page: usize) -> crate::error::AppResult<String> {
-            Ok(String::new())
+        fn extract_text_page(&self, _page: usize) -> crate::error::AppResult<TextPage> {
+            Ok(TextPage {
+                width_pt: 612.0,
+                height_pt: 792.0,
+                glyphs: Vec::new(),
+            })
         }
 
         fn extract_outline(&self) -> crate::error::AppResult<Vec<crate::backend::OutlineNode>> {

--- a/src/extension/host.rs
+++ b/src/extension/host.rs
@@ -253,6 +253,7 @@ mod tests {
                 width_pt: 612.0,
                 height_pt: 792.0,
                 glyphs: Vec::new(),
+                dropped_glyphs: 0,
             })
         }
 

--- a/src/highlight/mod.rs
+++ b/src/highlight/mod.rs
@@ -1,0 +1,68 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use crate::backend::PdfRect;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HighlightSource {
+    Search,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HighlightStyle {
+    pub fill_rgba: [u8; 4],
+    pub priority: u8,
+}
+
+impl HighlightStyle {
+    pub const SEARCH_HIT: Self = Self {
+        fill_rgba: [255, 196, 79, 96],
+        priority: 0,
+    };
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HighlightSpan {
+    pub source: HighlightSource,
+    pub page: usize,
+    pub rects: Vec<PdfRect>,
+    pub style: HighlightStyle,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct HighlightOverlaySnapshot {
+    pub spans: Vec<HighlightSpan>,
+    pub stamp: u64,
+}
+
+impl HighlightOverlaySnapshot {
+    pub fn new(spans: Vec<HighlightSpan>) -> Self {
+        let mut snapshot = Self { spans, stamp: 0 };
+        snapshot.stamp = snapshot.compute_stamp();
+        snapshot
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.spans.is_empty()
+    }
+
+    fn compute_stamp(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        for span in &self.spans {
+            span.source.hash(&mut hasher);
+            span.page.hash(&mut hasher);
+            span.style.hash(&mut hasher);
+            for rect in &span.rects {
+                quantize(rect.x0).hash(&mut hasher);
+                quantize(rect.y0).hash(&mut hasher);
+                quantize(rect.x1).hash(&mut hasher);
+                quantize(rect.y1).hash(&mut hasher);
+            }
+        }
+        hasher.finish()
+    }
+}
+
+fn quantize(value: f32) -> i32 {
+    (value * 100.0).round() as i32
+}

--- a/src/highlight/mod.rs
+++ b/src/highlight/mod.rs
@@ -37,6 +37,9 @@ pub struct HighlightOverlaySnapshot {
 
 impl HighlightOverlaySnapshot {
     pub fn new(spans: Vec<HighlightSpan>) -> Self {
+        if spans.is_empty() {
+            return Self::default();
+        }
         let mut snapshot = Self { spans, stamp: 0 };
         snapshot.stamp = snapshot.compute_stamp();
         snapshot

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod error;
 pub mod event;
 pub mod extension;
+pub mod highlight;
 pub mod history;
 pub mod input;
 pub mod outline;

--- a/src/outline/state.rs
+++ b/src/outline/state.rs
@@ -142,7 +142,11 @@ mod tests {
             })
         }
 
-        fn extract_text_page(&self, _page: usize) -> crate::error::AppResult<TextPage> {
+        fn extract_text(&self, _page: usize) -> crate::error::AppResult<String> {
+            Ok(String::new())
+        }
+
+        fn extract_positioned_text(&self, _page: usize) -> crate::error::AppResult<TextPage> {
             Ok(TextPage {
                 width_pt: 1.0,
                 height_pt: 1.0,

--- a/src/outline/state.rs
+++ b/src/outline/state.rs
@@ -107,7 +107,7 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
 
-    use crate::backend::{OutlineNode, PdfBackend, RgbaFrame, SharedPdfBackend};
+    use crate::backend::{OutlineNode, PdfBackend, RgbaFrame, SharedPdfBackend, TextPage};
 
     use super::OutlineState;
 
@@ -142,8 +142,12 @@ mod tests {
             })
         }
 
-        fn extract_text(&self, _page: usize) -> crate::error::AppResult<String> {
-            Ok(String::new())
+        fn extract_text_page(&self, _page: usize) -> crate::error::AppResult<TextPage> {
+            Ok(TextPage {
+                width_pt: 1.0,
+                height_pt: 1.0,
+                glyphs: Vec::new(),
+            })
         }
 
         fn extract_outline(&self) -> crate::error::AppResult<Vec<OutlineNode>> {

--- a/src/outline/state.rs
+++ b/src/outline/state.rs
@@ -151,6 +151,7 @@ mod tests {
                 width_pt: 1.0,
                 height_pt: 1.0,
                 glyphs: Vec::new(),
+                dropped_glyphs: 0,
             })
         }
 

--- a/src/presenter/encode.rs
+++ b/src/presenter/encode.rs
@@ -446,6 +446,7 @@ mod tests {
                 height: 6,
             },
             pan: PanOffset::default(),
+            overlay_stamp: 0,
         }
     }
 

--- a/src/presenter/l2_cache.rs
+++ b/src/presenter/l2_cache.rs
@@ -28,6 +28,7 @@ pub(crate) struct TerminalFrameKey {
     pub(crate) rendered_page: RenderedPageKey,
     pub(crate) viewport: Viewport,
     pub(crate) pan: PanOffset,
+    pub(crate) overlay_stamp: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/src/presenter/ratatui.rs
+++ b/src/presenter/ratatui.rs
@@ -191,12 +191,14 @@ impl RatatuiImagePresenter {
         frame: &RgbaFrame,
         viewport: Viewport,
         pan: PanOffset,
+        overlay_stamp: u64,
         allow_single_oversize: bool,
     ) -> AppResult<Option<TerminalFrameKey>> {
         let key = TerminalFrameKey {
             rendered_page: cache_key,
             viewport,
             pan,
+            overlay_stamp,
         };
 
         if self.state.l2_cache.lookup_mut(&key).is_none() {
@@ -471,10 +473,13 @@ impl ImagePresenter for RatatuiImagePresenter {
         frame: &RgbaFrame,
         viewport: Viewport,
         pan: PanOffset,
+        overlay_stamp: u64,
         generation: u64,
     ) -> AppResult<()> {
         self.drain_encode_results();
-        let Some(key) = self.ensure_frame_entry(cache_key, frame, viewport, pan, true)? else {
+        let Some(key) =
+            self.ensure_frame_entry(cache_key, frame, viewport, pan, overlay_stamp, true)?
+        else {
             self.state.current_key = None;
             return Ok(());
         };
@@ -489,12 +494,15 @@ impl ImagePresenter for RatatuiImagePresenter {
         frame: &RgbaFrame,
         viewport: Viewport,
         pan: PanOffset,
+        overlay_stamp: u64,
         class: WorkClass,
         generation: u64,
     ) -> AppResult<()> {
         self.drain_encode_results();
         debug_assert_ne!(class, WorkClass::CriticalCurrent);
-        let Some(key) = self.ensure_frame_entry(cache_key, frame, viewport, pan, false)? else {
+        let Some(key) =
+            self.ensure_frame_entry(cache_key, frame, viewport, pan, overlay_stamp, false)?
+        else {
             return Ok(());
         };
 

--- a/src/presenter/tests/mod.rs
+++ b/src/presenter/tests/mod.rs
@@ -154,6 +154,42 @@ fn presenter_cache_key_distinguishes_pages_even_with_same_pixels() {
 }
 
 #[test]
+fn presenter_cache_key_distinguishes_overlay_stamps() {
+    let mut presenter = RatatuiImagePresenter::new();
+    let viewport = Viewport {
+        x: 0,
+        y: 0,
+        width: 80,
+        height: 24,
+    };
+    let rendered_page = RenderedPageKey::new(1, 0, 1.0);
+
+    presenter
+        .prepare(
+            rendered_page,
+            &frame(),
+            viewport,
+            PanOffset::default(),
+            1,
+            1,
+        )
+        .expect("first overlay prepare should pass");
+    presenter
+        .prepare(
+            rendered_page,
+            &frame(),
+            viewport,
+            PanOffset::default(),
+            2,
+            2,
+        )
+        .expect("second overlay prepare should pass");
+
+    assert_eq!(presenter.l2_cache_len(), 2);
+    assert_eq!(presenter.perf_stats().cache_hit_rate_l2, 0.0);
+}
+
+#[test]
 fn presenter_renders_after_prepare() {
     let mut presenter = RatatuiImagePresenter::new();
     let viewport = Viewport {

--- a/src/presenter/tests/mod.rs
+++ b/src/presenter/tests/mod.rs
@@ -41,6 +41,7 @@ fn l2_key(page: usize) -> TerminalFrameKey {
             height: 24,
         },
         pan: PanOffset::default(),
+        overlay_stamp: 0,
     }
 }
 
@@ -100,6 +101,7 @@ fn presenter_uses_l2_cache_between_same_frames() {
             viewport,
             PanOffset::default(),
             0,
+            0,
         )
         .expect("first prepare should pass");
     presenter
@@ -108,6 +110,7 @@ fn presenter_uses_l2_cache_between_same_frames() {
             &frame(),
             viewport,
             PanOffset::default(),
+            0,
             0,
         )
         .expect("second prepare should pass");
@@ -133,6 +136,7 @@ fn presenter_cache_key_distinguishes_pages_even_with_same_pixels() {
             viewport,
             PanOffset::default(),
             0,
+            0,
         )
         .expect("first prepare should pass");
     presenter
@@ -141,6 +145,7 @@ fn presenter_cache_key_distinguishes_pages_even_with_same_pixels() {
             &frame(),
             viewport,
             PanOffset::default(),
+            0,
             0,
         )
         .expect("second page prepare should pass");
@@ -163,6 +168,7 @@ fn presenter_renders_after_prepare() {
             &frame(),
             viewport,
             PanOffset::default(),
+            0,
             0,
         )
         .expect("prepare should pass");
@@ -205,6 +211,7 @@ fn prefetch_encode_advances_entry_to_ready() {
         rendered_page,
         viewport,
         pan: PanOffset::default(),
+        overlay_stamp: 0,
     };
 
     presenter
@@ -213,6 +220,7 @@ fn prefetch_encode_advances_entry_to_ready() {
             &frame(),
             viewport,
             PanOffset::default(),
+            0,
             WorkClass::DirectionalLead,
             1,
         )
@@ -252,7 +260,7 @@ fn prefetch_encode_does_not_change_current_key() {
     let prefetch = RenderedPageKey::new(1, 1, 1.0);
 
     presenter
-        .prepare(current, &frame(), viewport, PanOffset::default(), 0)
+        .prepare(current, &frame(), viewport, PanOffset::default(), 0, 0)
         .expect("prepare should pass");
     let before = presenter.state.current_key;
 
@@ -262,6 +270,7 @@ fn prefetch_encode_does_not_change_current_key() {
             &frame(),
             viewport,
             PanOffset::default(),
+            0,
             WorkClass::DirectionalLead,
             1,
         )
@@ -287,6 +296,7 @@ fn presenter_has_pending_work_tracks_encode_progress() {
             &frame(),
             viewport,
             PanOffset::default(),
+            0,
             WorkClass::DirectionalLead,
             1,
         )
@@ -319,6 +329,7 @@ fn recv_background_event_requests_redraw_for_current_encode_completion() {
             &frame(),
             viewport,
             PanOffset::default(),
+            0,
             1,
         )
         .expect("prepare should pass");
@@ -368,6 +379,7 @@ fn render_pending_uses_stale_fallback_when_allowed() {
             &frame(),
             viewport,
             PanOffset::default(),
+            0,
             1,
         )
         .expect("first prepare should pass");
@@ -378,6 +390,7 @@ fn render_pending_uses_stale_fallback_when_allowed() {
             &frame(),
             viewport,
             PanOffset::default(),
+            0,
             2,
         )
         .expect("second prepare should pass");
@@ -421,6 +434,7 @@ fn render_pending_keeps_stale_fallback_when_new_oversize_entry_arrives() {
             &oversize,
             viewport,
             PanOffset::default(),
+            0,
             1,
         )
         .expect("preview prepare should pass");
@@ -432,6 +446,7 @@ fn render_pending_keeps_stale_fallback_when_new_oversize_entry_arrives() {
             &oversize,
             viewport,
             PanOffset::default(),
+            0,
             2,
         )
         .expect("full prepare should pass");
@@ -473,6 +488,7 @@ fn render_pending_does_not_use_stale_fallback_when_disallowed() {
             &frame(),
             viewport,
             PanOffset::default(),
+            0,
             1,
         )
         .expect("first prepare should pass");
@@ -483,6 +499,7 @@ fn render_pending_does_not_use_stale_fallback_when_disallowed() {
             &frame(),
             viewport,
             PanOffset::default(),
+            0,
             2,
         )
         .expect("second prepare should pass");
@@ -524,6 +541,7 @@ fn render_returns_failed_feedback_for_failed_current_entry() {
             &frame(),
             viewport,
             PanOffset::default(),
+            0,
             1,
         )
         .expect("prepare should pass");
@@ -534,6 +552,7 @@ fn render_returns_failed_feedback_for_failed_current_entry() {
             &frame(),
             viewport,
             PanOffset::default(),
+            0,
             2,
         )
         .expect("second prepare should pass");
@@ -582,6 +601,7 @@ fn render_failed_does_not_use_stale_fallback_when_disallowed() {
             &frame(),
             viewport,
             PanOffset::default(),
+            0,
             1,
         )
         .expect("prepare should pass");
@@ -592,6 +612,7 @@ fn render_failed_does_not_use_stale_fallback_when_disallowed() {
             &frame(),
             viewport,
             PanOffset::default(),
+            0,
             2,
         )
         .expect("second prepare should pass");
@@ -635,12 +656,20 @@ fn render_reports_failed_feedback_when_encode_worker_is_disconnected() {
     };
     let rendered_page = RenderedPageKey::new(7, 1, 1.0);
     presenter
-        .prepare(rendered_page, &frame(), viewport, PanOffset::default(), 0)
+        .prepare(
+            rendered_page,
+            &frame(),
+            viewport,
+            PanOffset::default(),
+            0,
+            0,
+        )
         .expect("prepare should pass");
     let key = TerminalFrameKey {
         rendered_page,
         viewport,
         pan: PanOffset::default(),
+        overlay_stamp: 0,
     };
     presenter.state.current_key = Some(key);
     presenter.shutdown_worker();
@@ -690,16 +719,19 @@ fn encode_queue_prioritizes_current_over_prefetch() {
         rendered_page: RenderedPageKey::new(1, 1, 1.0),
         viewport,
         pan: PanOffset::default(),
+        overlay_stamp: 0,
     };
     let low_key_2 = TerminalFrameKey {
         rendered_page: RenderedPageKey::new(1, 2, 1.0),
         viewport,
         pan: PanOffset::default(),
+        overlay_stamp: 0,
     };
     let high_key = TerminalFrameKey {
         rendered_page: RenderedPageKey::new(1, 3, 1.0),
         viewport,
         pan: PanOffset::default(),
+        overlay_stamp: 0,
     };
 
     let low_req_1 = EncodeWorkerRequest::Encode {
@@ -775,6 +807,7 @@ fn current_encode_queue_cancels_stale_generation() {
             rendered_page: RenderedPageKey::new(1, 1, 1.0),
             viewport,
             pan: PanOffset::default(),
+            overlay_stamp: 0,
         },
         picker: presenter.config.picker.clone(),
         frame: frame(),
@@ -789,6 +822,7 @@ fn current_encode_queue_cancels_stale_generation() {
             rendered_page: RenderedPageKey::new(1, 2, 1.0),
             viewport,
             pan: PanOffset::default(),
+            overlay_stamp: 0,
         },
         picker: presenter.config.picker.clone(),
         frame: frame(),
@@ -803,6 +837,7 @@ fn current_encode_queue_cancels_stale_generation() {
             rendered_page: RenderedPageKey::new(1, 3, 1.0),
             viewport,
             pan: PanOffset::default(),
+            overlay_stamp: 0,
         },
         picker: presenter.config.picker.clone(),
         frame: frame(),

--- a/src/presenter/traits.rs
+++ b/src/presenter/traits.rs
@@ -120,6 +120,7 @@ pub trait ImagePresenter {
         generation: u64,
     ) -> AppResult<()>;
 
+    #[allow(clippy::too_many_arguments)]
     fn prefetch_encode(
         &mut self,
         cache_key: RenderedPageKey,

--- a/src/presenter/traits.rs
+++ b/src/presenter/traits.rs
@@ -116,6 +116,7 @@ pub trait ImagePresenter {
         frame: &RgbaFrame,
         viewport: Viewport,
         pan: PanOffset,
+        overlay_stamp: u64,
         generation: u64,
     ) -> AppResult<()>;
 
@@ -125,10 +126,19 @@ pub trait ImagePresenter {
         frame: &RgbaFrame,
         viewport: Viewport,
         pan: PanOffset,
+        overlay_stamp: u64,
         class: WorkClass,
         generation: u64,
     ) -> AppResult<()> {
-        let _ = (cache_key, frame, viewport, pan, class, generation);
+        let _ = (
+            cache_key,
+            frame,
+            viewport,
+            pan,
+            overlay_stamp,
+            class,
+            generation,
+        );
         Ok(())
     }
 

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -281,7 +281,18 @@ fn run_job(
 
         if job.matcher.matches_page(&text, &query) {
             let occurrences = match doc.extract_positioned_text(page) {
-                Ok(text_page) => job.matcher.locate_matches(&text_page, &query),
+                Ok(text_page) => {
+                    if text_page.dropped_glyphs > 0 {
+                        highlight_unavailable = true;
+                        Vec::new()
+                    } else {
+                        let occurrences = job.matcher.locate_matches(&text_page, &query);
+                        if occurrences.is_empty() {
+                            highlight_unavailable = true;
+                        }
+                        occurrences
+                    }
+                }
                 Err(_) => {
                     highlight_unavailable = true;
                     Vec::new()
@@ -654,6 +665,56 @@ mod tests {
         }
     }
 
+    struct SearchPositionedStubPdf {
+        path: PathBuf,
+        text: String,
+        positioned_text: TextPage,
+    }
+
+    impl SearchPositionedStubPdf {
+        fn new(text: &str, positioned_text: TextPage) -> Self {
+            Self {
+                path: PathBuf::from("search-positioned.pdf"),
+                text: text.to_string(),
+                positioned_text,
+            }
+        }
+    }
+
+    impl PdfBackend for SearchPositionedStubPdf {
+        fn path(&self) -> &Path {
+            &self.path
+        }
+
+        fn doc_id(&self) -> u64 {
+            43
+        }
+
+        fn page_count(&self) -> usize {
+            1
+        }
+
+        fn page_dimensions(&self, _page: usize) -> AppResult<(f32, f32)> {
+            Ok((100.0, 100.0))
+        }
+
+        fn render_page(&self, _page: usize, _scale: f32) -> AppResult<RgbaFrame> {
+            Err(AppError::unsupported("not needed in search test"))
+        }
+
+        fn extract_text(&self, _page: usize) -> AppResult<String> {
+            Ok(self.text.clone())
+        }
+
+        fn extract_positioned_text(&self, _page: usize) -> AppResult<TextPage> {
+            Ok(self.positioned_text.clone())
+        }
+
+        fn extract_outline(&self) -> AppResult<Vec<OutlineNode>> {
+            Err(AppError::unsupported("not needed in search test"))
+        }
+    }
+
     #[test]
     fn submit_returns_incrementing_generation() {
         let file = unique_temp_path("generation.pdf");
@@ -803,6 +864,62 @@ mod tests {
         let (hits, highlight_unavailable) = wait_for_completed_hits(&mut engine, generation);
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].page, 0);
+        assert!(hits[0].occurrences.is_empty());
+        assert!(highlight_unavailable);
+    }
+
+    #[test]
+    fn search_marks_highlight_unavailable_when_match_has_no_geometry() {
+        let mut engine = SearchEngine::new();
+        let pdf: Arc<dyn PdfBackend> = Arc::new(SearchPositionedStubPdf::new(
+            "alpha beta",
+            TextPage {
+                width_pt: 100.0,
+                height_pt: 100.0,
+                glyphs: Vec::new(),
+                dropped_glyphs: 0,
+            },
+        ));
+        let generation = engine
+            .submit(
+                pdf,
+                "alpha",
+                Arc::new(ContainsMatcher {
+                    case_sensitive: false,
+                }),
+            )
+            .expect("submit should succeed");
+
+        let (hits, highlight_unavailable) = wait_for_completed_hits(&mut engine, generation);
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].occurrences.is_empty());
+        assert!(highlight_unavailable);
+    }
+
+    #[test]
+    fn search_treats_dropped_positioned_glyphs_as_highlight_failure() {
+        let mut engine = SearchEngine::new();
+        let pdf: Arc<dyn PdfBackend> = Arc::new(SearchPositionedStubPdf::new(
+            "alpha beta",
+            TextPage {
+                width_pt: 100.0,
+                height_pt: 100.0,
+                glyphs: vec![glyph('a', 0.0, 0.0, 10.0, 10.0)],
+                dropped_glyphs: 1,
+            },
+        ));
+        let generation = engine
+            .submit(
+                pdf,
+                "alpha",
+                Arc::new(ContainsMatcher {
+                    case_sensitive: false,
+                }),
+            )
+            .expect("submit should succeed");
+
+        let (hits, highlight_unavailable) = wait_for_completed_hits(&mut engine, generation);
+        assert_eq!(hits.len(), 1);
         assert!(hits[0].occurrences.is_empty());
         assert!(highlight_unavailable);
     }

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -347,6 +347,9 @@ pub(crate) fn locate_occurrences(
     let mut occurrences =
         locate_occurrences_with_strategy(glyphs, prepared_query, case_sensitive, false);
 
+    // `SearchOccurrence` dedups by `(glyph_start, glyph_end)` because
+    // locate_occurrences_with_strategy/merge_occurrence_rects are pure for a glyph slice; keep it
+    // that way and avoid adding path-dependent fields that would make equal ranges diverge.
     for occurrence in locate_occurrences_with_strategy(glyphs, prepared_query, case_sensitive, true)
     {
         let duplicate = occurrences.iter().any(|existing| {
@@ -392,6 +395,9 @@ fn locate_occurrences_with_strategy(
 
     let mut occurrences = Vec::new();
     let mut cursor = 0;
+    // Matches are intentionally non-overlapping "find in page" hits: after matching
+    // `search_chars[cursor..cursor + query_len]` against `query_chars`, we advance `cursor` by
+    // `query_len`, so overlapping occurrences are skipped by design.
     while cursor + query_len <= search_chars.len() {
         if search_chars[cursor..cursor + query_len] == query_chars[..] {
             let glyph_start = char_map[cursor];
@@ -404,6 +410,8 @@ fn locate_occurrences_with_strategy(
                     rects,
                 });
             }
+            // Empty rects can come from all-whitespace glyph slices; we intentionally drop that
+            // occurrence and still advance the cursor, leaving highlight_unavailable to the caller.
             cursor += query_len;
         } else {
             cursor += 1;

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -284,16 +284,11 @@ fn run_job(
         if job.matcher.matches_page(&text, &query) {
             let occurrences = match doc.extract_positioned_text(page) {
                 Ok(text_page) => {
-                    if text_page.dropped_glyphs > 0 {
+                    let occurrences = job.matcher.locate_matches(&text_page, &query);
+                    if occurrences.is_empty() {
                         highlight_unavailable = true;
-                        Vec::new()
-                    } else {
-                        let occurrences = job.matcher.locate_matches(&text_page, &query);
-                        if occurrences.is_empty() {
-                            highlight_unavailable = true;
-                        }
-                        occurrences
                     }
+                    occurrences
                 }
                 Err(_) => {
                     highlight_unavailable = true;

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -377,6 +377,7 @@ fn locate_occurrences_with_strategy(
         return Vec::new();
     }
 
+    // `prepared_query` already has case handling applied by prepare_query/prepare_contains_query.
     let query_text = normalize_text_for_search(prepared_query, true, ignore_whitespace);
     if query_text.is_empty() {
         return Vec::new();

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -51,6 +51,25 @@ pub trait SearchMatcher: Send + Sync {
     fn locate_matches(&self, page: &TextPage, prepared_query: &str) -> Vec<SearchOccurrence>;
 }
 
+pub(crate) fn prepare_contains_query(raw_query: &str, case_sensitive: bool) -> String {
+    normalize_text_for_search(raw_query, case_sensitive, false)
+}
+
+pub(crate) fn page_matches_contains(
+    page_text: &str,
+    prepared_query: &str,
+    case_sensitive: bool,
+) -> bool {
+    let prepared_page = normalize_text_for_search(page_text, case_sensitive, false);
+    if prepared_page.contains(prepared_query) {
+        return true;
+    }
+
+    let whitespace_insensitive_page = normalize_text_for_search(page_text, case_sensitive, true);
+    let whitespace_insensitive_query = normalize_text_for_search(prepared_query, true, true);
+    whitespace_insensitive_page.contains(&whitespace_insensitive_query)
+}
+
 #[derive(Clone)]
 struct SearchJob {
     generation: u64,
@@ -284,6 +303,9 @@ fn run_job(
         if job.matcher.matches_page(&text, &query) {
             let occurrences = match doc.extract_positioned_text(page) {
                 Ok(text_page) => {
+                    if text_page.dropped_glyphs > 0 {
+                        highlight_unavailable = true;
+                    }
                     let occurrences = job.matcher.locate_matches(&text_page, &query);
                     if occurrences.is_empty() {
                         highlight_unavailable = true;
@@ -349,31 +371,13 @@ fn locate_occurrences_with_strategy(
         return Vec::new();
     }
 
-    let mut search_text = String::new();
-    let mut char_map = Vec::new();
-    for (glyph_index, glyph) in glyphs.iter().enumerate() {
-        if ignore_whitespace && glyph.ch.is_whitespace() {
-            continue;
-        }
-        let normalized = normalize_char(glyph.ch, case_sensitive);
-        if !ignore_whitespace || !normalized.is_whitespace() {
-            search_text.push(normalized);
-            char_map.push(glyph_index);
-        }
-    }
-
+    let (search_text, char_map) =
+        normalize_glyphs_for_search(glyphs, case_sensitive, ignore_whitespace);
     if search_text.is_empty() {
         return Vec::new();
     }
 
-    let query_text = if ignore_whitespace {
-        prepared_query
-            .chars()
-            .filter(|ch| !ch.is_whitespace())
-            .collect::<String>()
-    } else {
-        prepared_query.to_string()
-    };
+    let query_text = normalize_text_for_search(prepared_query, true, ignore_whitespace);
     if query_text.is_empty() {
         return Vec::new();
     }
@@ -406,6 +410,29 @@ fn locate_occurrences_with_strategy(
     }
 
     occurrences
+}
+
+fn normalize_glyphs_for_search(
+    glyphs: &[TextGlyph],
+    case_sensitive: bool,
+    ignore_whitespace: bool,
+) -> (String, Vec<usize>) {
+    let mut search_text = String::new();
+    let mut char_map = Vec::new();
+
+    for (glyph_index, glyph) in glyphs.iter().enumerate() {
+        if ignore_whitespace && glyph.ch.is_whitespace() {
+            continue;
+        }
+        for normalized in normalize_chars(glyph.ch, case_sensitive) {
+            if !ignore_whitespace || !normalized.is_whitespace() {
+                search_text.push(normalized);
+                char_map.push(glyph_index);
+            }
+        }
+    }
+
+    (search_text, char_map)
 }
 
 fn merge_occurrence_rects(glyphs: &[TextGlyph]) -> Vec<PdfRect> {
@@ -532,12 +559,19 @@ fn median_rect_extent(glyphs: &[&TextGlyph], extent: RectExtent) -> f32 {
     values[values.len() / 2]
 }
 
-fn normalize_char(ch: char, case_sensitive: bool) -> char {
+fn normalize_chars(ch: char, case_sensitive: bool) -> Vec<char> {
     if case_sensitive {
-        ch
+        vec![ch]
     } else {
-        ch.to_lowercase().next().unwrap_or(ch)
+        ch.to_lowercase().collect()
     }
+}
+
+fn normalize_text_for_search(text: &str, case_sensitive: bool, ignore_whitespace: bool) -> String {
+    text.chars()
+        .flat_map(|ch| normalize_chars(ch, case_sensitive))
+        .filter(|ch| !ignore_whitespace || !ch.is_whitespace())
+        .collect()
 }
 
 fn flush_requests(
@@ -580,7 +614,7 @@ mod tests {
 
     use super::{
         SearchEngine, SearchEvent, SearchMatcher, SearchOccurrence, SearchPageHit,
-        locate_occurrences, merge_occurrence_rects,
+        locate_occurrences, merge_occurrence_rects, page_matches_contains, prepare_contains_query,
     };
     use crate::backend::open_default_backend;
     use crate::backend::{OutlineNode, PdfBackend, PdfRect, RgbaFrame, TextGlyph, TextPage};
@@ -593,34 +627,11 @@ mod tests {
 
     impl SearchMatcher for ContainsMatcher {
         fn prepare_query(&self, raw_query: &str) -> String {
-            if self.case_sensitive {
-                raw_query.to_string()
-            } else {
-                raw_query.to_lowercase()
-            }
+            prepare_contains_query(raw_query, self.case_sensitive)
         }
 
         fn matches_page(&self, page_text: &str, prepared_query: &str) -> bool {
-            let prepared_page = if self.case_sensitive {
-                page_text.to_string()
-            } else {
-                page_text.to_lowercase()
-            };
-
-            if prepared_page.contains(prepared_query) {
-                return true;
-            }
-
-            prepared_page
-                .chars()
-                .filter(|ch| !ch.is_whitespace())
-                .collect::<String>()
-                .contains(
-                    &prepared_query
-                        .chars()
-                        .filter(|ch| !ch.is_whitespace())
-                        .collect::<String>(),
-                )
+            page_matches_contains(page_text, prepared_query, self.case_sensitive)
         }
 
         fn locate_matches(&self, page: &TextPage, prepared_query: &str) -> Vec<SearchOccurrence> {
@@ -936,6 +947,40 @@ mod tests {
     }
 
     #[test]
+    fn search_marks_highlight_unavailable_when_dropped_glyphs_and_occurrences_exist() {
+        let mut engine = SearchEngine::new();
+        let pdf: Arc<dyn PdfBackend> = Arc::new(SearchPositionedStubPdf::new(
+            "alpha beta",
+            TextPage {
+                width_pt: 100.0,
+                height_pt: 100.0,
+                glyphs: vec![
+                    glyph('a', 0.0, 0.0, 10.0, 10.0),
+                    glyph('l', 10.0, 0.0, 20.0, 10.0),
+                    glyph('p', 20.0, 0.0, 30.0, 10.0),
+                    glyph('h', 30.0, 0.0, 40.0, 10.0),
+                    glyph('a', 40.0, 0.0, 50.0, 10.0),
+                ],
+                dropped_glyphs: 1,
+            },
+        ));
+        let generation = engine
+            .submit(
+                pdf,
+                "alpha",
+                Arc::new(ContainsMatcher {
+                    case_sensitive: false,
+                }),
+            )
+            .expect("submit should succeed");
+
+        let (hits, highlight_unavailable) = wait_for_completed_hits(&mut engine, generation);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].occurrences.len(), 1);
+        assert!(highlight_unavailable);
+    }
+
+    #[test]
     fn merge_occurrence_rects_merges_same_line_with_spaces() {
         let glyphs = vec![
             glyph('a', 10.0, 20.0, 18.0, 32.0),
@@ -1075,6 +1120,17 @@ mod tests {
         assert_eq!(occurrences[0].glyph_end, 5);
         assert_eq!(occurrences[1].glyph_start, 7);
         assert_eq!(occurrences[1].glyph_end, 13);
+    }
+
+    #[test]
+    fn locate_occurrences_preserves_multi_char_lowercase_expansion() {
+        let glyphs = vec![glyph('İ', 10.0, 20.0, 18.0, 32.0)];
+
+        let occurrences = locate_occurrences(&glyphs, "i\u{307}", false);
+
+        assert_eq!(occurrences.len(), 1);
+        assert_eq!(occurrences[0].glyph_start, 0);
+        assert_eq!(occurrences[0].glyph_end, 0);
     }
 
     fn wait_for_completed_hits(

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -24,6 +24,7 @@ pub enum SearchEvent {
     Completed {
         generation: u64,
         hits: Vec<SearchPageHit>,
+        highlight_unavailable: bool,
     },
     Failed {
         generation: u64,
@@ -44,6 +45,7 @@ pub struct SearchPageHit {
 
 pub trait SearchMatcher: Send + Sync {
     fn prepare_query(&self, raw_query: &str) -> String;
+    fn matches_page(&self, page_text: &str, prepared_query: &str) -> bool;
     fn locate_matches(&self, page: &TextPage, prepared_query: &str) -> Vec<SearchOccurrence>;
 }
 
@@ -179,6 +181,10 @@ impl SearchMatcher for CancelMatcher {
         String::new()
     }
 
+    fn matches_page(&self, _page_text: &str, _prepared_query: &str) -> bool {
+        false
+    }
+
     fn locate_matches(&self, _page: &TextPage, _prepared_query: &str) -> Vec<SearchOccurrence> {
         Vec::new()
     }
@@ -241,6 +247,7 @@ fn run_job(
         let _ = event_tx.send(SearchEvent::Completed {
             generation: job.generation,
             hits: Vec::new(),
+            highlight_unavailable: false,
         });
         return WorkerControl::Continue;
     }
@@ -250,6 +257,7 @@ fn run_job(
     let total_pages = doc.page_count();
 
     let mut hits = Vec::new();
+    let mut highlight_unavailable = false;
     for page in 0..total_pages {
         match flush_requests(request_rx, pending) {
             WorkerControl::Continue => {
@@ -260,8 +268,8 @@ fn run_job(
             WorkerControl::Shutdown => return WorkerControl::Shutdown,
         }
 
-        let text_page = match doc.extract_text_page(page) {
-            Ok(text_page) => text_page,
+        let text = match doc.extract_text(page) {
+            Ok(text) => text,
             Err(err) => {
                 let _ = event_tx.send(SearchEvent::Failed {
                     generation: job.generation,
@@ -271,8 +279,14 @@ fn run_job(
             }
         };
 
-        let occurrences = job.matcher.locate_matches(&text_page, &query);
-        if !occurrences.is_empty() {
+        if job.matcher.matches_page(&text, &query) {
+            let occurrences = match doc.extract_positioned_text(page) {
+                Ok(text_page) => job.matcher.locate_matches(&text_page, &query),
+                Err(_) => {
+                    highlight_unavailable = true;
+                    Vec::new()
+                }
+            };
             hits.push(SearchPageHit { page, occurrences });
         }
 
@@ -290,6 +304,7 @@ fn run_job(
     let _ = event_tx.send(SearchEvent::Completed {
         generation: job.generation,
         hits,
+        highlight_unavailable,
     });
     WorkerControl::Continue
 }
@@ -534,6 +549,7 @@ enum RectExtent {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::path::Path;
     use std::path::PathBuf;
     use std::process;
     use std::sync::Arc;
@@ -545,7 +561,8 @@ mod tests {
         locate_occurrences, merge_occurrence_rects,
     };
     use crate::backend::open_default_backend;
-    use crate::backend::{PdfRect, TextGlyph, TextPage};
+    use crate::backend::{OutlineNode, PdfBackend, PdfRect, RgbaFrame, TextGlyph, TextPage};
+    use crate::error::{AppError, AppResult};
 
     #[derive(Debug)]
     struct ContainsMatcher {
@@ -561,8 +578,79 @@ mod tests {
             }
         }
 
+        fn matches_page(&self, page_text: &str, prepared_query: &str) -> bool {
+            let prepared_page = if self.case_sensitive {
+                page_text.to_string()
+            } else {
+                page_text.to_lowercase()
+            };
+
+            if prepared_page.contains(prepared_query) {
+                return true;
+            }
+
+            prepared_page
+                .chars()
+                .filter(|ch| !ch.is_whitespace())
+                .collect::<String>()
+                .contains(
+                    &prepared_query
+                        .chars()
+                        .filter(|ch| !ch.is_whitespace())
+                        .collect::<String>(),
+                )
+        }
+
         fn locate_matches(&self, page: &TextPage, prepared_query: &str) -> Vec<SearchOccurrence> {
             locate_occurrences(&page.glyphs, prepared_query, self.case_sensitive)
+        }
+    }
+
+    struct SearchOnlyStubPdf {
+        path: PathBuf,
+        text: String,
+    }
+
+    impl SearchOnlyStubPdf {
+        fn new(text: &str) -> Self {
+            Self {
+                path: PathBuf::from("search-only.pdf"),
+                text: text.to_string(),
+            }
+        }
+    }
+
+    impl PdfBackend for SearchOnlyStubPdf {
+        fn path(&self) -> &Path {
+            &self.path
+        }
+
+        fn doc_id(&self) -> u64 {
+            42
+        }
+
+        fn page_count(&self) -> usize {
+            1
+        }
+
+        fn page_dimensions(&self, _page: usize) -> AppResult<(f32, f32)> {
+            Ok((100.0, 100.0))
+        }
+
+        fn render_page(&self, _page: usize, _scale: f32) -> AppResult<RgbaFrame> {
+            Err(AppError::unsupported("not needed in search test"))
+        }
+
+        fn extract_text(&self, _page: usize) -> AppResult<String> {
+            Ok(self.text.clone())
+        }
+
+        fn extract_positioned_text(&self, _page: usize) -> AppResult<TextPage> {
+            Err(AppError::unsupported("positioned text unavailable"))
+        }
+
+        fn extract_outline(&self) -> AppResult<Vec<OutlineNode>> {
+            Err(AppError::unsupported("not needed in search test"))
         }
     }
 
@@ -617,7 +705,7 @@ mod tests {
         let cancel_generation = engine.cancel(pdf).expect("cancel should succeed");
 
         assert_eq!(cancel_generation, running_generation + 1);
-        let hits = wait_for_completed_hits(&mut engine, cancel_generation);
+        let (hits, _) = wait_for_completed_hits(&mut engine, cancel_generation);
         assert!(hits.is_empty());
 
         fs::remove_file(&file).expect("test file should be removed");
@@ -641,7 +729,7 @@ mod tests {
             )
             .expect("submit should succeed");
 
-        let hits = wait_for_completed_hits(&mut engine, generation);
+        let (hits, _) = wait_for_completed_hits(&mut engine, generation);
         assert_eq!(hit_pages(&hits), vec![0, 1]);
 
         fs::remove_file(&file).expect("test file should be removed");
@@ -665,7 +753,7 @@ mod tests {
             )
             .expect("submit should succeed");
 
-        let hits = wait_for_completed_hits(&mut engine, generation);
+        let (hits, _) = wait_for_completed_hits(&mut engine, generation);
         assert_eq!(hit_pages(&hits), vec![1]);
 
         fs::remove_file(&file).expect("test file should be removed");
@@ -692,10 +780,31 @@ mod tests {
             )
             .expect("submit should succeed");
 
-        let hits = wait_for_completed_hits(&mut engine, generation);
+        let (hits, _) = wait_for_completed_hits(&mut engine, generation);
         assert_eq!(hit_pages(&hits), vec![0]);
 
         fs::remove_file(&file).expect("test file should be removed");
+    }
+
+    #[test]
+    fn search_keeps_hit_pages_when_positioned_text_is_unavailable() {
+        let mut engine = SearchEngine::new();
+        let pdf: Arc<dyn PdfBackend> = Arc::new(SearchOnlyStubPdf::new("alpha beta"));
+        let generation = engine
+            .submit(
+                pdf,
+                "alpha",
+                Arc::new(ContainsMatcher {
+                    case_sensitive: false,
+                }),
+            )
+            .expect("submit should succeed");
+
+        let (hits, highlight_unavailable) = wait_for_completed_hits(&mut engine, generation);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].page, 0);
+        assert!(hits[0].occurrences.is_empty());
+        assert!(highlight_unavailable);
     }
 
     #[test]
@@ -812,7 +921,10 @@ mod tests {
         );
     }
 
-    fn wait_for_completed_hits(engine: &mut SearchEngine, generation: u64) -> Vec<SearchPageHit> {
+    fn wait_for_completed_hits(
+        engine: &mut SearchEngine,
+        generation: u64,
+    ) -> (Vec<SearchPageHit>, bool) {
         let timeout = Duration::from_secs(3);
         let start = Instant::now();
 
@@ -821,10 +933,11 @@ mod tests {
                 if let SearchEvent::Completed {
                     generation: event_generation,
                     hits,
+                    highlight_unavailable,
                 } = event
                     && event_generation == generation
                 {
-                    return hits;
+                    return (hits, highlight_unavailable);
                 }
             }
 

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc::{
 };
 use tokio::task::JoinHandle;
 
-use crate::backend::SharedPdfBackend;
+use crate::backend::{PdfRect, SharedPdfBackend, TextGlyph, TextPage};
 use crate::error::{AppError, AppResult};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -18,16 +18,33 @@ pub struct SearchSnapshot {
     pub done: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SearchEvent {
     Snapshot(SearchSnapshot),
-    Completed { generation: u64, hits: Vec<usize> },
-    Failed { generation: u64, message: String },
+    Completed {
+        generation: u64,
+        hits: Vec<SearchPageHit>,
+    },
+    Failed {
+        generation: u64,
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SearchOccurrence {
+    pub rects: Vec<PdfRect>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SearchPageHit {
+    pub page: usize,
+    pub occurrences: Vec<SearchOccurrence>,
 }
 
 pub trait SearchMatcher: Send + Sync {
     fn prepare_query(&self, raw_query: &str) -> String;
-    fn matches_page(&self, page_text: &str, prepared_query: &str) -> bool;
+    fn locate_matches(&self, page: &TextPage, prepared_query: &str) -> Vec<SearchOccurrence>;
 }
 
 #[derive(Clone)]
@@ -162,8 +179,8 @@ impl SearchMatcher for CancelMatcher {
         String::new()
     }
 
-    fn matches_page(&self, _page_text: &str, _prepared_query: &str) -> bool {
-        false
+    fn locate_matches(&self, _page: &TextPage, _prepared_query: &str) -> Vec<SearchOccurrence> {
+        Vec::new()
     }
 }
 
@@ -243,8 +260,8 @@ fn run_job(
             WorkerControl::Shutdown => return WorkerControl::Shutdown,
         }
 
-        let text = match doc.extract_text(page) {
-            Ok(text) => text,
+        let text_page = match doc.extract_text_page(page) {
+            Ok(text_page) => text_page,
             Err(err) => {
                 let _ = event_tx.send(SearchEvent::Failed {
                     generation: job.generation,
@@ -254,8 +271,9 @@ fn run_job(
             }
         };
 
-        if job.matcher.matches_page(&text, &query) {
-            hits.push(page);
+        let occurrences = job.matcher.locate_matches(&text_page, &query);
+        if !occurrences.is_empty() {
+            hits.push(SearchPageHit { page, occurrences });
         }
 
         let scanned_pages = page + 1;
@@ -276,6 +294,215 @@ fn run_job(
     WorkerControl::Continue
 }
 
+pub(crate) fn locate_occurrences(
+    glyphs: &[TextGlyph],
+    prepared_query: &str,
+    case_sensitive: bool,
+) -> Vec<SearchOccurrence> {
+    let direct = locate_occurrences_with_strategy(glyphs, prepared_query, case_sensitive, false);
+    if !direct.is_empty() {
+        return direct;
+    }
+    locate_occurrences_with_strategy(glyphs, prepared_query, case_sensitive, true)
+}
+
+fn locate_occurrences_with_strategy(
+    glyphs: &[TextGlyph],
+    prepared_query: &str,
+    case_sensitive: bool,
+    ignore_whitespace: bool,
+) -> Vec<SearchOccurrence> {
+    if prepared_query.is_empty() {
+        return Vec::new();
+    }
+
+    let mut search_text = String::new();
+    let mut char_map = Vec::new();
+    for (glyph_index, glyph) in glyphs.iter().enumerate() {
+        if ignore_whitespace && glyph.ch.is_whitespace() {
+            continue;
+        }
+        let normalized = normalize_char(glyph.ch, case_sensitive);
+        if !ignore_whitespace || !normalized.is_whitespace() {
+            search_text.push(normalized);
+            char_map.push(glyph_index);
+        }
+    }
+
+    if search_text.is_empty() {
+        return Vec::new();
+    }
+
+    let query_text = if ignore_whitespace {
+        prepared_query
+            .chars()
+            .filter(|ch| !ch.is_whitespace())
+            .collect::<String>()
+    } else {
+        prepared_query.to_string()
+    };
+    if query_text.is_empty() {
+        return Vec::new();
+    }
+
+    let search_chars: Vec<char> = search_text.chars().collect();
+    let query_chars: Vec<char> = query_text.chars().collect();
+    let query_len = query_chars.len();
+    if query_len == 0 || query_len > search_chars.len() {
+        return Vec::new();
+    }
+
+    let mut occurrences = Vec::new();
+    let mut cursor = 0;
+    while cursor + query_len <= search_chars.len() {
+        if search_chars[cursor..cursor + query_len] == query_chars[..] {
+            let glyph_start = char_map[cursor];
+            let glyph_end = char_map[cursor + query_len - 1];
+            let rects = merge_occurrence_rects(&glyphs[glyph_start..=glyph_end]);
+            if !rects.is_empty() {
+                occurrences.push(SearchOccurrence { rects });
+            }
+            cursor += query_len;
+        } else {
+            cursor += 1;
+        }
+    }
+
+    occurrences
+}
+
+fn merge_occurrence_rects(glyphs: &[TextGlyph]) -> Vec<PdfRect> {
+    let glyphs: Vec<&TextGlyph> = glyphs
+        .iter()
+        .filter(|glyph| !glyph.ch.is_whitespace())
+        .collect();
+    if glyphs.is_empty() {
+        return Vec::new();
+    }
+
+    let merge_axis = infer_merge_axis(&glyphs);
+    let median_width = median_rect_extent(&glyphs, RectExtent::Width);
+    let median_height = median_rect_extent(&glyphs, RectExtent::Height);
+    let mut rects = Vec::new();
+    let mut current = glyphs[0].bbox;
+
+    for glyph in glyphs.iter().skip(1) {
+        if belongs_to_run(current, glyph.bbox, merge_axis, median_width, median_height) {
+            current = union_rects(current, glyph.bbox);
+        } else {
+            rects.push(current);
+            current = glyph.bbox;
+        }
+    }
+
+    rects.push(current);
+    rects
+}
+
+// Choose the screen-space axis used to merge highlight rectangles.
+// This is not a writing-mode detector: rotated horizontal text may still merge
+// on the vertical axis if that better matches the glyph layout on the page.
+fn infer_merge_axis(glyphs: &[&TextGlyph]) -> MergeAxis {
+    let mut horizontal_score = 0.0f32;
+    let mut vertical_score = 0.0f32;
+
+    for pair in glyphs.windows(2) {
+        let [left, right] = pair else {
+            continue;
+        };
+        horizontal_score +=
+            overlap_ratio_1d(left.bbox.y0, left.bbox.y1, right.bbox.y0, right.bbox.y1);
+        vertical_score +=
+            overlap_ratio_1d(left.bbox.x0, left.bbox.x1, right.bbox.x0, right.bbox.x1);
+    }
+
+    if vertical_score > horizontal_score {
+        MergeAxis::Vertical
+    } else {
+        MergeAxis::Horizontal
+    }
+}
+
+fn belongs_to_run(
+    current: PdfRect,
+    next: PdfRect,
+    merge_axis: MergeAxis,
+    median_width: f32,
+    median_height: f32,
+) -> bool {
+    match merge_axis {
+        MergeAxis::Horizontal => {
+            let same_band = overlap_ratio_1d(current.y0, current.y1, next.y0, next.y1) >= 0.45
+                || center_distance(current.y0, current.y1, next.y0, next.y1)
+                    <= median_height * 0.35;
+            let gap_ok =
+                interval_gap(current.x0, current.x1, next.x0, next.x1) <= median_width * 4.0;
+            same_band && gap_ok
+        }
+        MergeAxis::Vertical => {
+            let same_band = overlap_ratio_1d(current.x0, current.x1, next.x0, next.x1) >= 0.45
+                || center_distance(current.x0, current.x1, next.x0, next.x1) <= median_width * 0.35;
+            let gap_ok =
+                interval_gap(current.y0, current.y1, next.y0, next.y1) <= median_height * 4.0;
+            same_band && gap_ok
+        }
+    }
+}
+
+fn overlap_ratio_1d(a0: f32, a1: f32, b0: f32, b1: f32) -> f32 {
+    let overlap = (a1.min(b1) - a0.max(b0)).max(0.0);
+    let min_extent = (a1 - a0).abs().min((b1 - b0).abs()).max(1e-3);
+    overlap / min_extent
+}
+
+fn center_distance(a0: f32, a1: f32, b0: f32, b1: f32) -> f32 {
+    (((a0 + a1) * 0.5) - ((b0 + b1) * 0.5)).abs()
+}
+
+fn interval_gap(a0: f32, a1: f32, b0: f32, b1: f32) -> f32 {
+    if b0 > a1 {
+        b0 - a1
+    } else if a0 > b1 {
+        a0 - b1
+    } else {
+        0.0
+    }
+}
+
+fn union_rects(left: PdfRect, right: PdfRect) -> PdfRect {
+    PdfRect {
+        x0: left.x0.min(right.x0),
+        y0: left.y0.min(right.y0),
+        x1: left.x1.max(right.x1),
+        y1: left.y1.max(right.y1),
+    }
+}
+
+fn median_rect_extent(glyphs: &[&TextGlyph], extent: RectExtent) -> f32 {
+    let mut values: Vec<f32> = glyphs
+        .iter()
+        .map(|glyph| match extent {
+            RectExtent::Width => glyph.bbox.width(),
+            RectExtent::Height => glyph.bbox.height(),
+        })
+        .filter(|value| *value > 0.0)
+        .collect();
+    if values.is_empty() {
+        return 1.0;
+    }
+
+    values.sort_by(|left, right| left.total_cmp(right));
+    values[values.len() / 2]
+}
+
+fn normalize_char(ch: char, case_sensitive: bool) -> char {
+    if case_sensitive {
+        ch
+    } else {
+        ch.to_lowercase().next().unwrap_or(ch)
+    }
+}
+
 fn flush_requests(
     request_rx: &mut UnboundedReceiver<WorkerRequest>,
     pending: &mut Option<SearchJob>,
@@ -292,6 +519,18 @@ fn flush_requests(
     WorkerControl::Continue
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MergeAxis {
+    Horizontal,
+    Vertical,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RectExtent {
+    Width,
+    Height,
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
@@ -301,8 +540,12 @@ mod tests {
     use std::thread;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-    use super::{SearchEngine, SearchEvent, SearchMatcher};
+    use super::{
+        SearchEngine, SearchEvent, SearchMatcher, SearchOccurrence, SearchPageHit,
+        locate_occurrences, merge_occurrence_rects,
+    };
     use crate::backend::open_default_backend;
+    use crate::backend::{PdfRect, TextGlyph, TextPage};
 
     #[derive(Debug)]
     struct ContainsMatcher {
@@ -318,23 +561,9 @@ mod tests {
             }
         }
 
-        fn matches_page(&self, page_text: &str, prepared_query: &str) -> bool {
-            let prepared_page = if self.case_sensitive {
-                page_text.to_string()
-            } else {
-                page_text.to_lowercase()
-            };
-
-            if prepared_page.contains(prepared_query) {
-                return true;
-            }
-
-            remove_whitespace(&prepared_page).contains(&remove_whitespace(prepared_query))
+        fn locate_matches(&self, page: &TextPage, prepared_query: &str) -> Vec<SearchOccurrence> {
+            locate_occurrences(&page.glyphs, prepared_query, self.case_sensitive)
         }
-    }
-
-    fn remove_whitespace(input: &str) -> String {
-        input.chars().filter(|ch| !ch.is_whitespace()).collect()
     }
 
     #[test]
@@ -413,7 +642,7 @@ mod tests {
             .expect("submit should succeed");
 
         let hits = wait_for_completed_hits(&mut engine, generation);
-        assert_eq!(hits, vec![0, 1]);
+        assert_eq!(hit_pages(&hits), vec![0, 1]);
 
         fs::remove_file(&file).expect("test file should be removed");
     }
@@ -437,7 +666,7 @@ mod tests {
             .expect("submit should succeed");
 
         let hits = wait_for_completed_hits(&mut engine, generation);
-        assert_eq!(hits, vec![1]);
+        assert_eq!(hit_pages(&hits), vec![1]);
 
         fs::remove_file(&file).expect("test file should be removed");
     }
@@ -464,12 +693,126 @@ mod tests {
             .expect("submit should succeed");
 
         let hits = wait_for_completed_hits(&mut engine, generation);
-        assert_eq!(hits, vec![0]);
+        assert_eq!(hit_pages(&hits), vec![0]);
 
         fs::remove_file(&file).expect("test file should be removed");
     }
 
-    fn wait_for_completed_hits(engine: &mut SearchEngine, generation: u64) -> Vec<usize> {
+    #[test]
+    fn merge_occurrence_rects_merges_same_line_with_spaces() {
+        let glyphs = vec![
+            glyph('a', 10.0, 20.0, 18.0, 32.0),
+            glyph('b', 20.0, 20.0, 28.0, 32.0),
+            glyph(' ', 29.0, 20.0, 33.0, 32.0),
+            glyph('c', 34.0, 20.0, 42.0, 32.0),
+            glyph('d', 44.0, 20.0, 52.0, 32.0),
+        ];
+
+        let rects = merge_occurrence_rects(&glyphs);
+
+        assert_eq!(rects.len(), 1);
+        assert_eq!(
+            rects[0],
+            PdfRect {
+                x0: 10.0,
+                y0: 20.0,
+                x1: 52.0,
+                y1: 32.0
+            }
+        );
+    }
+
+    #[test]
+    fn merge_occurrence_rects_splits_wrapped_horizontal_lines() {
+        let glyphs = vec![
+            glyph('a', 10.0, 20.0, 18.0, 32.0),
+            glyph('b', 20.0, 20.0, 28.0, 32.0),
+            glyph('c', 30.0, 20.0, 38.0, 32.0),
+            glyph('d', 10.0, 36.0, 18.0, 48.0),
+            glyph('e', 20.0, 36.0, 28.0, 48.0),
+            glyph('f', 30.0, 36.0, 38.0, 48.0),
+        ];
+
+        let rects = merge_occurrence_rects(&glyphs);
+
+        assert_eq!(rects.len(), 2);
+        assert_eq!(
+            rects[0],
+            PdfRect {
+                x0: 10.0,
+                y0: 20.0,
+                x1: 38.0,
+                y1: 32.0
+            }
+        );
+        assert_eq!(
+            rects[1],
+            PdfRect {
+                x0: 10.0,
+                y0: 36.0,
+                x1: 38.0,
+                y1: 48.0
+            }
+        );
+    }
+
+    #[test]
+    fn merge_occurrence_rects_merges_vertical_column() {
+        let glyphs = vec![
+            glyph('縦', 80.0, 10.0, 92.0, 22.0),
+            glyph('書', 80.0, 24.0, 92.0, 36.0),
+            glyph('き', 80.0, 38.0, 92.0, 50.0),
+        ];
+
+        let rects = merge_occurrence_rects(&glyphs);
+
+        assert_eq!(rects.len(), 1);
+        assert_eq!(
+            rects[0],
+            PdfRect {
+                x0: 80.0,
+                y0: 10.0,
+                x1: 92.0,
+                y1: 50.0
+            }
+        );
+    }
+
+    #[test]
+    fn merge_occurrence_rects_splits_wrapped_vertical_columns() {
+        let glyphs = vec![
+            glyph('縦', 80.0, 10.0, 92.0, 22.0),
+            glyph('書', 80.0, 24.0, 92.0, 36.0),
+            glyph('き', 80.0, 38.0, 92.0, 50.0),
+            glyph('折', 62.0, 10.0, 74.0, 22.0),
+            glyph('返', 62.0, 24.0, 74.0, 36.0),
+            glyph('し', 62.0, 38.0, 74.0, 50.0),
+        ];
+
+        let rects = merge_occurrence_rects(&glyphs);
+
+        assert_eq!(rects.len(), 2);
+        assert_eq!(
+            rects[0],
+            PdfRect {
+                x0: 80.0,
+                y0: 10.0,
+                x1: 92.0,
+                y1: 50.0
+            }
+        );
+        assert_eq!(
+            rects[1],
+            PdfRect {
+                x0: 62.0,
+                y0: 10.0,
+                x1: 74.0,
+                y1: 50.0
+            }
+        );
+    }
+
+    fn wait_for_completed_hits(engine: &mut SearchEngine, generation: u64) -> Vec<SearchPageHit> {
         let timeout = Duration::from_secs(3);
         let start = Instant::now();
 
@@ -490,6 +833,17 @@ mod tests {
                 "timed out waiting for search completion"
             );
             thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    fn hit_pages(hits: &[SearchPageHit]) -> Vec<usize> {
+        hits.iter().map(|hit| hit.page).collect()
+    }
+
+    fn glyph(ch: char, x0: f32, y0: f32, x1: f32, y1: f32) -> TextGlyph {
+        TextGlyph {
+            ch,
+            bbox: PdfRect { x0, y0, x1, y1 },
         }
     }
 

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -34,6 +34,8 @@ pub enum SearchEvent {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SearchOccurrence {
+    pub glyph_start: usize,
+    pub glyph_end: usize,
     pub rects: Vec<PdfRect>,
 }
 
@@ -325,11 +327,21 @@ pub(crate) fn locate_occurrences(
     prepared_query: &str,
     case_sensitive: bool,
 ) -> Vec<SearchOccurrence> {
-    let direct = locate_occurrences_with_strategy(glyphs, prepared_query, case_sensitive, false);
-    if !direct.is_empty() {
-        return direct;
+    let mut occurrences =
+        locate_occurrences_with_strategy(glyphs, prepared_query, case_sensitive, false);
+
+    for occurrence in locate_occurrences_with_strategy(glyphs, prepared_query, case_sensitive, true)
+    {
+        let duplicate = occurrences.iter().any(|existing| {
+            existing.glyph_start == occurrence.glyph_start
+                && existing.glyph_end == occurrence.glyph_end
+        });
+        if !duplicate {
+            occurrences.push(occurrence);
+        }
     }
-    locate_occurrences_with_strategy(glyphs, prepared_query, case_sensitive, true)
+
+    occurrences
 }
 
 fn locate_occurrences_with_strategy(
@@ -386,7 +398,11 @@ fn locate_occurrences_with_strategy(
             let glyph_end = char_map[cursor + query_len - 1];
             let rects = merge_occurrence_rects(&glyphs[glyph_start..=glyph_end]);
             if !rects.is_empty() {
-                occurrences.push(SearchOccurrence { rects });
+                occurrences.push(SearchOccurrence {
+                    glyph_start,
+                    glyph_end,
+                    rects,
+                });
             }
             cursor += query_len;
         } else {
@@ -1036,6 +1052,34 @@ mod tests {
                 y1: 50.0
             }
         );
+    }
+
+    #[test]
+    fn locate_occurrences_keeps_direct_and_whitespace_insensitive_matches() {
+        let glyphs = vec![
+            glyph('f', 10.0, 20.0, 18.0, 32.0),
+            glyph('o', 20.0, 20.0, 28.0, 32.0),
+            glyph('o', 30.0, 20.0, 38.0, 32.0),
+            glyph('b', 40.0, 20.0, 48.0, 32.0),
+            glyph('a', 50.0, 20.0, 58.0, 32.0),
+            glyph('r', 60.0, 20.0, 68.0, 32.0),
+            glyph(' ', 70.0, 20.0, 74.0, 32.0),
+            glyph('f', 80.0, 20.0, 88.0, 32.0),
+            glyph('o', 90.0, 20.0, 98.0, 32.0),
+            glyph('o', 100.0, 20.0, 108.0, 32.0),
+            glyph(' ', 110.0, 20.0, 114.0, 32.0),
+            glyph('b', 120.0, 20.0, 128.0, 32.0),
+            glyph('a', 130.0, 20.0, 138.0, 32.0),
+            glyph('r', 140.0, 20.0, 148.0, 32.0),
+        ];
+
+        let occurrences = locate_occurrences(&glyphs, "foobar", false);
+
+        assert_eq!(occurrences.len(), 2);
+        assert_eq!(occurrences[0].glyph_start, 0);
+        assert_eq!(occurrences[0].glyph_end, 5);
+        assert_eq!(occurrences[1].glyph_start, 7);
+        assert_eq!(occurrences[1].glyph_end, 13);
     }
 
     fn wait_for_completed_hits(

--- a/src/search/state.rs
+++ b/src/search/state.rs
@@ -123,6 +123,8 @@ impl Default for SearchState {
 }
 
 impl SearchState {
+    const HIGHLIGHT_UNAVAILABLE_NOTICE: &str = "some search highlights are unavailable";
+
     pub fn open_palette(
         &mut self,
         _app: &mut AppState,
@@ -221,7 +223,11 @@ impl SearchState {
                     self.in_progress = true;
                     changed = true;
                 }
-                SearchEvent::Completed { generation, hits } => {
+                SearchEvent::Completed {
+                    generation,
+                    hits,
+                    highlight_unavailable,
+                } => {
                     if generation != self.generation {
                         continue;
                     }
@@ -230,6 +236,11 @@ impl SearchState {
                     self.hit_pages_progress = hits.len();
                     self.current_hit = None;
                     self.hits = hits;
+                    if highlight_unavailable {
+                        app.apply_notice_action(NoticeAction::warning(
+                            Self::HIGHLIGHT_UNAVAILABLE_NOTICE,
+                        ));
+                    }
                     changed = true;
                 }
                 SearchEvent::Failed {
@@ -382,6 +393,29 @@ impl SearchMatcher for ContainsMatcher {
         }
     }
 
+    fn matches_page(&self, page_text: &str, prepared_query: &str) -> bool {
+        let prepared_page = if self.case_sensitive {
+            page_text.to_string()
+        } else {
+            page_text.to_lowercase()
+        };
+
+        if prepared_page.contains(prepared_query) {
+            return true;
+        }
+
+        prepared_page
+            .chars()
+            .filter(|ch| !ch.is_whitespace())
+            .collect::<String>()
+            .contains(
+                &prepared_query
+                    .chars()
+                    .filter(|ch| !ch.is_whitespace())
+                    .collect::<String>(),
+            )
+    }
+
     fn locate_matches(
         &self,
         page: &crate::backend::TextPage,
@@ -396,9 +430,10 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
 
-    use crate::app::{AppState, NoticeAction};
+    use crate::app::{AppState, NoticeAction, NoticeLevel};
     use crate::backend::{PdfBackend, RgbaFrame, SharedPdfBackend, TextPage};
     use crate::command::{CommandOutcome, SearchMatcherKind};
+    use crate::error::AppError;
     use crate::search::engine::SearchEngine;
 
     use super::SearchState;
@@ -442,12 +477,68 @@ mod tests {
             })
         }
 
-        fn extract_text_page(&self, _page: usize) -> crate::error::AppResult<TextPage> {
+        fn extract_text(&self, _page: usize) -> crate::error::AppResult<String> {
+            Ok(String::new())
+        }
+
+        fn extract_positioned_text(&self, _page: usize) -> crate::error::AppResult<TextPage> {
             Ok(TextPage {
                 width_pt: 612.0,
                 height_pt: 792.0,
                 glyphs: Vec::new(),
             })
+        }
+
+        fn extract_outline(&self) -> crate::error::AppResult<Vec<crate::backend::OutlineNode>> {
+            Ok(Vec::new())
+        }
+    }
+
+    struct HighlightUnavailableStubPdf {
+        path: PathBuf,
+        text: String,
+    }
+
+    impl HighlightUnavailableStubPdf {
+        fn new(text: &str) -> Self {
+            Self {
+                path: PathBuf::from("highlight-unavailable.pdf"),
+                text: text.to_string(),
+            }
+        }
+    }
+
+    impl PdfBackend for HighlightUnavailableStubPdf {
+        fn path(&self) -> &Path {
+            &self.path
+        }
+
+        fn doc_id(&self) -> u64 {
+            10
+        }
+
+        fn page_count(&self) -> usize {
+            1
+        }
+
+        fn page_dimensions(&self, _page: usize) -> crate::error::AppResult<(f32, f32)> {
+            Ok((612.0, 792.0))
+        }
+
+        fn render_page(&self, _page: usize, _scale: f32) -> crate::error::AppResult<RgbaFrame> {
+            Ok(RgbaFrame {
+                width: 1,
+                height: 1,
+                pixels: vec![0, 0, 0, 0].into(),
+            })
+        }
+
+        fn extract_text(&self, _page: usize) -> crate::error::AppResult<String> {
+            Ok(self.text.clone())
+        }
+
+        fn extract_positioned_text(&self, _page: usize) -> crate::error::AppResult<TextPage> {
+            Err(AppError::unsupported("positioned text unavailable"))
         }
 
         fn extract_outline(&self) -> crate::error::AppResult<Vec<crate::backend::OutlineNode>> {
@@ -591,6 +682,45 @@ mod tests {
             assert_eq!(app.notice, None);
             std::thread::sleep(std::time::Duration::from_millis(5));
         }
+    }
+
+    #[test]
+    fn on_background_warns_when_highlight_is_unavailable() {
+        let mut state = SearchState::default();
+        let mut app = AppState::default();
+        let pdf = Arc::new(HighlightUnavailableStubPdf::new("alpha beta")) as SharedPdfBackend;
+        let mut engine = SearchEngine::new();
+
+        state
+            .submit(
+                &mut app,
+                Arc::clone(&pdf),
+                &mut engine,
+                "alpha".to_string(),
+                SearchMatcherKind::ContainsInsensitive,
+            )
+            .expect("submit should succeed");
+
+        let timeout = std::time::Duration::from_secs(3);
+        let start = std::time::Instant::now();
+        while state.in_progress() {
+            let _ = state.on_background(&mut app, &mut engine);
+            assert!(
+                start.elapsed() <= timeout,
+                "timed out waiting for search completion"
+            );
+            if state.in_progress() {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+        }
+
+        assert_eq!(
+            state.status_bar_segment(),
+            Some("SEARCH 1 hits".to_string())
+        );
+        let notice = app.notice.expect("warning notice should be set");
+        assert_eq!(notice.level, NoticeLevel::Warning);
+        assert_eq!(notice.message, SearchState::HIGHLIGHT_UNAVAILABLE_NOTICE);
     }
 
     #[test]

--- a/src/search/state.rs
+++ b/src/search/state.rs
@@ -10,6 +10,7 @@ use crate::palette::{PaletteKind, PaletteOpenPayload};
 
 use super::engine::{
     SearchEngine, SearchEvent, SearchMatcher, SearchOccurrence, SearchPageHit, locate_occurrences,
+    page_matches_contains, prepare_contains_query,
 };
 
 #[derive(Default)]
@@ -389,34 +390,11 @@ struct ContainsMatcher {
 
 impl SearchMatcher for ContainsMatcher {
     fn prepare_query(&self, raw_query: &str) -> String {
-        if self.case_sensitive {
-            raw_query.to_string()
-        } else {
-            raw_query.to_lowercase()
-        }
+        prepare_contains_query(raw_query, self.case_sensitive)
     }
 
     fn matches_page(&self, page_text: &str, prepared_query: &str) -> bool {
-        let prepared_page = if self.case_sensitive {
-            page_text.to_string()
-        } else {
-            page_text.to_lowercase()
-        };
-
-        if prepared_page.contains(prepared_query) {
-            return true;
-        }
-
-        prepared_page
-            .chars()
-            .filter(|ch| !ch.is_whitespace())
-            .collect::<String>()
-            .contains(
-                &prepared_query
-                    .chars()
-                    .filter(|ch| !ch.is_whitespace())
-                    .collect::<String>(),
-            )
+        page_matches_contains(page_text, prepared_query, self.case_sensitive)
     }
 
     fn locate_matches(

--- a/src/search/state.rs
+++ b/src/search/state.rs
@@ -5,9 +5,12 @@ use crate::app::{AppState, NoticeAction, PaletteRequest};
 use crate::backend::SharedPdfBackend;
 use crate::command::{CommandOutcome, SearchMatcherKind};
 use crate::error::AppResult;
+use crate::highlight::{HighlightOverlaySnapshot, HighlightSource, HighlightSpan, HighlightStyle};
 use crate::palette::PaletteKind;
 
-use super::engine::{SearchEngine, SearchEvent, SearchMatcher};
+use super::engine::{
+    SearchEngine, SearchEvent, SearchMatcher, SearchOccurrence, SearchPageHit, locate_occurrences,
+};
 
 #[derive(Default)]
 pub struct SearchRuntime {
@@ -73,6 +76,14 @@ impl SearchRuntime {
     pub fn status_bar_segment(&self) -> Option<String> {
         self.state.status_bar_segment()
     }
+
+    pub fn highlight_overlay_for_visible_pages(
+        &self,
+        visible_pages: [Option<usize>; 2],
+    ) -> HighlightOverlaySnapshot {
+        self.state
+            .highlight_overlay_for_visible_pages(visible_pages)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -88,8 +99,8 @@ pub struct SearchState {
     /// Number of matched pages observed so far while scanning.
     /// This is progress-oriented and may change before completion.
     hit_pages_progress: usize,
-    /// Final matched page list (0-based page indexes), available on completion.
-    hits: Vec<usize>,
+    /// Final matched page list with occurrence rects, available on completion.
+    hits: Vec<SearchPageHit>,
     current_hit: Option<usize>,
     last_error: Option<String>,
 }
@@ -308,10 +319,36 @@ impl SearchState {
         };
 
         self.current_hit = Some(next_index);
-        let hit_page = self.hits[next_index];
+        let hit_page = self.hits[next_index].page;
         let page_count = self.total_pages.max(hit_page + 1);
         app.current_page = app.normalize_page_for_layout(hit_page, page_count);
         (CommandOutcome::Applied, NoticeAction::Clear)
+    }
+
+    pub fn highlight_overlay_for_visible_pages(
+        &self,
+        visible_pages: [Option<usize>; 2],
+    ) -> HighlightOverlaySnapshot {
+        if self.query.is_empty() {
+            return HighlightOverlaySnapshot::default();
+        }
+
+        let spans = self
+            .hits
+            .iter()
+            .filter(|hit| visible_pages.contains(&Some(hit.page)))
+            .flat_map(|hit| {
+                hit.occurrences.iter().filter_map(move |occurrence| {
+                    (!occurrence.rects.is_empty()).then_some(HighlightSpan {
+                        source: HighlightSource::Search,
+                        page: hit.page,
+                        rects: occurrence.rects.clone(),
+                        style: HighlightStyle::SEARCH_HIT,
+                    })
+                })
+            })
+            .collect();
+        HighlightOverlaySnapshot::new(spans)
     }
 
     fn clear_results(&mut self) {
@@ -345,23 +382,13 @@ impl SearchMatcher for ContainsMatcher {
         }
     }
 
-    fn matches_page(&self, page_text: &str, prepared_query: &str) -> bool {
-        let prepared_page = if self.case_sensitive {
-            page_text.to_string()
-        } else {
-            page_text.to_lowercase()
-        };
-
-        if prepared_page.contains(prepared_query) {
-            return true;
-        }
-
-        remove_whitespace(&prepared_page).contains(&remove_whitespace(prepared_query))
+    fn locate_matches(
+        &self,
+        page: &crate::backend::TextPage,
+        prepared_query: &str,
+    ) -> Vec<SearchOccurrence> {
+        locate_occurrences(&page.glyphs, prepared_query, self.case_sensitive)
     }
-}
-
-fn remove_whitespace(input: &str) -> String {
-    input.chars().filter(|ch| !ch.is_whitespace()).collect()
 }
 
 #[cfg(test)]
@@ -370,7 +397,7 @@ mod tests {
     use std::sync::Arc;
 
     use crate::app::{AppState, NoticeAction};
-    use crate::backend::{PdfBackend, RgbaFrame, SharedPdfBackend};
+    use crate::backend::{PdfBackend, RgbaFrame, SharedPdfBackend, TextPage};
     use crate::command::{CommandOutcome, SearchMatcherKind};
     use crate::search::engine::SearchEngine;
 
@@ -415,8 +442,12 @@ mod tests {
             })
         }
 
-        fn extract_text(&self, _page: usize) -> crate::error::AppResult<String> {
-            Ok(String::new())
+        fn extract_text_page(&self, _page: usize) -> crate::error::AppResult<TextPage> {
+            Ok(TextPage {
+                width_pt: 612.0,
+                height_pt: 792.0,
+                glyphs: Vec::new(),
+            })
         }
 
         fn extract_outline(&self) -> crate::error::AppResult<Vec<crate::backend::OutlineNode>> {

--- a/src/search/state.rs
+++ b/src/search/state.rs
@@ -486,6 +486,7 @@ mod tests {
                 width_pt: 612.0,
                 height_pt: 792.0,
                 glyphs: Vec::new(),
+                dropped_glyphs: 0,
             })
         }
 


### PR DESCRIPTION
## Rationale
Search hits were navigable, but the current match was not visually anchored on the rendered page. This change adds page highlight overlays derived from extracted text geometry and warns when a PDF cannot provide enough data to draw them reliably.

## Approach
- add generic highlight overlay support in the frame/render pipeline
- extract search hit rectangles from backend text geometry and feed them into runtime search state
- surface a warning notice when highlight extraction is unavailable for the active document
- update runtime and rendering docs, plus a small presenter lint fix needed to keep CI green

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual highlight overlays for search hits; search now returns positioned text/geometry and an API to request overlay snapshots.
  * Render/preparation honors overlays and tracks an overlay stamp so displayed output reflects overlay state.

* **Behavior**
  * Prefetch/caching avoids storing frames when overlays are active.
  * If highlight extraction fails or is incomplete, results still appear and a concise warning is shown.

* **Documentation**
  * Rendering pipeline and runtime spec updated to document overlay rules and cache identity.

* **Tests**
  * Tests updated for overlay decoration, failure paths, and cache-key distinctions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->