### PR TITLE
refactor(palette): use typed open payloads

### DIFF
--- a/docs/palette-provider.md
+++ b/docs/palette-provider.md
@@ -29,10 +29,10 @@ behavior.
 - `assistive_text(ctx, selected) -> Option<String>`
 - `reset_selection_on_input_change() -> bool`
 - `initial_selected_candidate(ctx, candidates) -> Option<usize>`
-- `initial_input(seed) -> String`
+- `initial_input(open_payload) -> String`
 
-`PaletteContext` includes current app state, palette kind, input text, optional
-seed data, and extension UI snapshot data.
+`PaletteContext` includes current app state, palette kind, input text,
+optional `open_payload`, and extension UI snapshot data.
 
 ## Candidate and rendering contract
 
@@ -64,8 +64,9 @@ Selection rules:
   `reset_selection_on_input_change()`
 - providers can override the initial highlight with
   `initial_selected_candidate(...)`
-- `initial_input(seed)` defaults to the seed value and may be overridden when
-  seed data should not appear verbatim in the input field
+- `initial_input(open_payload)` defaults to the payload's visible input text and
+  may be overridden when open payload data should not appear verbatim in the
+  input field
 
 ## Keyboard semantics
 
@@ -162,7 +163,8 @@ current input.
 - kind: `PaletteKind::History`
 - command entry point: `history`
 - input mode: `Custom`
-- seed data is used as serialized context, while visible input starts empty
+- `PaletteOpenPayload::HistorySeed` is used as serialized context, while
+  visible input starts empty
 - candidates are shown in navigation order around the current page
 - the current page is selected when the palette opens
 - matching uses signed index, then formatted reason text, then page label

--- a/docs/palette-provider.md
+++ b/docs/palette-provider.md
@@ -86,7 +86,7 @@ Selection rules:
 `on_submit` returns:
 
 - `Close`
-- `Reopen { kind, seed }`
+- `Reopen { kind, payload }`
 - `Dispatch { command, history_record, next }`
 
 Dispatch order:
@@ -149,6 +149,7 @@ current input.
 - open shortcut: `/`
 - command entry point: `search`
 - input mode: `FreeText`
+- active search reopens with the current query prefilled and current matcher selected
 - `<up>` / `<down>` recall recent search queries
 - `<c-p>` / `<c-n>` select the matcher candidate
 - matcher candidates are `contains-insensitive` and `contains-sensitive`

