### PR TITLE
feat: add search results palette and hit highlighting

### DIFF
--- a/docs/command-system.md
+++ b/docs/command-system.md
@@ -120,6 +120,8 @@ Command-specific parsing rules:
 - `submit-search <query> [matcher]`
   - requires a non-empty query
   - if the last token matches a known matcher id, it is parsed as matcher
+- `search-goto <page>`
+  - requires exactly one integer page argument
 - `history-goto <page>`
   - requires exactly one integer page argument
 - `outline-goto <page> <title>`
@@ -190,6 +192,7 @@ Public commands:
 - Help and search
   - `help`
   - `search`
+  - `search-results`
   - `next-search-hit`
   - `prev-search-hit`
   - `cancel-search`
@@ -209,6 +212,7 @@ Internal commands:
 - `close-palette`
 - `close-help`
 - `submit-search <query> [matcher]`
+- `search-goto <page>`
 - `history-goto <page>`
 - `outline-goto <page> <title>`
 
@@ -216,6 +220,7 @@ Availability-gated public commands:
 
 - `next-search-hit`
 - `prev-search-hit`
+- `search-results`
 
 These are available only while search is active.
 

--- a/docs/palette-provider.md
+++ b/docs/palette-provider.md
@@ -73,7 +73,7 @@ Selection rules:
 - `<esc>` closes the current palette
 - `<c-p>` / `<c-n>` move the current selection
 - `<up>` / `<down>` recall input history in command and search palettes
-- `<up>` / `<down>` move selection in history and outline palettes
+- `<up>` / `<down>` move selection in history, outline, and search-results palettes
 - `<tab>` applies the provider `on_tab` effect
 - `<enter>` applies the provider `on_submit` effect
 
@@ -157,6 +157,18 @@ current input.
 - search history stores only the query text
 - pressing Enter with empty input reopens for correction
 - successful submit dispatches internal search-submit behavior and closes
+
+### Search-results palette
+
+- kind: `PaletteKind::SearchResults`
+- command entry point: `search-results`
+- input mode: `Custom`
+- availability: only while search is active
+- candidates represent search hit occurrences (including multiple hits on the same page)
+- row text shows hit index, context snippet containing the matched segment, and page label
+- matching uses hit index first, then snippet text, then page label
+- an empty hit list is valid and keeps the palette open with assistive text
+- Enter dispatches internal search-goto behavior and closes
 
 ### History palette
 

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -60,6 +60,9 @@ Rules:
     matchers
   - search runs asynchronously and reports progress while active
   - `search` opens the search palette
+  - `search-results` opens the search hit list palette while search is active
+  - search-results rows show hit index, context snippet, and page label
+  - the search-results palette can open even when there are zero hits
   - `next-search-hit` and `prev-search-hit` are available only while search is
     active
   - `cancel-search` cancels the active search state when search is active

--- a/src/command/dispatch.rs
+++ b/src/command/dispatch.rs
@@ -122,8 +122,14 @@ pub fn dispatch(
         Command::OpenHelp => open_help(app),
         Command::CloseHelp => close_help(app),
         Command::OpenSearch => Ok(extension_host.open_search_palette(app, palette_requests)),
+        Command::OpenSearchResults => {
+            Ok(extension_host.open_search_results_palette(app, palette_requests))
+        }
         Command::SubmitSearch { query, matcher } => {
             extension_host.submit_search(app, Arc::clone(&pdf), query, matcher)
+        }
+        Command::SearchResultGoto { page } => {
+            extension_host.search_result_goto(app, page_count, page)
         }
         Command::NextSearchHit => Ok(extension_host.next_search_hit(app)),
         Command::PrevSearchHit => Ok(extension_host.prev_search_hit(app)),
@@ -217,9 +223,11 @@ fn derive_nav_reason(command: &Command, extension_host: &ExtensionHost) -> Optio
         Command::LastPage => Some(NavReason::Goto(GotoKind::LastPage)),
         Command::GotoPage { .. } => Some(NavReason::Goto(GotoKind::SpecificPage)),
         Command::SetPageLayout { .. } => Some(NavReason::LayoutNormalize),
-        Command::NextSearchHit | Command::PrevSearchHit => Some(NavReason::Search {
-            query: extension_host.search_query().to_string(),
-        }),
+        Command::SearchResultGoto { .. } | Command::NextSearchHit | Command::PrevSearchHit => {
+            Some(NavReason::Search {
+                query: extension_host.search_query().to_string(),
+            })
+        }
         Command::HistoryBack => Some(NavReason::History(HistoryOp::Back)),
         Command::HistoryForward => Some(NavReason::History(HistoryOp::Forward)),
         Command::HistoryGoto { .. } => Some(NavReason::History(HistoryOp::Goto)),
@@ -239,6 +247,7 @@ fn derive_nav_reason(command: &Command, extension_host: &ExtensionHost) -> Optio
         | Command::OpenHelp
         | Command::CloseHelp
         | Command::OpenSearch
+        | Command::OpenSearchResults
         | Command::SubmitSearch { .. }
         | Command::OpenHistory
         | Command::OpenOutline

--- a/src/command/parse.rs
+++ b/src/command/parse.rs
@@ -47,7 +47,9 @@ pub fn parse_command_text(input: &str) -> AppResult<Command> {
         "help" => parse_no_args(id, args_text, Command::OpenHelp),
         "close-help" => parse_no_args(id, args_text, Command::CloseHelp),
         "search" => parse_no_args(id, args_text, Command::OpenSearch),
+        "search-results" => parse_no_args(id, args_text, Command::OpenSearchResults),
         "submit-search" => parse_submit_search(args_text),
+        "search-goto" => parse_search_goto(args_text),
         "next-search-hit" => parse_no_args(id, args_text, Command::NextSearchHit),
         "prev-search-hit" => parse_no_args(id, args_text, Command::PrevSearchHit),
         "history-back" => parse_no_args(id, args_text, Command::HistoryBack),
@@ -114,6 +116,7 @@ fn parse_no_args(id: &str, args_text: &str, cmd: Command) -> AppResult<Command> 
         "help" => "help does not accept arguments",
         "close-help" => "close-help does not accept arguments",
         "search" => "search does not accept arguments",
+        "search-results" => "search-results does not accept arguments",
         "next-search-hit" => "next-search-hit does not accept arguments",
         "prev-search-hit" => "prev-search-hit does not accept arguments",
         "history-back" => "history-back does not accept arguments",
@@ -161,6 +164,7 @@ fn parse_open_palette_payload(kind: PaletteKind, input: &str) -> Option<PaletteO
             query: input.to_string(),
             matcher: SearchMatcherKind::ContainsInsensitive,
         },
+        PaletteKind::SearchResults => PaletteOpenPayload::SearchResultsQuery(input.to_string()),
         PaletteKind::History => PaletteOpenPayload::HistorySeed(input.to_string()),
         PaletteKind::Outline => PaletteOpenPayload::OutlineQuery(input.to_string()),
     })
@@ -325,6 +329,31 @@ fn parse_submit_search(args_text: &str) -> AppResult<Command> {
     Ok(Command::SubmitSearch { query, matcher })
 }
 
+fn parse_search_goto(args_text: &str) -> AppResult<Command> {
+    let mut parts = args_text.split_whitespace();
+    let Some(page_text) = parts.next() else {
+        return Err(AppError::invalid_argument(
+            "search-goto requires 1 argument: page",
+        ));
+    };
+    if parts.next().is_some() {
+        return Err(AppError::invalid_argument(
+            "search-goto accepts exactly 1 argument",
+        ));
+    }
+
+    let page = page_text
+        .parse::<i32>()
+        .map_err(|_| AppError::invalid_argument("search-goto page must be an integer"))?;
+    if page < 1 {
+        return Err(AppError::invalid_argument("page number must be >= 1"));
+    }
+
+    Ok(Command::SearchResultGoto {
+        page: page as usize,
+    })
+}
+
 fn parse_history_goto(args_text: &str) -> AppResult<Command> {
     let mut parts = args_text.split_whitespace();
     let Some(page_text) = parts.next() else {
@@ -452,6 +481,13 @@ mod tests {
                 payload: Some(PaletteOpenPayload::OutlineQuery("appendix".to_string())),
             }
         );
+        assert_eq!(
+            parse_command_text("open-palette search-results needle").expect("parse should succeed"),
+            Command::OpenPalette {
+                kind: PaletteKind::SearchResults,
+                payload: Some(PaletteOpenPayload::SearchResultsQuery("needle".to_string())),
+            }
+        );
     }
 
     #[test]