--- a/src/app/input_ops.rs
+++ b/src/app/input_ops.rs
@@ -217,14 +217,14 @@ impl InteractionSubsystem {
         let mut changed = false;
         while let Some(request) = self.palette.pending_requests.pop_front() {
             match request {
-                PaletteRequest::Open { kind, seed } => {
+                PaletteRequest::Open { kind, payload } => {
                     let extensions = self.extensions.host.ui_snapshot();
                     match self.palette.manager.open(
                         &self.palette.registry,
                         state,
                         &extensions,
                         kind,
-                        seed,
+                        payload,
                         self.history.snapshot_for_palette(kind),
                     ) {
                         Ok(()) => {
@@ -360,10 +360,10 @@ impl InteractionSubsystem {
 
         match effect {
             PaletteSubmitEffect::Close => {}
-            PaletteSubmitEffect::Reopen { kind, seed } => {
+            PaletteSubmitEffect::Reopen { kind, payload } => {
                 self.palette
                     .pending_requests
-                    .push_back(PaletteRequest::Open { kind, seed });
+                    .push_back(PaletteRequest::Open { kind, payload });
             }
             PaletteSubmitEffect::Dispatch {
                 command,
@@ -379,10 +379,10 @@ impl InteractionSubsystem {
                 ));
                 match next {
                     PalettePostAction::Close => {}
-                    PalettePostAction::Reopen { kind, seed } => {
+                    PalettePostAction::Reopen { kind, payload } => {
                         self.palette
                             .pending_requests
-                            .push_back(PaletteRequest::Open { kind, seed });
+                            .push_back(PaletteRequest::Open { kind, payload });
                     }
                 }
             }
@@ -658,7 +658,7 @@ mod tests {
             .pending_requests
             .push_back(PaletteRequest::Open {
                 kind: PaletteKind::Command,
-                seed: None,
+                payload: None,
             });
         assert!(app.interaction.apply_palette_requests(&mut app.state));
         assert_eq!(app.state.mode, Mode::Palette);
@@ -869,7 +869,7 @@ mod tests {
             .pending_requests
             .push_back(PaletteRequest::Open {
                 kind: PaletteKind::Command,
-                seed: None,
+                payload: None,
             });
         assert!(interaction.apply_palette_requests(&mut state));
         assert_eq!(state.mode, Mode::Palette);
@@ -904,7 +904,7 @@ mod tests {
             .pending_requests
             .push_back(PaletteRequest::Open {
                 kind: PaletteKind::Command,
-                seed: None,
+                payload: None,
             });
         interaction
             .palette

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1,5 +1,5 @@
 use crate::error::AppError;
-use crate::palette::PaletteKind;
+use crate::palette::{PaletteKind, PaletteOpenPayload};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PageLayoutMode {
@@ -66,7 +66,7 @@ pub enum Mode {
 pub enum PaletteRequest {
     Open {
         kind: PaletteKind,
-        seed: Option<String>,
+        payload: Option<PaletteOpenPayload>,
     },
     Close,
 }

--- a/src/command/dispatch.rs
+++ b/src/command/dispatch.rs
@@ -111,8 +111,8 @@ pub fn dispatch(
             let visible = !app.debug_status_visible;
             set_debug_status_visible(app, visible)
         }
-        Command::OpenPalette { kind, seed } => {
-            palette_requests.push_back(PaletteRequest::Open { kind, seed });
+        Command::OpenPalette { kind, payload } => {
+            palette_requests.push_back(PaletteRequest::Open { kind, payload });
             Ok((CommandOutcome::Applied, NoticeAction::Clear))
         }
         Command::ClosePalette => {

--- a/src/command/parse.rs
+++ b/src/command/parse.rs
@@ -3,7 +3,7 @@ use std::num::IntErrorKind;
 use crate::app::AppState;
 use crate::error::{AppError, AppResult};
 use crate::extension::ExtensionUiSnapshot;
-use crate::palette::PaletteKind;
+use crate::palette::{PaletteKind, PaletteOpenPayload};
 
 use super::spec::{CommandConditionContext, find_command_spec, validate_command_id_for_source};
 use super::types::{
@@ -134,16 +134,16 @@ fn parse_open_palette(args_text: &str) -> AppResult<Command> {
         ));
     }
 
-    let (kind_text, seed) = match trimmed.find(char::is_whitespace) {
+    let (kind_text, payload) = match trimmed.find(char::is_whitespace) {
         Some(index) => {
             let kind = trimmed[..index].trim();
-            let seed = trimmed[index..].trim_start();
-            let seed = if seed.is_empty() {
+            let input = trimmed[index..].trim_start();
+            let payload = if input.is_empty() {
                 None
             } else {
-                Some(seed.to_string())
+                Some(PaletteOpenPayload::CommandInput(input.to_string()))
             };
-            (kind, seed)
+            (kind, payload)
         }
         None => (trimmed, None),
     };
@@ -151,7 +151,7 @@ fn parse_open_palette(args_text: &str) -> AppResult<Command> {
     let kind =
         PaletteKind::parse(kind_text).ok_or(AppError::invalid_argument("unknown palette kind"))?;
 
-    Ok(Command::OpenPalette { kind, seed })
+    Ok(Command::OpenPalette { kind, payload })
 }
 
 fn parse_goto_page(args_text: &str) -> AppResult<Command> {
@@ -410,7 +410,7 @@ mod tests {
             parse_command_text("open-palette command").expect("parse should succeed"),
             Command::OpenPalette {
                 kind: PaletteKind::Command,
-                seed: None,
+                payload: None,
             }
         );
     }

--- a/src/command/parse.rs
+++ b/src/command/parse.rs
@@ -134,24 +134,36 @@ fn parse_open_palette(args_text: &str) -> AppResult<Command> {
         ));
     }
 
-    let (kind_text, payload) = match trimmed.find(char::is_whitespace) {
+    let (kind_text, input) = match trimmed.find(char::is_whitespace) {
         Some(index) => {
             let kind = trimmed[..index].trim();
             let input = trimmed[index..].trim_start();
-            let payload = if input.is_empty() {
-                None
-            } else {
-                Some(PaletteOpenPayload::CommandInput(input.to_string()))
-            };
-            (kind, payload)
+            (kind, input)
         }
-        None => (trimmed, None),
+        None => (trimmed, ""),
     };
 
     let kind =
         PaletteKind::parse(kind_text).ok_or(AppError::invalid_argument("unknown palette kind"))?;
+    let payload = parse_open_palette_payload(kind, input);
 
     Ok(Command::OpenPalette { kind, payload })
+}
+
+fn parse_open_palette_payload(kind: PaletteKind, input: &str) -> Option<PaletteOpenPayload> {
+    if input.is_empty() {
+        return None;
+    }
+
+    Some(match kind {
+        PaletteKind::Command => PaletteOpenPayload::CommandInput(input.to_string()),
+        PaletteKind::Search => PaletteOpenPayload::Search {
+            query: input.to_string(),
+            matcher: SearchMatcherKind::ContainsInsensitive,
+        },
+        PaletteKind::History => PaletteOpenPayload::HistorySeed(input.to_string()),
+        PaletteKind::Outline => PaletteOpenPayload::OutlineQuery(input.to_string()),
+    })
 }
 
 fn parse_goto_page(args_text: &str) -> AppResult<Command> {
@@ -390,7 +402,7 @@ mod tests {
     use crate::command::{
         Command, PageLayoutModeArg, PanAmount, PanDirection, SearchMatcherKind, SpreadDirectionArg,
     };
-    use crate::palette::PaletteKind;
+    use crate::palette::{PaletteKind, PaletteOpenPayload};
 
     #[test]
     fn parses_basic_commands() {
@@ -411,6 +423,33 @@ mod tests {
             Command::OpenPalette {
                 kind: PaletteKind::Command,
                 payload: None,
+            }
+        );
+        assert_eq!(
+            parse_command_text("open-palette history b:11|c:12|f:13")
+                .expect("parse should succeed"),
+            Command::OpenPalette {
+                kind: PaletteKind::History,
+                payload: Some(PaletteOpenPayload::HistorySeed(
+                    "b:11|c:12|f:13".to_string(),
+                )),
+            }
+        );
+        assert_eq!(
+            parse_command_text("open-palette search needle").expect("parse should succeed"),
+            Command::OpenPalette {
+                kind: PaletteKind::Search,
+                payload: Some(PaletteOpenPayload::Search {
+                    query: "needle".to_string(),
+                    matcher: SearchMatcherKind::ContainsInsensitive,
+                }),
+            }
+        );
+        assert_eq!(
+            parse_command_text("open-palette outline appendix").expect("parse should succeed"),
+            Command::OpenPalette {
+                kind: PaletteKind::Outline,
+                payload: Some(PaletteOpenPayload::OutlineQuery("appendix".to_string())),
             }
         );
     }

--- a/src/command/spec.rs
+++ b/src/command/spec.rs
@@ -529,7 +529,7 @@ mod tests {
         validate_command_for_source(
             &Command::OpenPalette {
                 kind: crate::palette::PaletteKind::Command,
-                seed: None,
+                payload: None,
             },
             &keymap_ctx,
         )

--- a/src/command/types.rs
+++ b/src/command/types.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use crate::palette::PaletteKind;
+use crate::palette::{PaletteKind, PaletteOpenPayload};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SearchMatcherKind {
@@ -200,7 +200,7 @@ pub enum Command {
     DebugStatusToggle,
     OpenPalette {
         kind: PaletteKind,
-        seed: Option<String>,
+        payload: Option<PaletteOpenPayload>,
     },
     ClosePalette,
     OpenHelp,
@@ -555,7 +555,7 @@ mod tests {
         assert_eq!(
             Command::OpenPalette {
                 kind: PaletteKind::Command,
-                seed: None,
+                payload: None,
             }
             .action_id(),
             ActionId::OpenPalette

--- a/src/history/palette.rs
+++ b/src/history/palette.rs
@@ -2,8 +2,9 @@ use crate::command::Command;
 use crate::error::AppResult;
 use crate::input::shortcut::format_shortcut_key;
 use crate::palette::{
-    PaletteCandidate, PaletteContext, PaletteInputMode, PaletteKind, PalettePayload,
-    PalettePostAction, PaletteProvider, PaletteSearchText, PaletteSubmitEffect, PaletteTextPart,
+    PaletteCandidate, PaletteContext, PaletteInputMode, PaletteKind, PaletteOpenPayload,
+    PalettePayload, PalettePostAction, PaletteProvider, PaletteSearchText, PaletteSubmitEffect,
+    PaletteTextPart,
 };
 
 pub struct HistoryPaletteProvider;
@@ -39,7 +40,11 @@ impl PaletteProvider for HistoryPaletteProvider {
     }
 
     fn list(&self, ctx: &PaletteContext<'_>) -> AppResult<Vec<PaletteCandidate>> {
-        let seed = ctx.seed.unwrap_or("");
+        let payload = ctx.open_payload;
+        let seed = match payload {
+            Some(PaletteOpenPayload::HistorySeed(seed)) => seed.as_str(),
+            _ => "",
+        };
         let parsed = parse_seed(seed, ctx.app.current_page);
         let query = ctx.input.trim().to_ascii_lowercase();
         if query.is_empty() {
@@ -106,7 +111,7 @@ impl PaletteProvider for HistoryPaletteProvider {
         Some(format!("{enter} jump to page"))
     }
 
-    fn initial_input(&self, _seed: Option<&str>) -> String {
+    fn initial_input(&self, _open_payload: Option<&PaletteOpenPayload>) -> String {
         String::new()
     }
 }
@@ -381,13 +386,13 @@ struct SeedEntry {
     display_index: isize,
 }
 
-fn parse_seed(seed: &str, fallback_current: usize) -> Vec<SeedEntry> {
+fn parse_seed(payload: &str, fallback_current: usize) -> Vec<SeedEntry> {
     let mut back_entries = Vec::new();
     let mut forward_entries = Vec::new();
     let mut current_page = fallback_current;
     let mut current_reason = String::new();
 
-    let parts: Vec<&str> = seed.split('|').collect();
+    let parts: Vec<&str> = payload.split('|').collect();
     for part in &parts {
         if let Some(data) = part.strip_prefix("b:") {
             for item in data.split(';') {
@@ -461,7 +466,9 @@ mod tests {
     use crate::{
         app::AppState,
         extension::ExtensionUiSnapshot,
-        palette::{PaletteCandidate, PaletteContext, PalettePayload, PaletteProvider},
+        palette::{
+            PaletteCandidate, PaletteContext, PaletteOpenPayload, PalettePayload, PaletteProvider,
+        },
     };
 
     use super::{
@@ -547,7 +554,7 @@ mod tests {
             extensions: &extensions,
             kind: crate::palette::PaletteKind::History,
             input: "",
-            seed: None,
+            open_payload: None,
         };
 
         let current = PaletteCandidate {
@@ -602,13 +609,14 @@ mod tests {
             ..AppState::default()
         };
         let extensions = ExtensionUiSnapshot::default();
+        let payload = PaletteOpenPayload::HistorySeed(seed.to_string());
 
         let ctx = PaletteContext {
             app: &app,
             extensions: &extensions,
             kind: crate::palette::PaletteKind::History,
             input: "",
-            seed: Some(seed),
+            open_payload: Some(&payload),
         };
 
         let items = provider.list(&ctx).expect("history list should build");
@@ -627,13 +635,14 @@ mod tests {
             ..AppState::default()
         };
         let extensions = ExtensionUiSnapshot::default();
+        let payload = PaletteOpenPayload::HistorySeed(seed.to_string());
 
         let ctx = PaletteContext {
             app: &app,
             extensions: &extensions,
             kind: crate::palette::PaletteKind::History,
             input: "",
-            seed: Some(seed),
+            open_payload: Some(&payload),
         };
 
         let items = provider.list(&ctx).expect("history list should build");

--- a/src/history/state.rs
+++ b/src/history/state.rs
@@ -4,7 +4,7 @@ use crate::app::{AppState, NoticeAction, PaletteRequest};
 use crate::command::CommandOutcome;
 use crate::error::{AppError, AppResult};
 use crate::event::{AppEvent, GotoKind, HistoryOp, NavReason};
-use crate::palette::PaletteKind;
+use crate::palette::{PaletteKind, PaletteOpenPayload};
 
 const HISTORY_CAPACITY: usize = 64;
 
@@ -100,7 +100,7 @@ impl HistoryState {
         let seed = self.serialize_seed(app.current_page);
         palette_requests.push_back(PaletteRequest::Open {
             kind: PaletteKind::History,
-            seed: Some(seed),
+            payload: Some(PaletteOpenPayload::HistorySeed(seed)),
         });
         (CommandOutcome::Applied, NoticeAction::Clear)
     }
@@ -427,12 +427,13 @@ mod tests {
             ..AppState::default()
         };
         let extensions = ExtensionUiSnapshot::default();
+        let payload = crate::palette::PaletteOpenPayload::HistorySeed(seed);
         let ctx = PaletteContext {
             app: &app,
             extensions: &extensions,
             kind: PaletteKind::History,
             input: "",
-            seed: Some(&seed),
+            open_payload: Some(&payload),
         };
 
         let items = provider.list(&ctx).expect("history list should build");

--- a/src/input/keymap.rs
+++ b/src/input/keymap.rs
@@ -12,7 +12,7 @@ pub fn build_builtin_sequence_registry() -> SequenceRegistry {
         &[ShortcutKey::char(':')],
         Command::OpenPalette {
             kind: PaletteKind::Command,
-            seed: None,
+            payload: None,
         },
     );
     register_static(

--- a/src/outline/palette.rs
+++ b/src/outline/palette.rs
@@ -203,7 +203,7 @@ mod tests {
             extensions: &extensions,
             kind: PaletteKind::Outline,
             input: "",
-            seed: None,
+            open_payload: None,
         };
 
         let items = provider.list(&ctx).expect("outline list should build");
@@ -241,7 +241,7 @@ mod tests {
             extensions: &extensions,
             kind: PaletteKind::Outline,
             input: "3",
-            seed: None,
+            open_payload: None,
         };
 
         let items = provider.list(&ctx).expect("outline list should build");
@@ -280,7 +280,7 @@ mod tests {
             extensions: &extensions,
             kind: PaletteKind::Outline,
             input: "p.1",
-            seed: None,
+            open_payload: None,
         };
 
         let items = provider.list(&ctx).expect("outline list should build");
@@ -312,7 +312,7 @@ mod tests {
             extensions: &extensions,
             kind: PaletteKind::Outline,
             input: "ÜBER",
-            seed: None,
+            open_payload: None,
         };
 
         let items = provider.list(&ctx).expect("outline list should build");

--- a/src/outline/state.rs
+++ b/src/outline/state.rs
@@ -28,7 +28,7 @@ impl OutlineState {
         self.ensure_loaded(pdf.as_ref())?;
         palette_requests.push_back(PaletteRequest::Open {
             kind: PaletteKind::Outline,
-            seed: None,
+            payload: None,
         });
         Ok((CommandOutcome::Applied, NoticeAction::Clear))
     }

--- a/src/palette/manager.rs
+++ b/src/palette/manager.rs
@@ -13,14 +13,14 @@ use super::registry::PaletteProviderRef;
 use super::registry::PaletteRegistry;
 use super::types::{
     PaletteCandidate, PaletteContext, PaletteInputMode, PaletteItemView, PaletteKeyResult,
-    PaletteSubmitAction, PaletteTabEffect, PaletteView,
+    PaletteOpenPayload, PaletteSubmitAction, PaletteTabEffect, PaletteView,
 };
 
 #[derive(Debug)]
 struct PaletteSession {
     id: u64,
     kind: PaletteKind,
-    seed: Option<String>,
+    payload: Option<PaletteOpenPayload>,
     title: String,
     input_mode: PaletteInputMode,
     input: Input,
@@ -107,19 +107,19 @@ impl PaletteManager {
         app: &AppState,
         extensions: &ExtensionUiSnapshot,
         kind: PaletteKind,
-        seed: Option<String>,
+        payload: Option<PaletteOpenPayload>,
         input_history: Option<InputHistorySnapshot>,
     ) -> AppResult<()> {
         let provider = registry.get(kind);
 
-        let input = Input::new(provider.initial_input(seed.as_deref()));
+        let input = Input::new(provider.initial_input(payload.as_ref()));
 
         let ctx = PaletteContext {
             app,
             extensions,
             kind,
             input: input.value(),
-            seed: seed.as_deref(),
+            open_payload: payload.as_ref(),
         };
         let title = provider.title(&ctx);
         let candidates = provider.list(&ctx)?;
@@ -133,7 +133,7 @@ impl PaletteManager {
         self.active = Some(PaletteSession {
             id: self.take_session_id(),
             kind,
-            seed,
+            payload,
             title,
             input_mode,
             input,
@@ -222,7 +222,7 @@ impl PaletteManager {
                     extensions,
                     kind: session.kind,
                     input: session.input.value(),
-                    seed: session.seed.as_deref(),
+                    open_payload: session.payload.as_ref(),
                 };
                 match provider.on_tab(&ctx, selected)? {
                     PaletteTabEffect::Noop => {}
@@ -245,7 +245,7 @@ impl PaletteManager {
                     extensions,
                     kind: session.kind,
                     input: session.input.value(),
-                    seed: session.seed.as_deref(),
+                    open_payload: session.payload.as_ref(),
                 };
                 let effect = match provider.on_submit(&ctx, selected) {
                     Ok(effect) => effect,
@@ -305,7 +305,7 @@ impl PaletteManager {
             return Ok(());
         };
         let kind = existing.kind;
-        let seed = existing.seed.clone();
+        let payload = existing.payload.clone();
         let input_mode = existing.input_mode;
         let input_text = existing.input.value().to_string();
         let current_selected = existing.selected;
@@ -316,7 +316,7 @@ impl PaletteManager {
             extensions,
             kind,
             input: &input_text,
-            seed: seed.as_deref(),
+            open_payload: payload.as_ref(),
         };
 
         let title = provider.title(&ctx);
@@ -441,7 +441,7 @@ mod tests {
         app::AppState,
         extension::ExtensionUiSnapshot,
         input::InputHistorySnapshot,
-        palette::{PaletteKind, PaletteRegistry},
+        palette::{PaletteKind, PaletteOpenPayload, PaletteRegistry},
     };
 
     use super::PaletteManager;
@@ -700,7 +700,9 @@ mod tests {
                 &app,
                 &extensions,
                 PaletteKind::History,
-                Some("f:5,Search: later|c:4|b:3,Search: earlier".to_string()),
+                Some(PaletteOpenPayload::HistorySeed(
+                    "f:5,Search: later|c:4|b:3,Search: earlier".to_string(),
+                )),
                 None,
             )
             .expect("history palette should open");

--- a/src/palette/mod.rs
+++ b/src/palette/mod.rs
@@ -11,6 +11,7 @@ pub use matcher::{CandidateMatcher, ContainsMatcher};
 pub use registry::PaletteRegistry;
 pub use types::{
     PaletteCandidate, PaletteContext, PaletteInputMode, PaletteItemView, PaletteKeyResult,
-    PalettePayload, PalettePostAction, PaletteProvider, PaletteSearchText, PaletteSubmitAction,
-    PaletteSubmitEffect, PaletteTabEffect, PaletteTextPart, PaletteTextTone, PaletteView,
+    PaletteOpenPayload, PalettePayload, PalettePostAction, PaletteProvider, PaletteSearchText,
+    PaletteSubmitAction, PaletteSubmitEffect, PaletteTabEffect, PaletteTextPart, PaletteTextTone,
+    PaletteView,
 };

--- a/src/palette/providers/command.rs
+++ b/src/palette/providers/command.rs
@@ -11,9 +11,9 @@ use crate::input::shortcut::{
     ShortcutKey, format_shortcut_alternatives_tight, format_shortcut_key,
 };
 use crate::palette::{
-    PaletteCandidate, PaletteContext, PaletteInputMode, PaletteKind, PalettePayload,
-    PalettePostAction, PaletteProvider, PaletteSearchText, PaletteSubmitEffect, PaletteTabEffect,
-    PaletteTextPart,
+    PaletteCandidate, PaletteContext, PaletteInputMode, PaletteKind, PaletteOpenPayload,
+    PalettePayload, PalettePostAction, PaletteProvider, PaletteSearchText, PaletteSubmitEffect,
+    PaletteTabEffect, PaletteTextPart,
 };
 
 pub struct CommandPaletteProvider;
@@ -123,7 +123,7 @@ impl PaletteProvider for CommandPaletteProvider {
                 // Args required: reopen with command name pre-filled.
                 return Ok(PaletteSubmitEffect::Reopen {
                     kind: self.kind(),
-                    seed: Some(format!("{} ", spec.id)),
+                    payload: Some(PaletteOpenPayload::CommandInput(format!("{} ", spec.id))),
                 });
             }
         }
@@ -135,7 +135,7 @@ impl PaletteProvider for CommandPaletteProvider {
         // 3. Fallback: reopen preserving current input.
         Ok(PaletteSubmitEffect::Reopen {
             kind: self.kind(),
-            seed: Some(ctx.input.to_string()),
+            payload: Some(PaletteOpenPayload::CommandInput(ctx.input.to_string())),
         })
     }
 
@@ -420,7 +420,7 @@ fn submit_selected_enum_candidate(
         })),
         Err(_) => Ok(Some(PaletteSubmitEffect::Reopen {
             kind: PaletteKind::Command,
-            seed: Some(synthesized),
+            payload: Some(PaletteOpenPayload::CommandInput(synthesized)),
         })),
     }
 }
@@ -596,8 +596,8 @@ mod tests {
     use crate::extension::ExtensionUiSnapshot;
     use crate::input::InputHistoryRecord;
     use crate::palette::{
-        PaletteContext, PaletteKind, PalettePostAction, PaletteProvider, PaletteSubmitEffect,
-        PaletteTabEffect,
+        PaletteContext, PaletteKind, PaletteOpenPayload, PalettePostAction, PaletteProvider,
+        PaletteSubmitEffect, PaletteTabEffect,
     };
 
     use super::CommandPaletteProvider;
@@ -618,7 +618,7 @@ mod tests {
             extensions: &extensions,
             kind: PaletteKind::Command,
             input,
-            seed: None,
+            open_payload: None,
         };
         provider.list(&ctx).expect("list should be built")
     }
@@ -636,7 +636,7 @@ mod tests {
             extensions: &extensions,
             kind: PaletteKind::Command,
             input,
-            seed: None,
+            open_payload: None,
         };
         let candidates = provider.list(&ctx).expect("list should be built");
         let selected = candidates
@@ -657,7 +657,7 @@ mod tests {
             extensions: &extensions,
             kind: PaletteKind::Command,
             input,
-            seed: None,
+            open_payload: None,
         };
         let candidates = provider.list(&ctx).expect("list should be built");
         let selected = candidates
@@ -678,7 +678,7 @@ mod tests {
             extensions: &extensions,
             kind: PaletteKind::Command,
             input,
-            seed: None,
+            open_payload: None,
         };
         provider.assistive_text(&ctx, None)
     }
@@ -693,7 +693,7 @@ mod tests {
             extensions: &extensions,
             kind: PaletteKind::Command,
             input: "",
-            seed: None,
+            open_payload: None,
         };
 
         let list = provider.list(&ctx).expect("list should be built");
@@ -722,7 +722,7 @@ mod tests {
             extensions: &extensions,
             kind: PaletteKind::Command,
             input: "",
-            seed: None,
+            open_payload: None,
         };
 
         let list = provider.list(&ctx).expect("list should be built");
@@ -881,7 +881,7 @@ mod tests {
             effect,
             PaletteSubmitEffect::Reopen {
                 kind: PaletteKind::Command,
-                seed: Some("zoom ".to_string()),
+                payload: Some(PaletteOpenPayload::CommandInput("zoom ".to_string())),
             }
         );
     }
@@ -909,7 +909,7 @@ mod tests {
             extensions: &extensions,
             kind: PaletteKind::Command,
             input: "quit",
-            seed: None,
+            open_payload: None,
         };
 
         let effect = provider
@@ -936,7 +936,7 @@ mod tests {
             extensions: &extensions,
             kind: PaletteKind::Command,
             input: "page-layout-spread",
-            seed: None,
+            open_payload: None,
         };
 
         let effect = provider
@@ -1062,7 +1062,7 @@ mod tests {
             extensions: &extensions,
             kind: PaletteKind::Command,
             input: "submit-search hello",
-            seed: None,
+            open_payload: None,
         };
 
         let err = provider
@@ -1084,7 +1084,7 @@ mod tests {
             extensions: &extensions,
             kind: PaletteKind::Command,
             input: "first-page hoge",
-            seed: None,
+            open_payload: None,
         };
 
         let err = provider

--- a/src/palette/registry.rs
+++ b/src/palette/registry.rs
@@ -141,12 +141,12 @@ impl<'a> PaletteProviderRef<'a> {
         }
     }
 
-    pub fn initial_input(&self, seed: Option<&str>) -> String {
+    pub fn initial_input(&self, open_payload: Option<&super::PaletteOpenPayload>) -> String {
         match self {
-            Self::Command(provider) => provider.initial_input(seed),
-            Self::Search(provider) => provider.initial_input(seed),
-            Self::History(provider) => provider.initial_input(seed),
-            Self::Outline(provider) => provider.initial_input(seed),
+            Self::Command(provider) => provider.initial_input(open_payload),
+            Self::Search(provider) => provider.initial_input(open_payload),
+            Self::History(provider) => provider.initial_input(open_payload),
+            Self::Outline(provider) => provider.initial_input(open_payload),
         }
     }
 }
@@ -167,7 +167,7 @@ mod tests {
             extensions: &extensions,
             kind: PaletteKind::Command,
             input: "",
-            seed: None,
+            open_payload: None,
         };
 
         assert_eq!(

--- a/src/palette/types.rs
+++ b/src/palette/types.rs
@@ -101,6 +101,7 @@ impl PaletteCandidate {
 pub enum PaletteOpenPayload {
     CommandInput(String),
     HistorySeed(String),
+    OutlineQuery(String),
     Search {
         query: String,
         matcher: SearchMatcherKind,
@@ -112,6 +113,7 @@ impl PaletteOpenPayload {
         match self {
             Self::CommandInput(input) => Some(input.as_str()),
             Self::HistorySeed(_) => None,
+            Self::OutlineQuery(query) => Some(query.as_str()),
             Self::Search { query, .. } => Some(query.as_str()),
         }
     }

--- a/src/palette/types.rs
+++ b/src/palette/types.rs
@@ -1,6 +1,6 @@
 use super::kind::PaletteKind;
 use crate::app::AppState;
-use crate::command::Command;
+use crate::command::{Command, SearchMatcherKind};
 use crate::error::AppResult;
 use crate::extension::ExtensionUiSnapshot;
 use crate::input::InputHistoryRecord;
@@ -98,11 +98,31 @@ impl PaletteCandidate {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PaletteOpenPayload {
+    CommandInput(String),
+    HistorySeed(String),
+    Search {
+        query: String,
+        matcher: SearchMatcherKind,
+    },
+}
+
+impl PaletteOpenPayload {
+    pub fn initial_input(&self) -> Option<&str> {
+        match self {
+            Self::CommandInput(input) => Some(input.as_str()),
+            Self::HistorySeed(_) => None,
+            Self::Search { query, .. } => Some(query.as_str()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PalettePostAction {
     Close,
     Reopen {
         kind: PaletteKind,
-        seed: Option<String>,
+        payload: Option<PaletteOpenPayload>,
     },
 }
 
@@ -111,7 +131,7 @@ pub enum PaletteSubmitEffect {
     Close,
     Reopen {
         kind: PaletteKind,
-        seed: Option<String>,
+        payload: Option<PaletteOpenPayload>,
     },
     Dispatch {
         command: Command,
@@ -134,7 +154,7 @@ pub struct PaletteContext<'a> {
     pub extensions: &'a ExtensionUiSnapshot,
     pub kind: PaletteKind,
     pub input: &'a str,
-    pub seed: Option<&'a str>,
+    pub open_payload: Option<&'a PaletteOpenPayload>,
 }
 
 pub trait PaletteProvider: Send + Sync {
@@ -180,10 +200,13 @@ pub trait PaletteProvider: Send + Sync {
     }
     /// Returns the initial input text when the palette opens.
     ///
-    /// Defaults to the seed value. Override to decouple seed (data) from
+    /// Defaults to the open payload's input text. Override to decouple open payload data from
     /// the visible input field.
-    fn initial_input(&self, seed: Option<&str>) -> String {
-        seed.unwrap_or("").to_string()
+    fn initial_input(&self, open_payload: Option<&PaletteOpenPayload>) -> String {
+        open_payload
+            .and_then(PaletteOpenPayload::initial_input)
+            .unwrap_or("")
+            .to_string()
     }
 }
 

--- a/src/search/palette.rs
+++ b/src/search/palette.rs
@@ -123,13 +123,6 @@ impl PaletteProvider for SearchPaletteProvider {
             "{enter} search   {history} history   {matcher} matcher"
         ))
     }
-
-    fn initial_input(&self, open_payload: Option<&PaletteOpenPayload>) -> String {
-        open_payload
-            .and_then(PaletteOpenPayload::initial_input)
-            .unwrap_or("")
-            .to_string()
-    }
 }
 
 #[cfg(test)]
@@ -143,7 +136,7 @@ mod tests {
     use super::SearchPaletteProvider;
 
     #[test]
-    fn search_seed_prefills_query_input() {
+    fn search_payload_prefills_query_input() {
         let provider = SearchPaletteProvider;
         let open_payload = PaletteOpenPayload::Search {
             query: "needle".to_string(),
@@ -154,7 +147,7 @@ mod tests {
     }
 
     #[test]
-    fn search_seed_selects_current_matcher() {
+    fn search_payload_selects_current_matcher() {
         let provider = SearchPaletteProvider;
         let app = crate::app::AppState::default();
         let extensions = ExtensionUiSnapshot::default();
@@ -178,7 +171,7 @@ mod tests {
     }
 
     #[test]
-    fn non_search_seed_keeps_default_selection() {
+    fn non_search_payload_keeps_default_selection() {
         let provider = SearchPaletteProvider;
         let app = crate::app::AppState::default();
         let extensions = ExtensionUiSnapshot::default();

--- a/src/search/palette.rs
+++ b/src/search/palette.rs
@@ -5,8 +5,9 @@ use crate::input::shortcut::{
     ShortcutKey, format_shortcut_alternatives_tight, format_shortcut_key,
 };
 use crate::palette::{
-    PaletteCandidate, PaletteContext, PaletteInputMode, PaletteKind, PalettePayload,
-    PalettePostAction, PaletteProvider, PaletteSearchText, PaletteSubmitEffect, PaletteTextPart,
+    PaletteCandidate, PaletteContext, PaletteInputMode, PaletteKind, PaletteOpenPayload,
+    PalettePayload, PalettePostAction, PaletteProvider, PaletteSearchText, PaletteSubmitEffect,
+    PaletteTextPart,
 };
 
 pub struct SearchPaletteProvider;
@@ -26,6 +27,23 @@ impl PaletteProvider for SearchPaletteProvider {
 
     fn reset_selection_on_input_change(&self) -> bool {
         false
+    }
+
+    fn initial_selected_candidate(
+        &self,
+        ctx: &PaletteContext<'_>,
+        candidates: &[PaletteCandidate],
+    ) -> Option<usize> {
+        let PaletteOpenPayload::Search { matcher, .. } = ctx.open_payload? else {
+            return None;
+        };
+
+        candidates
+            .iter()
+            .position(|candidate| match &candidate.payload {
+                PalettePayload::Opaque(id) => SearchMatcherKind::parse(id) == Some(*matcher),
+                PalettePayload::None => false,
+            })
     }
 
     fn list(&self, _ctx: &PaletteContext<'_>) -> AppResult<Vec<PaletteCandidate>> {
@@ -68,7 +86,7 @@ impl PaletteProvider for SearchPaletteProvider {
         if query.is_empty() {
             return Ok(PaletteSubmitEffect::Reopen {
                 kind: self.kind(),
-                seed: None,
+                payload: None,
             });
         }
 
@@ -104,5 +122,76 @@ impl PaletteProvider for SearchPaletteProvider {
         Some(format!(
             "{enter} search   {history} history   {matcher} matcher"
         ))
+    }
+
+    fn initial_input(&self, open_payload: Option<&PaletteOpenPayload>) -> String {
+        open_payload
+            .and_then(PaletteOpenPayload::initial_input)
+            .unwrap_or("")
+            .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        command::SearchMatcherKind,
+        extension::ExtensionUiSnapshot,
+        palette::{PaletteContext, PaletteKind, PaletteOpenPayload, PaletteProvider},
+    };
+
+    use super::SearchPaletteProvider;
+
+    #[test]
+    fn search_seed_prefills_query_input() {
+        let provider = SearchPaletteProvider;
+        let open_payload = PaletteOpenPayload::Search {
+            query: "needle".to_string(),
+            matcher: SearchMatcherKind::ContainsSensitive,
+        };
+
+        assert_eq!(provider.initial_input(Some(&open_payload)), "needle");
+    }
+
+    #[test]
+    fn search_seed_selects_current_matcher() {
+        let provider = SearchPaletteProvider;
+        let app = crate::app::AppState::default();
+        let extensions = ExtensionUiSnapshot::default();
+        let open_payload = PaletteOpenPayload::Search {
+            query: "needle".to_string(),
+            matcher: SearchMatcherKind::ContainsSensitive,
+        };
+        let ctx = PaletteContext {
+            app: &app,
+            extensions: &extensions,
+            kind: PaletteKind::Search,
+            input: "needle",
+            open_payload: Some(&open_payload),
+        };
+        let candidates = provider.list(&ctx).expect("search list should build");
+
+        assert_eq!(
+            provider.initial_selected_candidate(&ctx, &candidates),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn non_search_seed_keeps_default_selection() {
+        let provider = SearchPaletteProvider;
+        let app = crate::app::AppState::default();
+        let extensions = ExtensionUiSnapshot::default();
+        let open_payload = PaletteOpenPayload::CommandInput("needle".to_string());
+        let ctx = PaletteContext {
+            app: &app,
+            extensions: &extensions,
+            kind: PaletteKind::Search,
+            input: "needle",
+            open_payload: Some(&open_payload),
+        };
+        let candidates = provider.list(&ctx).expect("search list should build");
+
+        assert_eq!(provider.initial_selected_candidate(&ctx, &candidates), None);
     }
 }

--- a/src/search/state.rs
+++ b/src/search/state.rs
@@ -5,7 +5,7 @@ use crate::app::{AppState, NoticeAction, PaletteRequest};
 use crate::backend::SharedPdfBackend;
 use crate::command::{CommandOutcome, SearchMatcherKind};
 use crate::error::AppResult;
-use crate::palette::PaletteKind;
+use crate::palette::{PaletteKind, PaletteOpenPayload};
 
 use super::engine::{SearchEngine, SearchEvent, SearchMatcher};
 
@@ -117,14 +117,17 @@ impl SearchState {
         _app: &mut AppState,
         palette_requests: &mut VecDeque<PaletteRequest>,
     ) -> (CommandOutcome, NoticeAction) {
-        let seed = if self.query.is_empty() {
+        let payload = if self.query.is_empty() {
             None
         } else {
-            Some(self.query.clone())
+            Some(PaletteOpenPayload::Search {
+                query: self.query.clone(),
+                matcher: self.matcher,
+            })
         };
         palette_requests.push_back(PaletteRequest::Open {
             kind: PaletteKind::Search,
-            seed,
+            payload,
         });
         (CommandOutcome::Applied, NoticeAction::Clear)
     }
@@ -366,12 +369,14 @@ fn remove_whitespace(input: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
 
-    use crate::app::{AppState, NoticeAction};
+    use crate::app::{AppState, NoticeAction, PaletteRequest};
     use crate::backend::{PdfBackend, RgbaFrame, SharedPdfBackend};
     use crate::command::{CommandOutcome, SearchMatcherKind};
+    use crate::palette::{PaletteKind, PaletteOpenPayload};
     use crate::search::engine::SearchEngine;
 
     use super::SearchState;
@@ -448,6 +453,32 @@ mod tests {
         assert_eq!(
             state.status_bar_segment(),
             Some("SEARCH 0 hits".to_string())
+        );
+    }
+
+    #[test]
+    fn open_palette_includes_query_and_matcher_in_seed() {
+        let mut state = SearchState {
+            query: "needle".to_string(),
+            matcher: SearchMatcherKind::ContainsSensitive,
+            ..SearchState::default()
+        };
+        let mut app = AppState::default();
+        let mut requests = VecDeque::new();
+
+        let (outcome, notice) = state.open_palette(&mut app, &mut requests);
+
+        assert_eq!(outcome, CommandOutcome::Applied);
+        assert_eq!(notice, NoticeAction::Clear);
+        assert_eq!(
+            requests.pop_front(),
+            Some(PaletteRequest::Open {
+                kind: PaletteKind::Search,
+                payload: Some(PaletteOpenPayload::Search {
+                    query: "needle".to_string(),
+                    matcher: SearchMatcherKind::ContainsSensitive,
+                }),
+            })
         );
     }
 

--- a/src/search/state.rs
+++ b/src/search/state.rs
@@ -457,7 +457,7 @@ mod tests {
     }
 
     #[test]
-    fn open_palette_includes_query_and_matcher_in_seed() {
+    fn open_palette_includes_query_and_matcher_in_payload() {
         let mut state = SearchState {
             query: "needle".to_string(),
             matcher: SearchMatcherKind::ContainsSensitive,


### PR DESCRIPTION
Rationale
The search palette only preserved the current query, and palette reopen state relied on a generic seed shape that made palette-specific payloads harder to maintain.

Approach
- replace generic palette seeds with typed open payloads
- reopen search with both query and matcher so the current matcher is initially selected
- keep command, history, and outline reopen data typed by palette kind
- preserve `open-palette <kind> [seed]` by parsing payloads per palette kind

Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Palette reopen behavior unified: palettes can reopen with structured context so Search pre-fills the previous query and matcher, Command preserves current input when reopening, and History reopens with its serialized context while keeping the visible input empty.

* **Documentation**
  * Palette docs updated to describe the new reopen and initial-input behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->