@@ -459,6 +495,10 @@ mod tests {
         assert_eq!(
             parse_command_text("search").expect("parse should succeed"),
             Command::OpenSearch
+        );
+        assert_eq!(
+            parse_command_text("search-results").expect("parse should succeed"),
+            Command::OpenSearchResults
         );
     }
 
@@ -486,6 +526,14 @@ mod tests {
                 query: "hello".to_string(),
                 matcher: SearchMatcherKind::ContainsSensitive,
             }
+        );
+    }
+
+    #[test]
+    fn parse_search_goto_accepts_page() {
+        assert_eq!(
+            parse_command_text("search-goto 8").expect("parse should succeed"),
+            Command::SearchResultGoto { page: 8 }
         );
     }
 

--- a/src/command/spec.rs
+++ b/src/command/spec.rs
@@ -77,6 +77,12 @@ const ARGS_HISTORY_GOTO: [ArgSpec; 1] = [ArgSpec {
     required: true,
     hint: ArgHint::None,
 }];
+const ARGS_SEARCH_GOTO: [ArgSpec; 1] = [ArgSpec {
+    name: "page",
+    kind: ArgKind::I32,
+    required: true,
+    hint: ArgHint::None,
+}];
 const ARGS_OUTLINE_GOTO: [ArgSpec; 2] = [
     ArgSpec {
         name: "page",
@@ -92,7 +98,7 @@ const ARGS_OUTLINE_GOTO: [ArgSpec; 2] = [
     },
 ];
 
-const COMMAND_SPECS: [CommandSpec; 31] = [
+const COMMAND_SPECS: [CommandSpec; 33] = [
     CommandSpec {
         id: "next-page",
         title: "Next Page",
@@ -254,12 +260,28 @@ const COMMAND_SPECS: [CommandSpec; 31] = [
         availability: CommandAvailability::Always,
     },
     CommandSpec {
+        id: "search-results",
+        title: "Open Search Results",
+        args: &NO_ARGS,
+        exposure: CommandExposure::Public,
+        invocation: CommandInvocationPolicy::User,
+        availability: CommandAvailability::AllOf(&REQUIRES_SEARCH_ACTIVE),
+    },
+    CommandSpec {
         id: "submit-search",
         title: "Submit Search",
         args: &ARGS_SUBMIT_SEARCH,
         exposure: CommandExposure::Internal,
         invocation: CommandInvocationPolicy::InternalOnly,
         availability: CommandAvailability::Always,
+    },
+    CommandSpec {
+        id: "search-goto",
+        title: "Search Go to Result",
+        args: &ARGS_SEARCH_GOTO,
+        exposure: CommandExposure::Internal,
+        invocation: CommandInvocationPolicy::InternalOnly,
+        availability: CommandAvailability::AllOf(&REQUIRES_SEARCH_ACTIVE),
     },
     CommandSpec {
         id: "next-search-hit",
@@ -513,6 +535,10 @@ mod tests {
         };
 
         let err = validate_command_id_for_source("next-search-hit", &ctx)
+            .expect_err("command should be unavailable");
+        assert!(err.to_string().contains("search is inactive"));
+
+        let err = validate_command_id_for_source("search-results", &ctx)
             .expect_err("command should be unavailable");
         assert!(err.to_string().contains("search is inactive"));
     }

--- a/src/command/types.rs
+++ b/src/command/types.rs
@@ -206,9 +206,13 @@ pub enum Command {
     OpenHelp,
     CloseHelp,
     OpenSearch,
+    OpenSearchResults,
     SubmitSearch {
         query: String,
         matcher: SearchMatcherKind,
+    },
+    SearchResultGoto {
+        page: usize,
     },
     NextSearchHit,
     PrevSearchHit,
@@ -252,7 +256,9 @@ impl Command {
             Self::OpenHelp => "help",
             Self::CloseHelp => "close-help",
             Self::OpenSearch => "search",
+            Self::OpenSearchResults => "search-results",
             Self::SubmitSearch { .. } => "submit-search",
+            Self::SearchResultGoto { .. } => "search-goto",
             Self::NextSearchHit => "next-search-hit",
             Self::PrevSearchHit => "prev-search-hit",
             Self::HistoryBack => "history-back",
@@ -331,7 +337,9 @@ pub enum ActionId {
     Help,
     CloseHelp,
     Search,
+    SearchResults,
     SubmitSearch,
+    SearchResultGoto,
     NextSearchHit,
     PrevSearchHit,
     HistoryBack,
@@ -376,7 +384,9 @@ impl ActionId {
             Self::Help => "help",
             Self::CloseHelp => "close-help",
             Self::Search => "search",
+            Self::SearchResults => "search-results",
             Self::SubmitSearch => "submit-search",
+            Self::SearchResultGoto => "search-goto",
             Self::NextSearchHit => "next-search-hit",
             Self::PrevSearchHit => "prev-search-hit",
             Self::HistoryBack => "history-back",
@@ -423,7 +433,9 @@ impl Command {
             Self::OpenHelp => ActionId::Help,
             Self::CloseHelp => ActionId::CloseHelp,
             Self::OpenSearch => ActionId::Search,
+            Self::OpenSearchResults => ActionId::SearchResults,
             Self::SubmitSearch { .. } => ActionId::SubmitSearch,
+            Self::SearchResultGoto { .. } => ActionId::SearchResultGoto,
             Self::NextSearchHit => ActionId::NextSearchHit,
             Self::PrevSearchHit => ActionId::PrevSearchHit,
             Self::HistoryBack => ActionId::HistoryBack,
@@ -515,12 +527,20 @@ mod tests {
     fn command_action_id_maps_search_and_history_variants() {
         assert_eq!(Command::OpenSearch.action_id(), ActionId::Search);
         assert_eq!(
+            Command::OpenSearchResults.action_id(),
+            ActionId::SearchResults
+        );
+        assert_eq!(
             Command::SubmitSearch {
                 query: "q".to_string(),
                 matcher: SearchMatcherKind::ContainsInsensitive,
             }
             .action_id(),
             ActionId::SubmitSearch
+        );
+        assert_eq!(
+            Command::SearchResultGoto { page: 3 }.action_id(),
+            ActionId::SearchResultGoto
         );
         assert_eq!(Command::ZoomReset.action_id(), ActionId::ZoomReset);
         assert_eq!(Command::HistoryBack.action_id(), ActionId::HistoryBack);

--- a/src/extension/host.rs
+++ b/src/extension/host.rs
@@ -9,13 +9,14 @@ use crate::event::AppEvent;
 use crate::history::{HistoryExtension, HistoryState};
 use crate::input::{AppInputEvent, InputHookResult};
 use crate::outline::{OutlineExtension, OutlinePaletteEntry, OutlineState};
-use crate::search::{SearchExtension, SearchRuntime};
+use crate::search::{SearchExtension, SearchPaletteEntry, SearchRuntime};
 
 use super::traits::Extension;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ExtensionUiSnapshot {
     pub search_active: bool,
+    pub search_results_entries: Arc<[SearchPaletteEntry]>,
     pub outline_entries: Arc<[OutlinePaletteEntry]>,
 }
 
@@ -23,6 +24,7 @@ impl ExtensionUiSnapshot {
     pub fn with_search_active(search_active: bool) -> Self {
         Self {
             search_active,
+            search_results_entries: Arc::from([]),
             outline_entries: Arc::from([]),
         }
     }
@@ -85,6 +87,23 @@ impl ExtensionHost {
         matcher: SearchMatcherKind,
     ) -> AppResult<(CommandOutcome, NoticeAction)> {
         self.search.submit(app, pdf, query, matcher)
+    }
+
+    pub fn open_search_results_palette(
+        &mut self,
+        app: &mut AppState,
+        palette_requests: &mut VecDeque<PaletteRequest>,
+    ) -> (CommandOutcome, NoticeAction) {
+        self.search.open_results_palette(app, palette_requests)
+    }
+
+    pub fn search_result_goto(
+        &mut self,
+        app: &mut AppState,
+        page_count: usize,
+        page: usize,
+    ) -> AppResult<(CommandOutcome, NoticeAction)> {
+        self.search.goto_result(app, page_count, page)
     }
 
     pub fn cancel_search(&mut self, pdf: SharedPdfBackend) -> AppResult<bool> {
@@ -175,6 +194,7 @@ impl ExtensionHost {
     pub fn ui_snapshot(&self) -> ExtensionUiSnapshot {
         ExtensionUiSnapshot {
             search_active: self.search.is_active(),
+            search_results_entries: self.search.palette_entries(),
             outline_entries: self.outline.palette_entries(),
         }
     }

--- a/src/extension/mod.rs
+++ b/src/extension/mod.rs
@@ -3,6 +3,6 @@ mod traits;
 
 pub use crate::history::HistoryPaletteProvider;
 pub use crate::outline::OutlinePaletteProvider;
-pub use crate::search::SearchPaletteProvider;
+pub use crate::search::{SearchPaletteProvider, SearchResultsPaletteProvider};
 pub use host::{ExtensionHost, ExtensionUiSnapshot};
 pub use traits::Extension;

--- a/src/input/history.rs
+++ b/src/input/history.rs
@@ -46,7 +46,7 @@ impl InputHistoryService {
         match kind {
             PaletteKind::Command => Some(self.command_snapshot()),
             PaletteKind::Search => Some(self.search_snapshot()),
-            PaletteKind::History | PaletteKind::Outline => None,
+            PaletteKind::SearchResults | PaletteKind::History | PaletteKind::Outline => None,
         }
     }
 
@@ -135,6 +135,11 @@ mod tests {
 
         assert!(history.snapshot_for_palette(PaletteKind::Command).is_some());
         assert!(history.snapshot_for_palette(PaletteKind::Search).is_some());
+        assert!(
+            history
+                .snapshot_for_palette(PaletteKind::SearchResults)
+                .is_none()
+        );
         assert!(history.snapshot_for_palette(PaletteKind::History).is_none());
         assert!(history.snapshot_for_palette(PaletteKind::Outline).is_none());
     }

--- a/src/palette/kind.rs
+++ b/src/palette/kind.rs
@@ -2,6 +2,7 @@
 pub enum PaletteKind {
     Command,
     Search,
+    SearchResults,
     History,
     Outline,
 }
@@ -11,6 +12,7 @@ impl PaletteKind {
         match self {
             Self::Command => "command",
             Self::Search => "search",
+            Self::SearchResults => "search-results",
             Self::History => "history",
             Self::Outline => "outline",
         }
@@ -20,6 +22,7 @@ impl PaletteKind {
         match value {
             "command" => Some(Self::Command),
             "search" => Some(Self::Search),
+            "search-results" => Some(Self::SearchResults),
             "history" => Some(Self::History),
             "outline" => Some(Self::Outline),
             _ => None,

--- a/src/palette/providers/command.rs
+++ b/src/palette/providers/command.rs
@@ -705,10 +705,16 @@ mod tests {
         assert!(
             !list
                 .iter()
+                .any(|candidate| candidate.id == "search-results")
+        );
+        assert!(
+            !list
+                .iter()
                 .any(|candidate| candidate.id == "prev-search-hit")
         );
         assert!(!list.iter().any(|candidate| candidate.id == "open-palette"));
         assert!(!list.iter().any(|candidate| candidate.id == "submit-search"));
+        assert!(!list.iter().any(|candidate| candidate.id == "search-goto"));
         assert!(!list.iter().any(|candidate| candidate.id == "history-goto"));
     }
 
@@ -729,6 +735,10 @@ mod tests {
         assert!(
             list.iter()
                 .any(|candidate| candidate.id == "next-search-hit")
+        );
+        assert!(
+            list.iter()
+                .any(|candidate| candidate.id == "search-results")
         );
         assert!(
             list.iter()

--- a/src/palette/registry.rs
+++ b/src/palette/registry.rs
@@ -1,5 +1,8 @@
 use crate::error::AppResult;
-use crate::extension::{HistoryPaletteProvider, OutlinePaletteProvider, SearchPaletteProvider};
+use crate::extension::{
+    HistoryPaletteProvider, OutlinePaletteProvider, SearchPaletteProvider,
+    SearchResultsPaletteProvider,
+};
 
 use super::providers::CommandPaletteProvider;
 use super::{
@@ -10,6 +13,7 @@ use super::{
 pub struct PaletteRegistry {
     command: CommandPaletteProvider,
     search: SearchPaletteProvider,
+    search_results: SearchResultsPaletteProvider,
     history: HistoryPaletteProvider,
     outline: OutlinePaletteProvider,
 }
@@ -17,6 +21,7 @@ pub struct PaletteRegistry {
 pub enum PaletteProviderRef<'a> {
     Command(&'a CommandPaletteProvider),
     Search(&'a SearchPaletteProvider),
+    SearchResults(&'a SearchResultsPaletteProvider),
     History(&'a HistoryPaletteProvider),
     Outline(&'a OutlinePaletteProvider),
 }
@@ -26,6 +31,7 @@ impl Default for PaletteRegistry {
         Self {
             command: CommandPaletteProvider,
             search: SearchPaletteProvider,
+            search_results: SearchResultsPaletteProvider,
             history: HistoryPaletteProvider,
             outline: OutlinePaletteProvider,
         }
@@ -37,6 +43,7 @@ impl PaletteRegistry {
         match kind {
             PaletteKind::Command => PaletteProviderRef::Command(&self.command),
             PaletteKind::Search => PaletteProviderRef::Search(&self.search),
+            PaletteKind::SearchResults => PaletteProviderRef::SearchResults(&self.search_results),
             PaletteKind::History => PaletteProviderRef::History(&self.history),
             PaletteKind::Outline => PaletteProviderRef::Outline(&self.outline),
         }
@@ -48,6 +55,7 @@ impl<'a> PaletteProviderRef<'a> {
         match self {
             Self::Command(provider) => provider.kind(),
             Self::Search(provider) => provider.kind(),
+            Self::SearchResults(provider) => provider.kind(),
             Self::History(provider) => provider.kind(),
             Self::Outline(provider) => provider.kind(),
         }
@@ -57,6 +65,7 @@ impl<'a> PaletteProviderRef<'a> {
         match self {
             Self::Command(provider) => provider.title(ctx),
             Self::Search(provider) => provider.title(ctx),
+            Self::SearchResults(provider) => provider.title(ctx),
             Self::History(provider) => provider.title(ctx),
             Self::Outline(provider) => provider.title(ctx),
         }
@@ -66,6 +75,7 @@ impl<'a> PaletteProviderRef<'a> {
         match self {
             Self::Command(provider) => provider.input_mode(),
             Self::Search(provider) => provider.input_mode(),
+            Self::SearchResults(provider) => provider.input_mode(),
             Self::History(provider) => provider.input_mode(),
             Self::Outline(provider) => provider.input_mode(),
         }
@@ -75,6 +85,7 @@ impl<'a> PaletteProviderRef<'a> {
         match self {
             Self::Command(provider) => provider.list(ctx),
             Self::Search(provider) => provider.list(ctx),
+            Self::SearchResults(provider) => provider.list(ctx),
             Self::History(provider) => provider.list(ctx),
             Self::Outline(provider) => provider.list(ctx),
         }
@@ -88,6 +99,7 @@ impl<'a> PaletteProviderRef<'a> {
         match self {
             Self::Command(provider) => provider.on_tab(ctx, selected),
             Self::Search(provider) => provider.on_tab(ctx, selected),
+            Self::SearchResults(provider) => provider.on_tab(ctx, selected),
             Self::History(provider) => provider.on_tab(ctx, selected),
             Self::Outline(provider) => provider.on_tab(ctx, selected),
         }
@@ -101,6 +113,7 @@ impl<'a> PaletteProviderRef<'a> {
         match self {
             Self::Command(provider) => provider.on_submit(ctx, selected),
             Self::Search(provider) => provider.on_submit(ctx, selected),
+            Self::SearchResults(provider) => provider.on_submit(ctx, selected),
             Self::History(provider) => provider.on_submit(ctx, selected),
             Self::Outline(provider) => provider.on_submit(ctx, selected),
         }
@@ -114,6 +127,7 @@ impl<'a> PaletteProviderRef<'a> {
         match self {
             Self::Command(provider) => provider.assistive_text(ctx, selected),
             Self::Search(provider) => provider.assistive_text(ctx, selected),
+            Self::SearchResults(provider) => provider.assistive_text(ctx, selected),
             Self::History(provider) => provider.assistive_text(ctx, selected),
             Self::Outline(provider) => provider.assistive_text(ctx, selected),
         }
@@ -123,6 +137,7 @@ impl<'a> PaletteProviderRef<'a> {
         match self {
             Self::Command(provider) => provider.reset_selection_on_input_change(),
             Self::Search(provider) => provider.reset_selection_on_input_change(),
+            Self::SearchResults(provider) => provider.reset_selection_on_input_change(),
             Self::History(provider) => provider.reset_selection_on_input_change(),
             Self::Outline(provider) => provider.reset_selection_on_input_change(),
         }
@@ -136,6 +151,7 @@ impl<'a> PaletteProviderRef<'a> {
         match self {
             Self::Command(provider) => provider.initial_selected_candidate(ctx, candidates),
             Self::Search(provider) => provider.initial_selected_candidate(ctx, candidates),
+            Self::SearchResults(provider) => provider.initial_selected_candidate(ctx, candidates),
             Self::History(provider) => provider.initial_selected_candidate(ctx, candidates),
             Self::Outline(provider) => provider.initial_selected_candidate(ctx, candidates),
         }
@@ -145,6 +161,7 @@ impl<'a> PaletteProviderRef<'a> {
         match self {
             Self::Command(provider) => provider.initial_input(open_payload),
             Self::Search(provider) => provider.initial_input(open_payload),
+            Self::SearchResults(provider) => provider.initial_input(open_payload),
             Self::History(provider) => provider.initial_input(open_payload),
             Self::Outline(provider) => provider.initial_input(open_payload),
         }
@@ -177,6 +194,10 @@ mod tests {
         assert_eq!(
             registry.get(PaletteKind::Search).kind(),
             PaletteKind::Search
+        );
+        assert_eq!(
+            registry.get(PaletteKind::SearchResults).kind(),
+            PaletteKind::SearchResults
         );
         assert_eq!(
             registry.get(PaletteKind::History).kind(),

--- a/src/palette/types.rs
+++ b/src/palette/types.rs
@@ -22,6 +22,7 @@ pub enum PalettePayload {
 pub enum PaletteTextTone {
     Primary,
     Secondary,
+    Highlight,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -53,6 +54,13 @@ impl PaletteTextPart {
         Self {
             text: text.into(),
             tone: PaletteTextTone::Secondary,
+        }
+    }
+
+    pub fn highlight(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            tone: PaletteTextTone::Highlight,
         }
     }
 }
@@ -102,6 +110,7 @@ pub enum PaletteOpenPayload {
     CommandInput(String),
     HistorySeed(String),
     OutlineQuery(String),
+    SearchResultsQuery(String),
     Search {
         query: String,
         matcher: SearchMatcherKind,
@@ -114,6 +123,7 @@ impl PaletteOpenPayload {
             Self::CommandInput(input) => Some(input.as_str()),
             Self::HistorySeed(_) => None,
             Self::OutlineQuery(query) => Some(query.as_str()),
+            Self::SearchResultsQuery(query) => Some(query.as_str()),
             Self::Search { query, .. } => Some(query.as_str()),
         }
     }
@@ -344,6 +354,10 @@ mod tests {
         assert_eq!(
             PaletteTextPart::secondary("b").tone,
             PaletteTextTone::Secondary
+        );
+        assert_eq!(
+            PaletteTextPart::highlight("c").tone,
+            PaletteTextTone::Highlight
         );
     }
 }

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -21,13 +21,37 @@ pub struct SearchSnapshot {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SearchEvent {
     Snapshot(SearchSnapshot),
-    Completed { generation: u64, hits: Vec<usize> },
-    Failed { generation: u64, message: String },
+    Completed {
+        generation: u64,
+        page_hits: Vec<usize>,
+        occurrences: Vec<SearchHitOccurrence>,
+    },
+    Failed {
+        generation: u64,
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchMatchSpan {
+    pub start: usize,
+    pub end: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchHitOccurrence {
+    pub page: usize,
+    pub snippet: String,
+    pub snippet_match_start: Option<usize>,
+    pub snippet_match_end: Option<usize>,
 }
 
 pub trait SearchMatcher: Send + Sync {
     fn prepare_query(&self, raw_query: &str) -> String;
-    fn matches_page(&self, page_text: &str, prepared_query: &str) -> bool;
+    fn find_matches(&self, page_text: &str, prepared_query: &str) -> Vec<SearchMatchSpan>;
+    fn matches_page(&self, page_text: &str, prepared_query: &str) -> bool {
+        !self.find_matches(page_text, prepared_query).is_empty()
+    }
 }
 
 #[derive(Clone)]
@@ -162,8 +186,8 @@ impl SearchMatcher for CancelMatcher {
         String::new()
     }
 
-    fn matches_page(&self, _page_text: &str, _prepared_query: &str) -> bool {
-        false
+    fn find_matches(&self, _page_text: &str, _prepared_query: &str) -> Vec<SearchMatchSpan> {
+        Vec::new()
     }
 }
 
@@ -223,7 +247,8 @@ fn run_job(
         let _ = event_tx.send(SearchEvent::Snapshot(snapshot));
         let _ = event_tx.send(SearchEvent::Completed {
             generation: job.generation,
-            hits: Vec::new(),
+            page_hits: Vec::new(),
+            occurrences: Vec::new(),
         });
         return WorkerControl::Continue;
     }
@@ -232,7 +257,8 @@ fn run_job(
 
     let total_pages = doc.page_count();
 
-    let mut hits = Vec::new();
+    let mut page_hits = Vec::new();
+    let mut occurrences = Vec::new();
     for page in 0..total_pages {
         match flush_requests(request_rx, pending) {
             WorkerControl::Continue => {
@@ -254,8 +280,18 @@ fn run_job(
             }
         };
 
-        if job.matcher.matches_page(&text, &query) {
-            hits.push(page);
+        let matches = job.matcher.find_matches(&text, &query);
+        if !matches.is_empty() {
+            page_hits.push(page);
+            occurrences.extend(matches.into_iter().map(|mat| {
+                let snippet = build_hit_snippet(&text, mat.start, mat.end);
+                SearchHitOccurrence {
+                    page,
+                    snippet: snippet.text,
+                    snippet_match_start: snippet.match_start,
+                    snippet_match_end: snippet.match_end,
+                }
+            }));
         }
 
         let scanned_pages = page + 1;
@@ -263,7 +299,7 @@ fn run_job(
             generation: job.generation,
             scanned_pages,
             total_pages,
-            hit_pages: hits.len(),
+            hit_pages: page_hits.len(),
             done: scanned_pages == total_pages,
         };
         let _ = event_tx.send(SearchEvent::Snapshot(snapshot));
@@ -271,9 +307,74 @@ fn run_job(
 
     let _ = event_tx.send(SearchEvent::Completed {
         generation: job.generation,
-        hits,
+        page_hits,
+        occurrences,
     });
     WorkerControl::Continue
+}
+
+struct SnippetPresentation {
+    text: String,
+    match_start: Option<usize>,
+    match_end: Option<usize>,
+}
+
+fn build_hit_snippet(page_text: &str, start: usize, end: usize) -> SnippetPresentation {
+    const CONTEXT_CHARS: usize = 16;
+
+    let chars = page_text.chars().collect::<Vec<_>>();
+    if chars.is_empty() {
+        return SnippetPresentation {
+            text: String::new(),
+            match_start: None,
+            match_end: None,
+        };
+    }
+
+    let start_char = byte_to_char_index(page_text, start).min(chars.len());
+    let end_char = byte_to_char_index(page_text, end).min(chars.len());
+    let end_char = end_char.max(start_char.saturating_add(1)).min(chars.len());
+
+    let context_start = start_char.saturating_sub(CONTEXT_CHARS);
+    let context_end = end_char.saturating_add(CONTEXT_CHARS).min(chars.len());
+
+    let before = chars[context_start..start_char].iter().collect::<String>();
+    let matched = chars[start_char..end_char].iter().collect::<String>();
+    let after = chars[end_char..context_end].iter().collect::<String>();
+
+    let mut snippet = String::new();
+    let mut match_start = None;
+    let mut match_end = None;
+    if context_start > 0 {
+        snippet.push('…');
+    }
+    snippet.push_str(&before);
+    if !matched.is_empty() {
+        match_start = Some(snippet.len());
+    }
+    snippet.push_str(&matched);
+    if !matched.is_empty() {
+        match_end = Some(snippet.len());
+    }
+    snippet.push_str(&after);
+    if context_end < chars.len() {
+        snippet.push('…');
+    }
+
+    SnippetPresentation {
+        text: snippet,
+        match_start,
+        match_end,
+    }
+}
+
+fn byte_to_char_index(text: &str, byte_idx: usize) -> usize {
+    if byte_idx == 0 {
+        return 0;
+    }
+    text.char_indices()
+        .take_while(|(idx, _)| *idx < byte_idx)
+        .count()
 }
 
 fn flush_requests(
@@ -301,7 +402,7 @@ mod tests {
     use std::thread;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-    use super::{SearchEngine, SearchEvent, SearchMatcher};
+    use super::{SearchEngine, SearchEvent, SearchMatchSpan, SearchMatcher};
     use crate::backend::open_default_backend;
 
     #[derive(Debug)]
@@ -318,18 +419,33 @@ mod tests {
             }
         }
 
-        fn matches_page(&self, page_text: &str, prepared_query: &str) -> bool {
+        fn find_matches(&self, page_text: &str, prepared_query: &str) -> Vec<SearchMatchSpan> {
             let prepared_page = if self.case_sensitive {
                 page_text.to_string()
             } else {
                 page_text.to_lowercase()
             };
 
-            if prepared_page.contains(prepared_query) {
-                return true;
+            let mut matches = Vec::new();
+            let mut offset = 0usize;
+            while offset < prepared_page.len() {
+                let Some(relative) = prepared_page[offset..].find(prepared_query) else {
+                    break;
+                };
+                let start = offset + relative;
+                let end = start + prepared_query.len();
+                matches.push(SearchMatchSpan { start, end });
+                offset = end;
+            }
+            if !matches.is_empty() {
+                return matches;
             }
 
-            remove_whitespace(&prepared_page).contains(&remove_whitespace(prepared_query))
+            let compact_page = remove_whitespace(&prepared_page);
+            if !compact_page.contains(&remove_whitespace(prepared_query)) {
+                return Vec::new();
+            }
+            vec![SearchMatchSpan { start: 0, end: 1 }]
         }
     }
 
@@ -477,11 +593,12 @@ mod tests {
             for event in engine.drain_events() {
                 if let SearchEvent::Completed {
                     generation: event_generation,
-                    hits,
+                    page_hits,
+                    ..
                 } = event
                     && event_generation == generation
                 {
-                    return hits;
+                    return page_hits;
                 }
             }
 

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -6,7 +6,8 @@ use crate::app::AppState;
 use crate::event::AppEvent;
 use crate::extension::Extension;
 pub use palette::SearchPaletteProvider;
-pub use state::{SearchRuntime, SearchState};
+pub use palette::SearchResultsPaletteProvider;
+pub use state::{SearchPaletteEntry, SearchRuntime, SearchState};
 
 pub struct SearchExtension;
 

--- a/src/search/palette.rs
+++ b/src/search/palette.rs
@@ -10,7 +10,10 @@ use crate::palette::{
     PaletteTextPart,
 };
 
+use super::state::SearchPaletteEntry;
+
 pub struct SearchPaletteProvider;
+pub struct SearchResultsPaletteProvider;
 
 impl PaletteProvider for SearchPaletteProvider {
     fn kind(&self) -> PaletteKind {
@@ -125,15 +128,198 @@ impl PaletteProvider for SearchPaletteProvider {
     }
 }
 
+impl PaletteProvider for SearchResultsPaletteProvider {
+    fn kind(&self) -> PaletteKind {
+        PaletteKind::SearchResults
+    }
+
+    fn title(&self, _ctx: &PaletteContext<'_>) -> String {
+        "Search Results".to_string()
+    }
+
+    fn input_mode(&self) -> PaletteInputMode {
+        PaletteInputMode::Custom
+    }
+
+    fn reset_selection_on_input_change(&self) -> bool {
+        true
+    }
+
+    fn initial_selected_candidate(
+        &self,
+        ctx: &PaletteContext<'_>,
+        candidates: &[PaletteCandidate],
+    ) -> Option<usize> {
+        candidates
+            .iter()
+            .position(|candidate| match &candidate.payload {
+                PalettePayload::Opaque(page) => {
+                    page.parse::<usize>().ok() == Some(ctx.app.current_page + 1)
+                }
+                PalettePayload::None => false,
+            })
+    }
+
+    fn list(&self, ctx: &PaletteContext<'_>) -> AppResult<Vec<PaletteCandidate>> {
+        let entries = ctx.extensions.search_results_entries.as_ref();
+        let query = ctx.input.trim().to_ascii_lowercase();
+        if query.is_empty() {
+            return Ok(build_result_candidates(entries));
+        }
+
+        let mut index_matches = Vec::new();
+        let mut snippet_matches = Vec::new();
+        let mut page_matches = Vec::new();
+        for entry in entries.iter() {
+            let candidate = result_candidate(entry);
+            match result_match_bucket(entry, &query) {
+                Some(SearchResultMatchBucket::Index) => index_matches.push(candidate),
+                Some(SearchResultMatchBucket::Snippet) => snippet_matches.push(candidate),
+                Some(SearchResultMatchBucket::Page) => page_matches.push(candidate),
+                None => {}
+            }
+        }
+
+        Ok(index_matches
+            .into_iter()
+            .chain(snippet_matches)
+            .chain(page_matches)
+            .collect())
+    }
+
+    fn on_submit(
+        &self,
+        _ctx: &PaletteContext<'_>,
+        selected: Option<&PaletteCandidate>,
+    ) -> AppResult<PaletteSubmitEffect> {
+        let Some(candidate) = selected else {
+            return Ok(PaletteSubmitEffect::Close);
+        };
+        let page = match &candidate.payload {
+            PalettePayload::Opaque(value) => value.parse::<usize>().ok(),
+            PalettePayload::None => None,
+        };
+        let Some(page) = page else {
+            return Ok(PaletteSubmitEffect::Close);
+        };
+
+        Ok(PaletteSubmitEffect::Dispatch {
+            command: Command::SearchResultGoto { page },
+            history_record: None,
+            next: PalettePostAction::Close,
+        })
+    }
+
+    fn assistive_text(
+        &self,
+        ctx: &PaletteContext<'_>,
+        _selected: Option<&PaletteCandidate>,
+    ) -> Option<String> {
+        if ctx.extensions.search_results_entries.is_empty() {
+            return Some("0 hits".to_string());
+        }
+
+        let enter = format_shortcut_key(ShortcutKey::key(crossterm::event::KeyCode::Enter));
+        Some(format!("{enter} jump to page"))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SearchResultMatchBucket {
+    Index,
+    Snippet,
+    Page,
+}
+
+fn result_match_bucket(entry: &SearchPaletteEntry, query: &str) -> Option<SearchResultMatchBucket> {
+    if entry.index.to_string().contains(query) {
+        return Some(SearchResultMatchBucket::Index);
+    }
+    if entry.snippet.to_ascii_lowercase().contains(query) {
+        return Some(SearchResultMatchBucket::Snippet);
+    }
+    let page_text = page_label(entry.page);
+    if page_text.contains(query) || (entry.page + 1).to_string().contains(query) {
+        return Some(SearchResultMatchBucket::Page);
+    }
+    None
+}
+
+fn page_label(page: usize) -> String {
+    format!("p.{}", page + 1)
+}
+
+fn build_result_candidates(entries: &[SearchPaletteEntry]) -> Vec<PaletteCandidate> {
+    entries.iter().map(result_candidate).collect()
+}
+
+fn snippet_parts(entry: &SearchPaletteEntry) -> Vec<PaletteTextPart> {
+    let snippet = entry.snippet.as_str();
+    let (Some(start), Some(end)) = (entry.snippet_match_start, entry.snippet_match_end) else {
+        return vec![PaletteTextPart::primary(snippet)];
+    };
+    if start >= end || end > snippet.len() {
+        return vec![PaletteTextPart::primary(snippet)];
+    }
+    if !snippet.is_char_boundary(start) || !snippet.is_char_boundary(end) {
+        return vec![PaletteTextPart::primary(snippet)];
+    }
+
+    let before = &snippet[..start];
+    let matched = &snippet[start..end];
+    let after = &snippet[end..];
+
+    let mut parts = Vec::new();
+    if !before.is_empty() {
+        parts.push(PaletteTextPart::secondary(before));
+    }
+    if !matched.is_empty() {
+        parts.push(PaletteTextPart::highlight(matched));
+    }
+    if !after.is_empty() {
+        parts.push(PaletteTextPart::secondary(after));
+    }
+    if parts.is_empty() {
+        vec![PaletteTextPart::primary(snippet)]
+    } else {
+        parts
+    }
+}
+
+fn result_candidate(entry: &SearchPaletteEntry) -> PaletteCandidate {
+    let page = page_label(entry.page);
+    PaletteCandidate {
+        id: format!("result-{}", entry.index),
+        left: {
+            let mut parts = vec![
+                PaletteTextPart::primary(entry.index.to_string()),
+                PaletteTextPart::primary("  "),
+            ];
+            parts.extend(snippet_parts(entry));
+            parts
+        },
+        right: vec![PaletteTextPart::secondary(page.clone())],
+        search_texts: vec![
+            PaletteSearchText::new(entry.index.to_string()),
+            PaletteSearchText::new(entry.snippet.clone()),
+            PaletteSearchText::new(page.clone()),
+            PaletteSearchText::new(format!("page {}", entry.page + 1)),
+            PaletteSearchText::new((entry.page + 1).to_string()),
+        ],
+        payload: PalettePayload::Opaque((entry.page + 1).to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
         command::SearchMatcherKind,
         extension::ExtensionUiSnapshot,
         palette::{PaletteContext, PaletteKind, PaletteOpenPayload, PaletteProvider},
+        search::SearchPaletteEntry,
     };
 
-    use super::SearchPaletteProvider;
+    use super::{SearchPaletteProvider, SearchResultsPaletteProvider};
 
     #[test]
     fn search_payload_prefills_query_input() {
@@ -186,5 +372,56 @@ mod tests {
         let candidates = provider.list(&ctx).expect("search list should build");
 
         assert_eq!(provider.initial_selected_candidate(&ctx, &candidates), None);
+    }
+
+    #[test]
+    fn results_list_shows_index_snippet_and_page() {
+        let provider = SearchResultsPaletteProvider;
+        let app = crate::app::AppState::default();
+        let extensions = ExtensionUiSnapshot {
+            search_results_entries: vec![SearchPaletteEntry {
+                index: 1,
+                page: 4,
+                snippet: "…foo needle bar…".to_string(),
+                snippet_match_start: Some(7),
+                snippet_match_end: Some(13),
+            }]
+            .into(),
+            ..ExtensionUiSnapshot::default()
+        };
+        let ctx = PaletteContext {
+            app: &app,
+            extensions: &extensions,
+            kind: PaletteKind::SearchResults,
+            input: "",
+            open_payload: None,
+        };
+
+        let list = provider.list(&ctx).expect("results list should build");
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].left[0].text, "1");
+        assert_eq!(list[0].left[2].text, "…foo ");
+        assert_eq!(list[0].left[3].text, "needle");
+        assert_eq!(list[0].left[4].text, " bar…");
+        assert_eq!(list[0].right[0].text, "p.5");
+    }
+
+    #[test]
+    fn results_assistive_text_shows_zero_hits() {
+        let provider = SearchResultsPaletteProvider;
+        let app = crate::app::AppState::default();
+        let extensions = ExtensionUiSnapshot::default();
+        let ctx = PaletteContext {
+            app: &app,
+            extensions: &extensions,
+            kind: PaletteKind::SearchResults,
+            input: "",
+            open_payload: None,
+        };
+
+        assert_eq!(
+            provider.assistive_text(&ctx, None),
+            Some("0 hits".to_string())
+        );
     }
 }

--- a/src/search/palette.rs
+++ b/src/search/palette.rs
@@ -1,3 +1,4 @@
+use crate::app::PageLayoutMode;
 use crate::command::{Command, SearchMatcherKind};
 use crate::error::AppResult;
 use crate::input::InputHistoryRecord;
@@ -150,12 +151,19 @@ impl PaletteProvider for SearchResultsPaletteProvider {
         ctx: &PaletteContext<'_>,
         candidates: &[PaletteCandidate],
     ) -> Option<usize> {
+        let primary_page = ctx.app.current_page + 1;
+        let trailing_page = if ctx.app.page_layout_mode == PageLayoutMode::Spread {
+            Some(primary_page + 1)
+        } else {
+            None
+        };
         candidates
             .iter()
             .position(|candidate| match &candidate.payload {
-                PalettePayload::Opaque(page) => {
-                    page.parse::<usize>().ok() == Some(ctx.app.current_page + 1)
-                }
+                PalettePayload::Opaque(page) => page
+                    .parse::<usize>()
+                    .ok()
+                    .is_some_and(|page| page == primary_page || Some(page) == trailing_page),
                 PalettePayload::None => false,
             })
     }
@@ -313,6 +321,7 @@ fn result_candidate(entry: &SearchPaletteEntry) -> PaletteCandidate {
 #[cfg(test)]
 mod tests {
     use crate::{
+        app::PageLayoutMode,
         command::SearchMatcherKind,
         extension::ExtensionUiSnapshot,
         palette::{PaletteContext, PaletteKind, PaletteOpenPayload, PaletteProvider},
@@ -404,6 +413,49 @@ mod tests {
         assert_eq!(list[0].left[3].text, "needle");
         assert_eq!(list[0].left[4].text, " bar…");
         assert_eq!(list[0].right[0].text, "p.5");
+    }
+
+    #[test]
+    fn results_initial_selection_accepts_right_page_of_visible_spread() {
+        let provider = SearchResultsPaletteProvider;
+        let app = crate::app::AppState {
+            current_page: 4,
+            page_layout_mode: PageLayoutMode::Spread,
+            ..crate::app::AppState::default()
+        };
+        let extensions = ExtensionUiSnapshot {
+            search_results_entries: vec![
+                SearchPaletteEntry {
+                    index: 1,
+                    page: 8,
+                    snippet: "other".to_string(),
+                    snippet_match_start: None,
+                    snippet_match_end: None,
+                },
+                SearchPaletteEntry {
+                    index: 2,
+                    page: 5,
+                    snippet: "right".to_string(),
+                    snippet_match_start: None,
+                    snippet_match_end: None,
+                },
+            ]
+            .into(),
+            ..ExtensionUiSnapshot::default()
+        };
+        let ctx = PaletteContext {
+            app: &app,
+            extensions: &extensions,
+            kind: PaletteKind::SearchResults,
+            input: "",
+            open_payload: None,
+        };
+        let candidates = provider.list(&ctx).expect("results list should build");
+
+        assert_eq!(
+            provider.initial_selected_candidate(&ctx, &candidates),
+            Some(1)
+        );
     }
 
     #[test]

--- a/src/search/state.rs
+++ b/src/search/state.rs
@@ -7,7 +7,9 @@ use crate::command::{CommandOutcome, SearchMatcherKind};
 use crate::error::AppResult;
 use crate::palette::{PaletteKind, PaletteOpenPayload};
 
-use super::engine::{SearchEngine, SearchEvent, SearchMatcher};
+use super::engine::{
+    SearchEngine, SearchEvent, SearchHitOccurrence, SearchMatchSpan, SearchMatcher,
+};
 
 #[derive(Default)]
 pub struct SearchRuntime {
@@ -42,6 +44,23 @@ impl SearchRuntime {
             .submit(app, pdf, &mut self.engine, query, matcher)
     }
 
+    pub fn open_results_palette(
+        &mut self,
+        app: &mut AppState,
+        palette_requests: &mut VecDeque<PaletteRequest>,
+    ) -> (CommandOutcome, NoticeAction) {
+        self.state.open_results_palette(app, palette_requests)
+    }
+
+    pub fn goto_result(
+        &mut self,
+        app: &mut AppState,
+        page_count: usize,
+        page: usize,
+    ) -> AppResult<(CommandOutcome, NoticeAction)> {
+        self.state.goto_result(app, page_count, page)
+    }
+
     pub fn cancel(&mut self, pdf: SharedPdfBackend) -> AppResult<bool> {
         self.state.cancel(pdf, &mut self.engine)
     }
@@ -73,6 +92,19 @@ impl SearchRuntime {
     pub fn status_bar_segment(&self) -> Option<String> {
         self.state.status_bar_segment()
     }
+
+    pub fn palette_entries(&self) -> Arc<[SearchPaletteEntry]> {
+        self.state.palette_entries()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchPaletteEntry {
+    pub index: usize,
+    pub page: usize,
+    pub snippet: String,
+    pub snippet_match_start: Option<usize>,
+    pub snippet_match_end: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -90,6 +122,8 @@ pub struct SearchState {
     hit_pages_progress: usize,
     /// Final matched page list (0-based page indexes), available on completion.
     hits: Vec<usize>,
+    /// Final matched occurrences (ordered by scan/page/match order), available on completion.
+    palette_entries: Arc<[SearchPaletteEntry]>,
     current_hit: Option<usize>,
     last_error: Option<String>,
 }
@@ -105,6 +139,7 @@ impl Default for SearchState {
             total_pages: 0,
             hit_pages_progress: 0,
             hits: Vec::new(),
+            palette_entries: Arc::from([]),
             current_hit: None,
             last_error: None,
         }
@@ -128,6 +163,21 @@ impl SearchState {
         palette_requests.push_back(PaletteRequest::Open {
             kind: PaletteKind::Search,
             payload,
+        });
+        (CommandOutcome::Applied, NoticeAction::Clear)
+    }
+
+    pub fn open_results_palette(
+        &mut self,
+        _app: &mut AppState,
+        palette_requests: &mut VecDeque<PaletteRequest>,
+    ) -> (CommandOutcome, NoticeAction) {
+        if self.query.is_empty() {
+            return (CommandOutcome::Noop, NoticeAction::Clear);
+        }
+        palette_requests.push_back(PaletteRequest::Open {
+            kind: PaletteKind::SearchResults,
+            payload: None,
         });
         (CommandOutcome::Applied, NoticeAction::Clear)
     }
@@ -161,6 +211,7 @@ impl SearchState {
         self.total_pages = pdf.page_count();
         self.hit_pages_progress = 0;
         self.hits.clear();
+        self.palette_entries = Arc::from([]);
         self.current_hit = None;
         self.last_error = None;
         Ok((CommandOutcome::Applied, NoticeAction::Clear))
@@ -172,6 +223,30 @@ impl SearchState {
 
     pub fn prev_hit(&mut self, app: &mut AppState) -> (CommandOutcome, NoticeAction) {
         self.move_hit(app, false)
+    }
+
+    pub fn goto_result(
+        &mut self,
+        app: &mut AppState,
+        page_count: usize,
+        page: usize,
+    ) -> AppResult<(CommandOutcome, NoticeAction)> {
+        if page < 1 {
+            return Err(crate::error::AppError::invalid_argument(
+                "page number must be >= 1",
+            ));
+        }
+        if page > page_count {
+            return Err(crate::error::AppError::page_out_of_range(page, page_count));
+        }
+        let target = app.normalize_page_for_layout(page - 1, page_count);
+        if app.current_page == target {
+            self.current_hit = self.hits.iter().position(|hit_page| *hit_page == target);
+            return Ok((CommandOutcome::Noop, NoticeAction::Clear));
+        }
+        app.current_page = target;
+        self.current_hit = self.hits.iter().position(|hit_page| *hit_page == target);
+        Ok((CommandOutcome::Applied, NoticeAction::Clear))
     }
 
     pub fn cancel(
@@ -213,15 +288,20 @@ impl SearchState {
                     self.in_progress = true;
                     changed = true;
                 }
-                SearchEvent::Completed { generation, hits } => {
+                SearchEvent::Completed {
+                    generation,
+                    page_hits,
+                    occurrences,
+                } => {
                     if generation != self.generation {
                         continue;
                     }
                     self.in_progress = false;
                     self.scanned_pages_progress = self.total_pages.max(self.scanned_pages_progress);
-                    self.hit_pages_progress = hits.len();
+                    self.hit_pages_progress = page_hits.len();
                     self.current_hit = None;
-                    self.hits = hits;
+                    self.hits = page_hits;
+                    self.palette_entries = build_palette_entries(occurrences);
                     changed = true;
                 }
                 SearchEvent::Failed {
@@ -279,6 +359,10 @@ impl SearchState {
         Some(format!("SEARCH {} hits", self.hit_pages_progress))
     }
 
+    pub fn palette_entries(&self) -> Arc<[SearchPaletteEntry]> {
+        Arc::clone(&self.palette_entries)
+    }
+
     fn move_hit(&mut self, app: &mut AppState, forward: bool) -> (CommandOutcome, NoticeAction) {
         if self.hits.is_empty() {
             // Without an active search context, hit navigation does not need extra feedback.
@@ -323,9 +407,26 @@ impl SearchState {
         self.total_pages = 0;
         self.hit_pages_progress = 0;
         self.hits.clear();
+        self.palette_entries = Arc::from([]);
         self.current_hit = None;
         self.last_error = None;
     }
+}
+
+fn build_palette_entries(occurrences: Vec<SearchHitOccurrence>) -> Arc<[SearchPaletteEntry]> {
+    Arc::from(
+        occurrences
+            .into_iter()
+            .enumerate()
+            .map(|(idx, hit)| SearchPaletteEntry {
+                index: idx + 1,
+                page: hit.page,
+                snippet: hit.snippet,
+                snippet_match_start: hit.snippet_match_start,
+                snippet_match_end: hit.snippet_match_end,
+            })
+            .collect::<Vec<_>>(),
+    )
 }
 
 fn matcher_for_kind(kind: SearchMatcherKind) -> Arc<dyn SearchMatcher> {
@@ -348,23 +449,90 @@ impl SearchMatcher for ContainsMatcher {
         }
     }
 
-    fn matches_page(&self, page_text: &str, prepared_query: &str) -> bool {
+    fn find_matches(&self, page_text: &str, prepared_query: &str) -> Vec<SearchMatchSpan> {
+        if prepared_query.is_empty() {
+            return Vec::new();
+        }
         let prepared_page = if self.case_sensitive {
             page_text.to_string()
         } else {
             page_text.to_lowercase()
         };
 
-        if prepared_page.contains(prepared_query) {
-            return true;
+        let direct_matches = find_non_overlapping_matches(&prepared_page, prepared_query);
+        if !direct_matches.is_empty() {
+            return direct_matches;
         }
 
-        remove_whitespace(&prepared_page).contains(&remove_whitespace(prepared_query))
+        let compact_matches = find_compact_matches(&prepared_page, prepared_query);
+        if compact_matches.is_empty() {
+            return Vec::new();
+        }
+        compact_matches
     }
 }
 
 fn remove_whitespace(input: &str) -> String {
     input.chars().filter(|ch| !ch.is_whitespace()).collect()
+}
+
+fn find_non_overlapping_matches(page_text: &str, prepared_query: &str) -> Vec<SearchMatchSpan> {
+    let mut matches = Vec::new();
+    let mut offset = 0usize;
+    while offset < page_text.len() {
+        let Some(relative) = page_text[offset..].find(prepared_query) else {
+            break;
+        };
+        let start = offset + relative;
+        let end = start + prepared_query.len();
+        matches.push(SearchMatchSpan { start, end });
+        offset = end;
+    }
+    matches
+}
+
+fn find_compact_matches(page_text: &str, prepared_query: &str) -> Vec<SearchMatchSpan> {
+    let compact_query = remove_whitespace(prepared_query);
+    if compact_query.is_empty() {
+        return Vec::new();
+    }
+    let compact_query_chars = compact_query.chars().collect::<Vec<_>>();
+    if compact_query_chars.is_empty() {
+        return Vec::new();
+    }
+
+    let compact_page = page_text
+        .char_indices()
+        .filter_map(|(start, ch)| {
+            if ch.is_whitespace() {
+                None
+            } else {
+                Some((ch, start, start + ch.len_utf8()))
+            }
+        })
+        .collect::<Vec<_>>();
+    if compact_page.is_empty() {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+    let mut i = 0usize;
+    while i + compact_query_chars.len() <= compact_page.len() {
+        let is_match = compact_query_chars
+            .iter()
+            .enumerate()
+            .all(|(offset, query_ch)| compact_page[i + offset].0 == *query_ch);
+        if is_match {
+            let start = compact_page[i].1;
+            let end = compact_page[i + compact_query_chars.len() - 1].2;
+            matches.push(SearchMatchSpan { start, end });
+            i += compact_query_chars.len();
+        } else {
+            i += 1;
+        }
+    }
+
+    matches
 }
 
 #[cfg(test)]
@@ -480,6 +648,59 @@ mod tests {
                 }),
             })
         );
+    }
+
+    #[test]
+    fn open_results_palette_requires_active_search() {
+        let mut state = SearchState::default();
+        let mut app = AppState::default();
+        let mut requests = VecDeque::new();
+
+        let (outcome, notice) = state.open_results_palette(&mut app, &mut requests);
+
+        assert_eq!(outcome, CommandOutcome::Noop);
+        assert_eq!(notice, NoticeAction::Clear);
+        assert!(requests.is_empty());
+    }
+
+    #[test]
+    fn open_results_palette_is_available_with_zero_hits_when_search_is_active() {
+        let mut state = SearchState {
+            query: "needle".to_string(),
+            ..SearchState::default()
+        };
+        let mut app = AppState::default();
+        let mut requests = VecDeque::new();
+
+        let (outcome, notice) = state.open_results_palette(&mut app, &mut requests);
+
+        assert_eq!(outcome, CommandOutcome::Applied);
+        assert_eq!(notice, NoticeAction::Clear);
+        assert_eq!(
+            requests.pop_front(),
+            Some(PaletteRequest::Open {
+                kind: PaletteKind::SearchResults,
+                payload: None,
+            })
+        );
+    }
+
+    #[test]
+    fn goto_result_moves_to_selected_page() {
+        let mut state = SearchState {
+            query: "needle".to_string(),
+            hits: vec![1, 4],
+            ..SearchState::default()
+        };
+        let mut app = AppState::default();
+
+        let (outcome, notice) = state
+            .goto_result(&mut app, 10, 5)
+            .expect("goto result should succeed");
+
+        assert_eq!(outcome, CommandOutcome::Applied);
+        assert_eq!(notice, NoticeAction::Clear);
+        assert_eq!(app.current_page, 4);
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -9,5 +9,6 @@ pub use help::draw_help_overlay;
 pub use layout::{UiLayout, split_layout};
 pub use overlay::{draw_error_overlay, draw_loading_overlay, draw_palette_overlay};
 pub(crate) use theme::{
-    border, error_text, heading_text, primary_text, secondary_text, warning_text,
+    border, error_text, heading_text, hit_highlight_text, primary_text, secondary_text,
+    warning_text,
 };

--- a/src/ui/overlay.rs
+++ b/src/ui/overlay.rs
@@ -9,7 +9,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::palette::{PaletteItemView, PaletteView};
 
 use super::layout::centered_rect;
-use super::{border, error_text, primary_text, secondary_text};
+use super::{border, error_text, hit_highlight_text, primary_text, secondary_text};
 
 const PALETTE_ITEM_DECORATION_WIDTH: usize = 3;
 const MIN_VISIBLE_SIDE_WIDTH: usize = 4;
@@ -397,6 +397,7 @@ fn palette_text_style(tone: crate::palette::PaletteTextTone, selected: bool) -> 
     match tone {
         crate::palette::PaletteTextTone::Primary => primary_text(),
         crate::palette::PaletteTextTone::Secondary => secondary_text(),
+        crate::palette::PaletteTextTone::Highlight => hit_highlight_text(),
     }
 }
 

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -20,6 +20,10 @@ pub fn warning_text() -> Style {
     Style::default().fg(Color::LightYellow)
 }
 
+pub fn hit_highlight_text() -> Style {
+    Style::default().bg(Color::Yellow)
+}
+
 pub fn error_text() -> Style {
     Style::default().fg(Color::LightRed)
 }


### PR DESCRIPTION
## Why
Search had no way to review and jump from a full hit list; users could only move next/prev hit. This adds a dedicated palette for occurrence-level results and improves hit readability.

## What changed
- Added `search-results` palette flow (open only when search is active)
- Added occurrence-level result entries (index, snippet context, page) and `search-goto` dispatch path
- Extended search engine/state payloads to provide snippet and match-range metadata to the palette
- Updated palette rendering to preserve extracted whitespace in snippets and highlight hit text with terminal-palette background color
- Kept selected-row behavior as uniform foreground/background inversion
- Updated command/palette/runtime docs and related tests

## Risk / impact
- Touches search matching/rendering paths and command wiring, so regressions could affect search navigation/palette behavior
- A known Unicode case-fold offset issue remains and is being handled separately (intentionally left out of this PR)

## Verification
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Search Results palette showing per-hit rows with contextual snippets and highlighted match text
  * Added a search-goto command to jump to a page from results; Enter submits a selected hit and navigates
  * Results palette stays open and usable even when there are zero hits; up/down now navigates results like other palettes

* **Documentation**
  * Updated docs for new commands, palette behavior, keyboard semantics, and empty-state/submit behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->