### PR TITLE
feat(perf): move diagnostics to bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ name = "pvf"
 name = "pvf"
 path = "src/main.rs"
 
+[[bench]]
+name = "perf"
+harness = false
+
 [dependencies]
 bytemuck = { version = "1.25.0", features = ["extern_crate_alloc"] }
 hayro = "0.5.0"

--- a/benches/perf.rs
+++ b/benches/perf.rs
@@ -1,0 +1,82 @@
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use clap::Parser;
+use pvf::error::{AppError, AppResult};
+use pvf::perf::{PerfScenarioId, PerfSuiteConfig, run_suite, write_report};
+
+#[derive(Debug, Parser)]
+#[command(version, about = "Headless pvf performance diagnostics")]
+struct BenchArgs {
+    #[arg(long, value_name = "PATH")]
+    pdf: PathBuf,
+
+    #[arg(long, value_name = "ID|all")]
+    scenario: Vec<String>,
+
+    #[arg(long, default_value_t = 1)]
+    warmup: usize,
+
+    #[arg(long, default_value_t = 5)]
+    iterations: usize,
+
+    #[arg(long, default_value_t = 8)]
+    page_steps: usize,
+
+    #[arg(long, default_value_t = 250)]
+    idle_ms: u64,
+
+    #[arg(long, value_name = "PATH")]
+    out: Option<PathBuf>,
+
+    #[arg(long, hide = true)]
+    bench: bool,
+}
+
+impl BenchArgs {
+    fn suite_config(&self) -> AppResult<PerfSuiteConfig> {
+        let scenarios = parse_scenarios(&self.scenario)?;
+        Ok(PerfSuiteConfig {
+            pdf_path: self.pdf.clone(),
+            scenarios,
+            warmup_iterations: self.warmup,
+            measured_iterations: self.iterations,
+            page_steps: self.page_steps,
+            idle_ms: self.idle_ms,
+        })
+    }
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    let args = BenchArgs::parse();
+    let config = match args.suite_config() {
+        Ok(config) => config,
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(2);
+        }
+    };
+
+    match run_suite(config)
+        .await
+        .and_then(|report| write_report(&report, args.out.as_deref()))
+    {
+        Ok(()) => {}
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn parse_scenarios(values: &[String]) -> AppResult<Vec<PerfScenarioId>> {
+    if values.is_empty() || values.iter().any(|value| value == "all") {
+        return Ok(PerfScenarioId::all().to_vec());
+    }
+
+    values
+        .iter()
+        .map(|value| PerfScenarioId::from_str(value))
+        .collect::<Result<Vec<_>, AppError>>()
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,9 @@ This directory contains the canonical developer-facing documentation.
 2. `command-system.md`
 3. `architecture.md`
 4. `rendering-pipeline.md`
-5. `palette-provider.md`
-6. `extension-system.md`
+5. `performance-diagnostics.md`
+6. `palette-provider.md`
+7. `extension-system.md`
 
 ## Writing rules
 
@@ -27,5 +28,6 @@ This directory contains the canonical developer-facing documentation.
 | `command-system.md` | Command ids, parsing, invocation policy, and dispatch |
 | `architecture.md` | Runtime/module map, subsystem ownership, and event-loop structure |
 | `rendering-pipeline.md` | L1/L2 cache semantics, worker lanes, encode flow, and redraw timing |
+| `performance-diagnostics.md` | Developer scenario benchmark command, scenarios, and JSON report shape |
 | `palette-provider.md` | `PaletteProvider`, `PaletteKind`, palette keyboard behavior, and built-in palettes |
 | `extension-system.md` | `Extension`, `ExtensionHost`, extension flows, and built-in extensions |

--- a/docs/performance-diagnostics.md
+++ b/docs/performance-diagnostics.md
@@ -1,0 +1,72 @@
+# Performance Diagnostics
+
+This document owns developer-facing performance measurement. The public CLI is
+only `pvf <file.pdf>`; diagnostics run through Cargo's bench entry point.
+
+## Command
+
+```bash
+cargo bench --bench perf -- --pdf sample.pdf
+```
+
+Options:
+
+- `--pdf <path>`: required input PDF.
+- `--scenario <id>`: optional and repeatable. Defaults to all scenarios. `all`
+  selects all scenarios explicitly.
+- `--warmup <n>`: warmup iterations, default `1`.
+- `--iterations <n>`: measured iterations, default `5`.
+- `--page-steps <n>`: page navigation steps for page scenarios, default `8`.
+- `--idle-ms <n>`: idle observation window for `idle-settled-redraw`, default
+  `250`.
+- `--out <path>`: optional JSON output path. When omitted, JSON is written to
+  stdout.
+
+The bench binary uses `harness = false` and does not use Criterion. It runs the
+same headless app event loop, render worker, presenter encode path, cache path,
+blit path, and redraw scheduling used by the viewer.
+
+## Scenarios
+
+- `cold-first-page`: PDF open through first settled idle display.
+- `steady-next-page`: after each settled idle state, send the next-page command
+  until `--page-steps` or the last page is reached.
+- `steady-prev-page`: move to the last page side, then after each settled idle
+  state send previous-page until `--page-steps` or page zero is reached.
+- `rapid-next-page`: after first settled idle, enqueue multiple next-page
+  commands without waiting between them and measure until settled.
+- `zoom-step`: after first settled idle, measure zoom-in and zoom-out redraw.
+- `idle-settled-redraw`: after first settled idle, observe the idle window and
+  report redraw activity.
+
+Search performance is intentionally excluded from v1 diagnostics.
+
+## JSON Report
+
+The report is a single JSON document with no separate human summary.
+
+Top-level fields:
+
+- `version`
+- `generated_at_unix_ms`
+- `pdf`: includes `path` and `doc_id`
+- `run`: includes warmup, measured iteration, page-step, and idle settings
+- `scenarios`
+
+Each scenario includes:
+
+- `id`
+- `parameters`
+- `aggregate`
+- `iterations`
+
+Aggregates use count, average, min, p50, p95, p99, and max summaries. Each
+iteration includes wall-clock duration, render/encode/blit phase metrics, queue
+metrics, cache hit rates, redraw counts, final page, and visited step count.
+
+## Code References
+
+- `benches/perf.rs`
+- `src/perf.rs`
+- `src/app/perf_runner.rs`
+- `src/app/event_loop.rs`

--- a/docs/rendering-pipeline.md
+++ b/docs/rendering-pipeline.md
@@ -183,7 +183,9 @@ The runtime tracks:
 - canceled render and encode task counts
 - redraw request counts by reason
 
-These values feed perf JSON reports and offline diagnostics.
+These values feed the developer-only performance diagnostics JSON emitted by
+`cargo bench --bench perf`; the public viewer CLI does not expose a performance
+subcommand.
 
 ## Code references
 

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -18,19 +18,14 @@ Supported invocations:
 
 ```bash
 pvf <file.pdf>
-pvf perf <file.pdf> --scenario <scenario-id> [--out <path|->]
 ```
 
 Rules:
 
 - Exactly one PDF path argument is required.
 - The document is opened through the default backend factory.
-- `perf` runs a built-in scenario, emits JSON, and exits without opening the
-  interactive viewer.
-- Supported perf scenarios are:
-  - `page-flip-forward`
-  - `page-flip-backward`
-  - `idle-pending-redraw`
+- Performance diagnostics are developer tooling and are not part of the public
+  viewer CLI. See `performance-diagnostics.md`.
 
 ## Viewer behavior
 

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -187,6 +187,7 @@ impl App {
         pdf: SharedPdfBackend,
         scenario: PerfScenarioId,
         parameters: PerfScenarioParameters,
+        cold_started_at: Instant,
     ) -> AppResult<PerfIterationSnapshot> {
         let page_count = pdf.page_count();
         if page_count == 0 {
@@ -208,7 +209,7 @@ impl App {
             loop_event_runtime,
         )?;
         let result = self
-            .run_perf_loop(&mut runtime, pdf, scenario, parameters)
+            .run_perf_loop(&mut runtime, pdf, scenario, parameters, cold_started_at)
             .await;
         runtime.loop_event_runtime.shutdown();
         let restore_result = runtime.session.restore();
@@ -306,9 +307,9 @@ impl App {
         pdf: SharedPdfBackend,
         scenario: PerfScenarioId,
         parameters: PerfScenarioParameters,
+        cold_started_at: Instant,
     ) -> AppResult<PerfIterationSnapshot> {
-        let started_at = Instant::now();
-        let mut perf_driver = PerfLoopDriver::new(scenario, parameters);
+        let mut perf_driver = PerfLoopDriver::new(scenario, parameters, cold_started_at);
 
         loop {
             let step = self.process_loop_iteration(runtime, pdf.as_ref())?;
@@ -326,7 +327,7 @@ impl App {
                 return Ok(PerfIterationSnapshot {
                     runtime: self.render.runtime.perf_stats.clone(),
                     presenter: self.render.presenter.perf_snapshot().unwrap_or_default(),
-                    wall_time: started_at.elapsed(),
+                    wall_time: perf_driver.measured_elapsed(),
                     final_page: self.state.current_page,
                     visited_steps: perf_driver.visited_steps(),
                 });

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -8,7 +8,7 @@ use crate::backend::{PdfBackend, SharedPdfBackend};
 use crate::command::{Command, CommandOutcome, CommandRequest, PanAmount};
 use crate::error::{AppError, AppResult};
 use crate::event::DomainEvent;
-use crate::perf::{PerfIterationSnapshot, PerfScenarioId, RedrawReason};
+use crate::perf::{PerfIterationSnapshot, PerfScenarioId, PerfScenarioParameters, RedrawReason};
 use crate::presenter::{ImagePresenter, PanOffset, PresenterBackgroundEvent, Viewport};
 use crate::render::cache::RenderedPageKey;
 use crate::render::scheduler::RenderTask;
@@ -186,6 +186,7 @@ impl App {
         &mut self,
         pdf: SharedPdfBackend,
         scenario: PerfScenarioId,
+        parameters: PerfScenarioParameters,
     ) -> AppResult<PerfIterationSnapshot> {
         let page_count = pdf.page_count();
         if page_count == 0 {
@@ -206,7 +207,9 @@ impl App {
             loop_event_rx,
             loop_event_runtime,
         )?;
-        let result = self.run_perf_loop(&mut runtime, pdf, scenario).await;
+        let result = self
+            .run_perf_loop(&mut runtime, pdf, scenario, parameters)
+            .await;
         runtime.loop_event_runtime.shutdown();
         let restore_result = runtime.session.restore();
         let snapshot = result?;
@@ -302,15 +305,18 @@ impl App {
         runtime: &mut LoopRuntime<HeadlessTerminalSession>,
         pdf: SharedPdfBackend,
         scenario: PerfScenarioId,
+        parameters: PerfScenarioParameters,
     ) -> AppResult<PerfIterationSnapshot> {
-        let mut perf_driver = PerfLoopDriver::new(scenario);
+        let started_at = Instant::now();
+        let mut perf_driver = PerfLoopDriver::new(scenario, parameters);
 
         loop {
             let step = self.process_loop_iteration(runtime, pdf.as_ref())?;
             let system_idle = step.current_cached
                 && runtime.render_worker.in_flight_len() == 0
                 && !self.render.presenter.has_pending_work()
-                && !runtime.ui_actor.needs_redraw();
+                && !runtime.ui_actor.needs_redraw()
+                && runtime.loop_event_rx.is_empty();
             if perf_driver.advance(
                 &self.state,
                 runtime.page_count,
@@ -320,6 +326,9 @@ impl App {
                 return Ok(PerfIterationSnapshot {
                     runtime: self.render.runtime.perf_stats.clone(),
                     presenter: self.render.presenter.perf_snapshot().unwrap_or_default(),
+                    wall_time: started_at.elapsed(),
+                    final_page: self.state.current_page,
+                    visited_steps: perf_driver.visited_steps(),
                 });
             }
 

--- a/src/app/perf_runner.rs
+++ b/src/app/perf_runner.rs
@@ -1,6 +1,6 @@
 use std::convert::Infallible;
 use std::io;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use ratatui::backend::TestBackend;
 use ratatui::layout::Size;
@@ -59,10 +59,15 @@ pub(crate) struct PerfLoopDriver {
     zoomed_in: bool,
     zoomed_out: bool,
     idle_started_at: Option<Instant>,
+    measured_started_at: Option<Instant>,
 }
 
 impl PerfLoopDriver {
-    pub(crate) fn new(scenario: PerfScenarioId, parameters: PerfScenarioParameters) -> Self {
+    pub(crate) fn new(
+        scenario: PerfScenarioId,
+        parameters: PerfScenarioParameters,
+        cold_started_at: Instant,
+    ) -> Self {
         Self {
             scenario,
             parameters,
@@ -73,11 +78,21 @@ impl PerfLoopDriver {
             zoomed_in: false,
             zoomed_out: false,
             idle_started_at: None,
+            measured_started_at: match scenario {
+                PerfScenarioId::ColdFirstPage => Some(cold_started_at),
+                _ => None,
+            },
         }
     }
 
     pub(crate) fn visited_steps(&self) -> usize {
         self.command_count
+    }
+
+    pub(crate) fn measured_elapsed(&self) -> Duration {
+        self.measured_started_at
+            .map(|started_at| started_at.elapsed())
+            .unwrap_or_default()
     }
 
     pub(crate) fn advance(
@@ -99,8 +114,10 @@ impl PerfLoopDriver {
                 if state.current_page >= last_page
                     || self.command_count >= self.parameters.page_steps
                 {
+                    self.start_measured_window();
                     return true;
                 }
+                self.start_measured_window();
                 let _ = loop_event_tx.send(DomainEvent::Command(CommandRequest::new(
                     Command::NextPage,
                     CommandInvocationSource::Keymap,
@@ -123,9 +140,11 @@ impl PerfLoopDriver {
                 }
 
                 if state.current_page == 0 || self.command_count >= self.parameters.page_steps {
+                    self.start_measured_window();
                     return true;
                 }
 
+                self.start_measured_window();
                 let _ = loop_event_tx.send(DomainEvent::Command(CommandRequest::new(
                     Command::PrevPage,
                     CommandInvocationSource::Keymap,
@@ -136,6 +155,7 @@ impl PerfLoopDriver {
             PerfScenarioId::RapidNextPage => {
                 if !self.initial_idle_seen {
                     self.initial_idle_seen = true;
+                    self.start_measured_window();
                     let last_page = page_count.saturating_sub(1);
                     let steps = self
                         .parameters
@@ -156,6 +176,7 @@ impl PerfLoopDriver {
             PerfScenarioId::ZoomStep => {
                 if !self.initial_idle_seen {
                     self.initial_idle_seen = true;
+                    self.start_measured_window();
                     let _ = loop_event_tx.send(DomainEvent::Command(CommandRequest::new(
                         Command::ZoomIn,
                         CommandInvocationSource::Keymap,
@@ -177,12 +198,18 @@ impl PerfLoopDriver {
             }
             PerfScenarioId::IdleSettledRedraw => {
                 let Some(started_at) = self.idle_started_at else {
-                    self.idle_started_at = Some(Instant::now());
+                    let started_at = Instant::now();
+                    self.idle_started_at = Some(started_at);
+                    self.measured_started_at = Some(started_at);
                     return false;
                 };
                 started_at.elapsed().as_millis() >= u128::from(self.parameters.idle_duration_ms)
             }
         }
+    }
+
+    fn start_measured_window(&mut self) {
+        self.measured_started_at.get_or_insert_with(Instant::now);
     }
 }
 
@@ -197,8 +224,11 @@ fn infallible_to_io<T>(result: Result<T, Infallible>) -> io::Result<T> {
 mod tests {
     use ratatui::layout::{Rect, Size};
     use ratatui::widgets::Paragraph;
+    use tokio::sync::mpsc::unbounded_channel;
 
-    use super::{HeadlessTerminalSession, TerminalSurface};
+    use crate::perf::{PerfScenarioId, PerfScenarioParameters};
+
+    use super::{HeadlessTerminalSession, PerfLoopDriver, TerminalSurface};
 
     #[test]
     fn headless_terminal_session_supports_terminal_surface_contract() {
@@ -213,5 +243,49 @@ mod tests {
                 frame.render_widget(Paragraph::new("ok"), Rect::new(0, 0, 2, 1));
             })
             .expect("draw should succeed");
+    }
+
+    #[test]
+    fn non_cold_scenario_starts_measured_window_after_initial_idle() {
+        let (tx, _rx) = unbounded_channel();
+        let mut driver = PerfLoopDriver::new(
+            PerfScenarioId::RapidNextPage,
+            PerfScenarioParameters {
+                page_steps: 2,
+                idle_duration_ms: 0,
+            },
+            std::time::Instant::now(),
+        );
+        let state = crate::app::state::AppState::default();
+
+        assert!(driver.measured_started_at.is_none());
+        assert!(!driver.advance(&state, 3, false, &tx));
+        assert!(driver.measured_started_at.is_none());
+
+        assert!(!driver.advance(&state, 3, true, &tx));
+        assert!(driver.measured_started_at.is_some());
+        assert_eq!(driver.visited_steps(), 2);
+    }
+
+    #[test]
+    fn steady_prev_starts_measured_window_after_last_page_positioning() {
+        let (tx, _rx) = unbounded_channel();
+        let mut driver = PerfLoopDriver::new(
+            PerfScenarioId::SteadyPrevPage,
+            PerfScenarioParameters {
+                page_steps: 1,
+                idle_duration_ms: 0,
+            },
+            std::time::Instant::now(),
+        );
+        let mut state = crate::app::state::AppState::default();
+
+        assert!(!driver.advance(&state, 3, true, &tx));
+        assert!(driver.measured_started_at.is_none());
+
+        state.current_page = 2;
+        assert!(!driver.advance(&state, 3, true, &tx));
+        assert!(driver.measured_started_at.is_some());
+        assert_eq!(driver.visited_steps(), 1);
     }
 }

--- a/src/app/perf_runner.rs
+++ b/src/app/perf_runner.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::command::{Command, CommandInvocationSource, CommandRequest};
 use crate::event::DomainEvent;
-use crate::perf::PerfScenarioId;
+use crate::perf::{PerfScenarioId, PerfScenarioParameters};
 
 use super::state::AppState;
 use super::terminal_session::TerminalSurface;
@@ -51,19 +51,33 @@ impl TerminalSurface for HeadlessTerminalSession {
 
 pub(crate) struct PerfLoopDriver {
     scenario: PerfScenarioId,
+    parameters: PerfScenarioParameters,
     command_count: usize,
     positioned_backward_start: bool,
+    rapid_commands_sent: bool,
+    initial_idle_seen: bool,
+    zoomed_in: bool,
+    zoomed_out: bool,
     idle_started_at: Option<Instant>,
 }
 
 impl PerfLoopDriver {
-    pub(crate) fn new(scenario: PerfScenarioId) -> Self {
+    pub(crate) fn new(scenario: PerfScenarioId, parameters: PerfScenarioParameters) -> Self {
         Self {
             scenario,
+            parameters,
             command_count: 0,
             positioned_backward_start: false,
+            rapid_commands_sent: false,
+            initial_idle_seen: false,
+            zoomed_in: false,
+            zoomed_out: false,
             idle_started_at: None,
         }
+    }
+
+    pub(crate) fn visited_steps(&self) -> usize {
+        self.command_count
     }
 
     pub(crate) fn advance(
@@ -79,10 +93,12 @@ impl PerfLoopDriver {
         }
 
         match self.scenario {
-            PerfScenarioId::PageFlipForward => {
-                let params = self.scenario.parameters();
+            PerfScenarioId::ColdFirstPage => true,
+            PerfScenarioId::SteadyNextPage => {
                 let last_page = page_count.saturating_sub(1);
-                if state.current_page >= last_page || self.command_count >= params.page_flip_limit {
+                if state.current_page >= last_page
+                    || self.command_count >= self.parameters.page_steps
+                {
                     return true;
                 }
                 let _ = loop_event_tx.send(DomainEvent::Command(CommandRequest::new(
@@ -92,8 +108,7 @@ impl PerfLoopDriver {
                 self.command_count += 1;
                 false
             }
-            PerfScenarioId::PageFlipBackward => {
-                let params = self.scenario.parameters();
+            PerfScenarioId::SteadyPrevPage => {
                 let last_page = page_count.saturating_sub(1);
                 if !self.positioned_backward_start {
                     if state.current_page < last_page {
@@ -107,7 +122,7 @@ impl PerfLoopDriver {
                     self.positioned_backward_start = true;
                 }
 
-                if state.current_page == 0 || self.command_count >= params.page_flip_limit {
+                if state.current_page == 0 || self.command_count >= self.parameters.page_steps {
                     return true;
                 }
 
@@ -118,13 +133,54 @@ impl PerfLoopDriver {
                 self.command_count += 1;
                 false
             }
-            PerfScenarioId::IdlePendingRedraw => {
+            PerfScenarioId::RapidNextPage => {
+                if !self.initial_idle_seen {
+                    self.initial_idle_seen = true;
+                    let last_page = page_count.saturating_sub(1);
+                    let steps = self
+                        .parameters
+                        .page_steps
+                        .min(last_page.saturating_sub(state.current_page));
+                    for _ in 0..steps {
+                        let _ = loop_event_tx.send(DomainEvent::Command(CommandRequest::new(
+                            Command::NextPage,
+                            CommandInvocationSource::Keymap,
+                        )));
+                    }
+                    self.command_count += steps;
+                    self.rapid_commands_sent = true;
+                    return steps == 0;
+                }
+                self.rapid_commands_sent
+            }
+            PerfScenarioId::ZoomStep => {
+                if !self.initial_idle_seen {
+                    self.initial_idle_seen = true;
+                    let _ = loop_event_tx.send(DomainEvent::Command(CommandRequest::new(
+                        Command::ZoomIn,
+                        CommandInvocationSource::Keymap,
+                    )));
+                    self.command_count += 1;
+                    self.zoomed_in = true;
+                    return false;
+                }
+                if self.zoomed_in && !self.zoomed_out {
+                    let _ = loop_event_tx.send(DomainEvent::Command(CommandRequest::new(
+                        Command::ZoomOut,
+                        CommandInvocationSource::Keymap,
+                    )));
+                    self.command_count += 1;
+                    self.zoomed_out = true;
+                    return false;
+                }
+                self.zoomed_out
+            }
+            PerfScenarioId::IdleSettledRedraw => {
                 let Some(started_at) = self.idle_started_at else {
                     self.idle_started_at = Some(Instant::now());
                     return false;
                 };
-                started_at.elapsed().as_millis()
-                    >= u128::from(self.scenario.parameters().idle_duration_ms)
+                started_at.elapsed().as_millis() >= u128::from(self.parameters.idle_duration_ms)
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,9 @@
 use std::path::PathBuf;
 
-use clap::{Args, Parser, Subcommand};
+use clap::Parser;
 use pvf::app::App;
 use pvf::backend::open_default_backend;
 use pvf::error::AppResult;
-use pvf::perf::{PerfRunConfig, PerfScenarioId, run_report, write_report};
 use pvf::presenter::PresenterKind;
 
 #[tokio::main(flavor = "multi_thread")]
@@ -18,54 +17,17 @@ async fn main() {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CliOptions {
     pdf_path: PathBuf,
-    perf: Option<PerfCliOptions>,
 }
 
 #[derive(Debug, Parser)]
-#[command(
-    version,
-    about = "PDF viewer for the terminal",
-    args_conflicts_with_subcommands = true,
-    subcommand_negates_reqs = true
-)]
+#[command(version, about = "PDF viewer for the terminal")]
 struct Cli {
-    #[command(subcommand)]
-    command: Option<Commands>,
-
-    #[arg(value_name = "FILE", required = true)]
-    pdf_path: Option<PathBuf>,
-}
-
-#[derive(Debug, Subcommand)]
-enum Commands {
-    Perf(PerfCommand),
-}
-
-#[derive(Debug, Args)]
-struct PerfCommand {
     #[arg(value_name = "FILE")]
     pdf_path: PathBuf,
-
-    #[arg(long, value_enum)]
-    scenario: PerfScenarioId,
-
-    #[arg(long, value_name = "PATH|-")]
-    out: Option<PathBuf>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct PerfCliOptions {
-    run: PerfRunConfig,
-    out: Option<PathBuf>,
 }
 
 async fn run() -> AppResult<()> {
     let options = parse_cli(Cli::parse());
-
-    if let Some(perf) = options.perf {
-        let report = run_report(&options.pdf_path, perf.run).await?;
-        return write_report(&report, perf.out.as_deref());
-    }
 
     let pdf = open_default_backend(&options.pdf_path)?;
     let mut app = App::new(PresenterKind::RatatuiImage)?;
@@ -73,29 +35,8 @@ async fn run() -> AppResult<()> {
 }
 
 fn parse_cli(cli: Cli) -> CliOptions {
-    match cli.command {
-        Some(Commands::Perf(perf)) => CliOptions {
-            pdf_path: perf.pdf_path,
-            perf: Some(PerfCliOptions {
-                run: PerfRunConfig {
-                    scenario: perf.scenario,
-                    ..PerfRunConfig::default()
-                },
-                out: perf.out.and_then(|path| {
-                    if path.as_os_str() == "-" {
-                        None
-                    } else {
-                        Some(path)
-                    }
-                }),
-            }),
-        },
-        None => CliOptions {
-            pdf_path: cli
-                .pdf_path
-                .expect("clap enforces pdf path when no subcommand is present"),
-            perf: None,
-        },
+    CliOptions {
+        pdf_path: cli.pdf_path,
     }
 }
 
@@ -104,7 +45,6 @@ mod tests {
     use std::path::PathBuf;
 
     use clap::Parser;
-    use pvf::perf::PerfScenarioId;
 
     use super::{Cli, parse_cli};
 
@@ -113,55 +53,12 @@ mod tests {
         let cli = Cli::try_parse_from(["pvf", "sample.pdf"]).expect("single arg should parse");
         let options = parse_cli(cli);
         assert_eq!(options.pdf_path, PathBuf::from("sample.pdf"));
-        assert!(options.perf.is_none());
-    }
-
-    #[test]
-    fn parse_cli_accepts_perf_options() {
-        let cli = Cli::try_parse_from([
-            "pvf",
-            "perf",
-            "sample.pdf",
-            "--scenario",
-            "page-flip-forward",
-            "--out",
-            "report.json",
-        ])
-        .expect("perf args should parse");
-        let options = parse_cli(cli);
-        let perf = options.perf.expect("perf options should exist");
-        assert_eq!(perf.run.scenario, PerfScenarioId::PageFlipForward);
-        assert_eq!(perf.out, Some(PathBuf::from("report.json")));
-    }
-
-    #[test]
-    fn parse_cli_accepts_stdout_perf_output() {
-        let cli = Cli::try_parse_from([
-            "pvf",
-            "perf",
-            "sample.pdf",
-            "--scenario",
-            "idle-pending-redraw",
-            "--out",
-            "-",
-        ])
-        .expect("stdout output should parse");
-        let options = parse_cli(cli);
-        let perf = options.perf.expect("perf options should exist");
-        assert_eq!(perf.run.scenario, PerfScenarioId::IdlePendingRedraw);
-        assert_eq!(perf.out, None);
     }
 
     #[test]
     fn parse_cli_rejects_invalid_combinations() {
         assert!(Cli::try_parse_from(["pvf"]).is_err());
         assert!(Cli::try_parse_from(["pvf", "a.pdf", "b.pdf"]).is_err());
-        assert!(Cli::try_parse_from(["pvf", "perf", "a.pdf"]).is_err());
-        assert!(
-            Cli::try_parse_from(["pvf", "sample.pdf", "--perf-run", "page-flip-forward",]).is_err()
-        );
-        assert!(
-            Cli::try_parse_from(["pvf", "perf", "sample.pdf", "--scenario", "unknown",]).is_err()
-        );
+        assert!(Cli::try_parse_from(["pvf", "sample.pdf", "--scenario", "unknown",]).is_err());
     }
 }

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -554,8 +554,9 @@ pub async fn run_suite(config: PerfSuiteConfig) -> AppResult<PerfSuiteReport> {
             let pdf = open_default_backend(&config.pdf_path)?;
             doc_id.get_or_insert(pdf.doc_id());
             let mut app = App::new(PresenterKind::RatatuiImage)?;
-            let mut snapshot = app.run_perf(pdf, scenario, parameters.clone()).await?;
-            snapshot.wall_time = iteration_started_at.elapsed();
+            let snapshot = app
+                .run_perf(pdf, scenario, parameters.clone(), iteration_started_at)
+                .await?;
             if iteration >= config.warmup_iterations {
                 measured.push(snapshot);
             }

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -318,6 +318,13 @@ pub struct PerfScenarioParameters {
     pub idle_duration_ms: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PageStepPolicy {
+    Unused,
+    Fixed(usize),
+    Configured,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum PerfScenarioId {
@@ -349,15 +356,35 @@ impl PerfScenarioId {
 
     pub fn parameters(self, run: &PerfSuiteConfig) -> PerfScenarioParameters {
         PerfScenarioParameters {
-            page_steps: match self {
-                Self::ColdFirstPage | Self::IdleSettledRedraw => 0,
-                Self::ZoomStep => 2,
-                Self::SteadyNextPage | Self::SteadyPrevPage | Self::RapidNextPage => run.page_steps,
-            },
+            page_steps: self.page_step_policy().resolve(run.page_steps),
             idle_duration_ms: match self {
                 Self::IdleSettledRedraw => run.idle_ms,
                 _ => 0,
             },
+        }
+    }
+
+    fn uses_configured_page_steps(self) -> bool {
+        self.page_step_policy() == PageStepPolicy::Configured
+    }
+
+    fn page_step_policy(self) -> PageStepPolicy {
+        match self {
+            Self::ColdFirstPage | Self::IdleSettledRedraw => PageStepPolicy::Unused,
+            Self::ZoomStep => PageStepPolicy::Fixed(2),
+            Self::SteadyNextPage | Self::SteadyPrevPage | Self::RapidNextPage => {
+                PageStepPolicy::Configured
+            }
+        }
+    }
+}
+
+impl PageStepPolicy {
+    fn resolve(self, configured_page_steps: usize) -> usize {
+        match self {
+            Self::Unused => 0,
+            Self::Fixed(page_steps) => page_steps,
+            Self::Configured => configured_page_steps,
         }
     }
 }
@@ -590,7 +617,12 @@ fn validate_suite_config(config: &PerfSuiteConfig) -> AppResult<()> {
             "perf run requires at least one measured iteration",
         ));
     }
-    if config.page_steps == 0 {
+    if config.page_steps == 0
+        && config
+            .scenarios
+            .iter()
+            .any(|scenario| scenario.uses_configured_page_steps())
+    {
         return Err(AppError::invalid_argument(
             "--page-steps must be greater than zero",
         ));
@@ -963,6 +995,32 @@ mod tests {
     }
 
     #[test]
+    fn resolves_page_step_policy_per_scenario() {
+        let run = PerfSuiteConfig {
+            page_steps: 7,
+            ..PerfSuiteConfig::default()
+        };
+
+        assert_eq!(PerfScenarioId::ColdFirstPage.parameters(&run).page_steps, 0);
+        assert_eq!(
+            PerfScenarioId::IdleSettledRedraw
+                .parameters(&run)
+                .page_steps,
+            0
+        );
+        assert_eq!(PerfScenarioId::ZoomStep.parameters(&run).page_steps, 2);
+        assert_eq!(
+            PerfScenarioId::SteadyNextPage.parameters(&run).page_steps,
+            7
+        );
+        assert_eq!(
+            PerfScenarioId::SteadyPrevPage.parameters(&run).page_steps,
+            7
+        );
+        assert_eq!(PerfScenarioId::RapidNextPage.parameters(&run).page_steps, 7);
+    }
+
+    #[test]
     fn merge_stats_averages_cache_hit_rates() {
         let mut first = PerfStats::default();
         first.set_l1_hit_rate(0.25);
@@ -1024,6 +1082,35 @@ mod tests {
 
         let err = validate_suite_config(&run).expect_err("zero measured iterations should fail");
         assert!(err.to_string().contains("measured iteration"));
+    }
+
+    #[test]
+    fn allows_zero_page_steps_when_selected_scenarios_do_not_use_them() {
+        let run = PerfSuiteConfig {
+            pdf_path: "sample.pdf".into(),
+            scenarios: vec![
+                PerfScenarioId::ColdFirstPage,
+                PerfScenarioId::ZoomStep,
+                PerfScenarioId::IdleSettledRedraw,
+            ],
+            page_steps: 0,
+            ..PerfSuiteConfig::default()
+        };
+
+        validate_suite_config(&run).expect("zero page steps should be allowed");
+    }
+
+    #[test]
+    fn rejects_zero_page_steps_when_selected_scenarios_use_them() {
+        let run = PerfSuiteConfig {
+            pdf_path: "sample.pdf".into(),
+            scenarios: vec![PerfScenarioId::SteadyNextPage],
+            page_steps: 0,
+            ..PerfSuiteConfig::default()
+        };
+
+        let err = validate_suite_config(&run).expect_err("zero page steps should fail");
+        assert!(err.to_string().contains("--page-steps"));
     }
 
     #[test]

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -1,8 +1,8 @@
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::str::FromStr;
+use std::time::{Duration, Instant};
 
-use clap::ValueEnum;
 use serde::Serialize;
 
 use crate::app::App;
@@ -294,14 +294,18 @@ pub struct CacheSummary {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PerfIterationReport {
     pub iteration_index: usize,
+    pub wall_time_ms: f64,
     pub phase_metrics: PhaseMetricsSummary,
     pub redraw: RedrawSummary,
     pub queues: QueueSummary,
     pub cache: CacheSummary,
+    pub final_page: usize,
+    pub visited_steps: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct PerfSummaryReport {
+pub struct PerfAggregateReport {
+    pub wall_time_ms: MetricSummary,
     pub phase_metrics: PhaseMetricsSummary,
     pub redraw: RedrawSummary,
     pub queues: QueueSummary,
@@ -310,63 +314,110 @@ pub struct PerfSummaryReport {
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PerfScenarioParameters {
-    pub page_flip_limit: usize,
+    pub page_steps: usize,
     pub idle_duration_ms: u64,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum PerfScenarioId {
-    PageFlipForward,
-    PageFlipBackward,
-    IdlePendingRedraw,
+    ColdFirstPage,
+    SteadyNextPage,
+    SteadyPrevPage,
+    RapidNextPage,
+    ZoomStep,
+    IdleSettledRedraw,
 }
 
 impl PerfScenarioId {
-    pub fn parse(value: &str) -> Option<Self> {
-        match value {
-            "page-flip-forward" => Some(Self::PageFlipForward),
-            "page-flip-backward" => Some(Self::PageFlipBackward),
-            "idle-pending-redraw" => Some(Self::IdlePendingRedraw),
-            _ => None,
-        }
+    pub const ALL: [Self; 6] = [
+        Self::ColdFirstPage,
+        Self::SteadyNextPage,
+        Self::SteadyPrevPage,
+        Self::RapidNextPage,
+        Self::ZoomStep,
+        Self::IdleSettledRedraw,
+    ];
+
+    pub fn all() -> &'static [Self] {
+        &Self::ALL
     }
 
     pub fn id(self) -> &'static str {
-        match self {
-            Self::PageFlipForward => "page-flip-forward",
-            Self::PageFlipBackward => "page-flip-backward",
-            Self::IdlePendingRedraw => "idle-pending-redraw",
-        }
+        self.as_str()
     }
 
-    pub fn parameters(self) -> PerfScenarioParameters {
-        match self {
-            Self::PageFlipForward | Self::PageFlipBackward => PerfScenarioParameters {
-                page_flip_limit: 8,
-                idle_duration_ms: 0,
+    pub fn parameters(self, run: &PerfSuiteConfig) -> PerfScenarioParameters {
+        PerfScenarioParameters {
+            page_steps: match self {
+                Self::ColdFirstPage | Self::IdleSettledRedraw => 0,
+                Self::ZoomStep => 2,
+                Self::SteadyNextPage | Self::SteadyPrevPage | Self::RapidNextPage => run.page_steps,
             },
-            Self::IdlePendingRedraw => PerfScenarioParameters {
-                page_flip_limit: 0,
-                idle_duration_ms: 250,
+            idle_duration_ms: match self {
+                Self::IdleSettledRedraw => run.idle_ms,
+                _ => 0,
             },
         }
+    }
+}
+
+impl PerfScenarioId {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ColdFirstPage => "cold-first-page",
+            Self::SteadyNextPage => "steady-next-page",
+            Self::SteadyPrevPage => "steady-prev-page",
+            Self::RapidNextPage => "rapid-next-page",
+            Self::ZoomStep => "zoom-step",
+            Self::IdleSettledRedraw => "idle-settled-redraw",
+        }
+    }
+}
+
+impl FromStr for PerfScenarioId {
+    type Err = AppError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "cold-first-page" => Ok(Self::ColdFirstPage),
+            "steady-next-page" => Ok(Self::SteadyNextPage),
+            "steady-prev-page" => Ok(Self::SteadyPrevPage),
+            "rapid-next-page" => Ok(Self::RapidNextPage),
+            "zoom-step" => Ok(Self::ZoomStep),
+            "idle-settled-redraw" => Ok(Self::IdleSettledRedraw),
+            _ => Err(AppError::invalid_argument(format!(
+                "unknown perf scenario: {value}"
+            ))),
+        }
+    }
+}
+
+impl std::fmt::Display for PerfScenarioId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PerfRunConfig {
-    pub scenario: PerfScenarioId,
+pub struct PerfSuiteConfig {
+    pub pdf_path: PathBuf,
+    pub scenarios: Vec<PerfScenarioId>,
     pub warmup_iterations: usize,
     pub measured_iterations: usize,
+    pub page_steps: usize,
+    pub idle_ms: u64,
 }
 
-impl Default for PerfRunConfig {
+impl Default for PerfSuiteConfig {
     fn default() -> Self {
         Self {
-            scenario: PerfScenarioId::PageFlipForward,
-            warmup_iterations: 0,
+            pdf_path: PathBuf::new(),
+            scenarios: PerfScenarioId::all().to_vec(),
+            warmup_iterations: 1,
             measured_iterations: 5,
+            page_steps: 8,
+            idle_ms: 250,
         }
     }
 }
@@ -375,11 +426,21 @@ impl Default for PerfRunConfig {
 pub struct PerfIterationSnapshot {
     pub runtime: PerfStats,
     pub presenter: PerfStats,
+    pub wall_time: Duration,
+    pub final_page: usize,
+    pub visited_steps: usize,
 }
 
 impl PerfIterationSnapshot {
     pub fn into_report(self, iteration_index: usize) -> PerfIterationReport {
-        build_iteration_report(iteration_index, &self.runtime, &self.presenter)
+        build_iteration_report(
+            iteration_index,
+            self.wall_time,
+            &self.runtime,
+            &self.presenter,
+            self.final_page,
+            self.visited_steps,
+        )
     }
 }
 
@@ -399,26 +460,37 @@ pub struct PerfScenarioInfo {
 pub struct PerfRunInfo {
     pub warmup_iterations: usize,
     pub measured_iterations: usize,
+    pub page_steps: usize,
+    pub idle_ms: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct PerfReport {
-    pub version: u32,
-    pub generated_at_unix_ms: u128,
-    pub pdf: PerfPdfInfo,
-    pub scenario: PerfScenarioInfo,
-    pub run: PerfRunInfo,
-    pub summary: PerfSummaryReport,
+pub struct PerfScenarioReport {
+    pub id: PerfScenarioId,
+    pub parameters: PerfScenarioParameters,
+    pub aggregate: PerfAggregateReport,
     pub iterations: Vec<PerfIterationReport>,
 }
 
-impl PerfReport {
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct PerfSuiteReport {
+    pub version: u32,
+    pub generated_at_unix_ms: u128,
+    pub pdf: PerfPdfInfo,
+    pub run: PerfRunInfo,
+    pub scenarios: Vec<PerfScenarioReport>,
+}
+
+impl PerfScenarioReport {
     pub fn from_iterations(
-        pdf_path: &Path,
-        doc_id: u64,
-        run: &PerfRunConfig,
+        scenario: PerfScenarioId,
+        run: &PerfSuiteConfig,
         measured: Vec<PerfIterationSnapshot>,
     ) -> Self {
+        let wall_samples = measured
+            .iter()
+            .map(|snapshot| snapshot.wall_time.as_secs_f64() * 1000.0)
+            .collect::<Vec<_>>();
         let iterations = measured
             .iter()
             .cloned()
@@ -429,6 +501,22 @@ impl PerfReport {
         let summary_presenter = merge_stats(measured.iter().map(|snapshot| &snapshot.presenter));
 
         Self {
+            id: scenario,
+            parameters: scenario.parameters(run),
+            aggregate: build_aggregate_report(&summary_runtime, &summary_presenter, &wall_samples),
+            iterations,
+        }
+    }
+}
+
+impl PerfSuiteReport {
+    pub fn new(
+        pdf_path: &Path,
+        doc_id: u64,
+        run: &PerfSuiteConfig,
+        scenarios: Vec<PerfScenarioReport>,
+    ) -> Self {
+        Self {
             version: 1,
             generated_at_unix_ms: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -438,59 +526,78 @@ impl PerfReport {
                 path: pdf_path.display().to_string(),
                 doc_id,
             },
-            scenario: PerfScenarioInfo {
-                id: run.scenario,
-                parameters: run.scenario.parameters(),
-            },
             run: PerfRunInfo {
                 warmup_iterations: run.warmup_iterations,
                 measured_iterations: run.measured_iterations,
+                page_steps: run.page_steps,
+                idle_ms: run.idle_ms,
             },
-            summary: build_summary_report(&summary_runtime, &summary_presenter),
-            iterations,
+            scenarios,
         }
     }
 }
 
-pub async fn run_report(pdf_path: &Path, run: PerfRunConfig) -> AppResult<PerfReport> {
-    validate_run_config(&run)?;
-    let total_iterations = run
+pub async fn run_suite(config: PerfSuiteConfig) -> AppResult<PerfSuiteReport> {
+    validate_suite_config(&config)?;
+    let total_iterations = config
         .warmup_iterations
-        .checked_add(run.measured_iterations)
+        .checked_add(config.measured_iterations)
         .ok_or_else(|| AppError::invalid_argument("perf iteration count overflow"))?;
-    let mut measured = Vec::with_capacity(run.measured_iterations);
     let mut doc_id = None;
+    let mut scenario_reports = Vec::with_capacity(config.scenarios.len());
 
-    for iteration in 0..total_iterations {
-        let pdf = open_default_backend(pdf_path)?;
-        doc_id.get_or_insert(pdf.doc_id());
-        let mut app = App::new(PresenterKind::RatatuiImage)?;
-        let snapshot = app.run_perf(pdf, run.scenario).await?;
-        if iteration >= run.warmup_iterations {
-            measured.push(snapshot);
+    for scenario in config.scenarios.iter().copied() {
+        let mut measured = Vec::with_capacity(config.measured_iterations);
+        let parameters = scenario.parameters(&config);
+        for iteration in 0..total_iterations {
+            let iteration_started_at = Instant::now();
+            let pdf = open_default_backend(&config.pdf_path)?;
+            doc_id.get_or_insert(pdf.doc_id());
+            let mut app = App::new(PresenterKind::RatatuiImage)?;
+            let mut snapshot = app.run_perf(pdf, scenario, parameters.clone()).await?;
+            snapshot.wall_time = iteration_started_at.elapsed();
+            if iteration >= config.warmup_iterations {
+                measured.push(snapshot);
+            }
         }
+        scenario_reports.push(PerfScenarioReport::from_iterations(
+            scenario, &config, measured,
+        ));
     }
 
     let doc_id = doc_id.ok_or_else(|| AppError::unsupported("perf run did not open the PDF"))?;
 
-    Ok(PerfReport::from_iterations(
-        &PathBuf::from(pdf_path),
+    Ok(PerfSuiteReport::new(
+        &PathBuf::from(&config.pdf_path),
         doc_id,
-        &run,
-        measured,
+        &config,
+        scenario_reports,
     ))
 }
 
-fn validate_run_config(run: &PerfRunConfig) -> AppResult<()> {
-    if run.measured_iterations == 0 {
+fn validate_suite_config(config: &PerfSuiteConfig) -> AppResult<()> {
+    if config.pdf_path.as_os_str().is_empty() {
+        return Err(AppError::invalid_argument("--pdf is required"));
+    }
+    if config.scenarios.is_empty() {
+        return Err(AppError::invalid_argument(
+            "perf run requires at least one scenario",
+        ));
+    }
+    if config.measured_iterations == 0 {
         return Err(AppError::invalid_argument(
             "perf run requires at least one measured iteration",
+        ));
+    }
+    if config.page_steps == 0 {
+        return Err(AppError::invalid_argument(
+            "--page-steps must be greater than zero",
         ));
     }
     Ok(())
 }
 
-pub fn write_report(report: &PerfReport, out: Option<&Path>) -> AppResult<()> {
+pub fn write_report(report: &PerfSuiteReport, out: Option<&Path>) -> AppResult<()> {
     let json = serde_json::to_string_pretty(report)
         .map_err(|err| AppError::unsupported(format!("failed to serialize perf report: {err}")))?;
 
@@ -567,12 +674,33 @@ fn merge_stats<'a>(stats: impl Iterator<Item = &'a PerfStats>) -> PerfStats {
 
 fn build_iteration_report(
     iteration_index: usize,
+    wall_time: Duration,
     runtime: &PerfStats,
     presenter: &PerfStats,
+    final_page: usize,
+    visited_steps: usize,
 ) -> PerfIterationReport {
-    let summary = build_summary_report(runtime, presenter);
+    let summary = build_metrics_report(runtime, presenter);
     PerfIterationReport {
         iteration_index,
+        wall_time_ms: wall_time.as_secs_f64() * 1000.0,
+        phase_metrics: summary.phase_metrics,
+        redraw: summary.redraw,
+        queues: summary.queues,
+        cache: summary.cache,
+        final_page,
+        visited_steps,
+    }
+}
+
+fn build_aggregate_report(
+    runtime: &PerfStats,
+    presenter: &PerfStats,
+    wall_samples_ms: &[f64],
+) -> PerfAggregateReport {
+    let summary = build_metrics_report(runtime, presenter);
+    PerfAggregateReport {
+        wall_time_ms: summarize_metric(wall_samples_ms),
         phase_metrics: summary.phase_metrics,
         redraw: summary.redraw,
         queues: summary.queues,
@@ -580,8 +708,15 @@ fn build_iteration_report(
     }
 }
 
-fn build_summary_report(runtime: &PerfStats, presenter: &PerfStats) -> PerfSummaryReport {
-    PerfSummaryReport {
+struct PerfMetricsReport {
+    phase_metrics: PhaseMetricsSummary,
+    redraw: RedrawSummary,
+    queues: QueueSummary,
+    cache: CacheSummary,
+}
+
+fn build_metrics_report(runtime: &PerfStats, presenter: &PerfStats) -> PerfMetricsReport {
+    PerfMetricsReport {
         phase_metrics: PhaseMetricsSummary {
             render_ms: summarize_metric(runtime.render_samples_ms()),
             encode_ms: summarize_metric(presenter.encode_samples_ms()),
@@ -699,12 +834,15 @@ fn percentile(sorted: &[f64], percentile: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
-    use std::time::Duration;
+    use std::fs;
+    use std::process;
+    use std::str::FromStr;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use super::{
-        PerfRunConfig, PerfScenarioId, PerfStats, RedrawReason, merge_stats, run_report,
-        summarize_metric, summarize_scalar, validate_run_config,
+        PerfIterationSnapshot, PerfScenarioId, PerfStats, PerfSuiteConfig, RedrawReason,
+        build_aggregate_report, merge_stats, run_suite, summarize_metric, summarize_scalar,
+        validate_suite_config,
     };
 
     #[test]
@@ -816,11 +954,11 @@ mod tests {
 
     #[test]
     fn parses_perf_scenarios() {
-        assert_eq!(
-            PerfScenarioId::parse("page-flip-forward"),
-            Some(PerfScenarioId::PageFlipForward)
-        );
-        assert_eq!(PerfScenarioId::parse("unknown"), None);
+        for scenario in PerfScenarioId::all() {
+            assert_eq!(PerfScenarioId::from_str(scenario.id()).unwrap(), *scenario);
+        }
+        assert!(PerfScenarioId::from_str("all").is_err());
+        assert!(PerfScenarioId::from_str("unknown").is_err());
     }
 
     #[test]
@@ -877,27 +1015,185 @@ mod tests {
 
     #[test]
     fn rejects_zero_measured_iterations() {
-        let run = PerfRunConfig {
+        let run = PerfSuiteConfig {
+            pdf_path: "sample.pdf".into(),
             measured_iterations: 0,
-            ..PerfRunConfig::default()
+            ..PerfSuiteConfig::default()
         };
 
-        let err = validate_run_config(&run).expect_err("zero measured iterations should fail");
+        let err = validate_suite_config(&run).expect_err("zero measured iterations should fail");
         assert!(err.to_string().contains("measured iteration"));
     }
 
     #[test]
     fn rejects_iteration_count_overflow() {
         let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should initialize");
-        let run = PerfRunConfig {
+        let run = PerfSuiteConfig {
+            pdf_path: "dummy.pdf".into(),
             warmup_iterations: usize::MAX,
             measured_iterations: 1,
-            ..PerfRunConfig::default()
+            ..PerfSuiteConfig::default()
         };
 
         let err = runtime
-            .block_on(run_report(Path::new("dummy.pdf"), run))
+            .block_on(run_suite(run))
             .expect_err("overflow should fail");
         assert!(err.to_string().contains("overflow"));
+    }
+
+    #[test]
+    fn aggregates_wall_phase_redraw_queue_and_cache_metrics() {
+        let mut runtime = PerfStats::default();
+        runtime.enable_sample_collection();
+        runtime.record_render(Duration::from_millis(10));
+        runtime.record_render_queue_wait(Duration::from_millis(2));
+        runtime.set_queue_depth(3);
+        runtime.set_render_in_flight(1);
+        runtime.set_l1_hit_rate(0.5);
+        runtime.record_redraw(RedrawReason::PendingWork);
+
+        let mut presenter = PerfStats::default();
+        presenter.enable_sample_collection();
+        presenter.record_convert(Duration::from_millis(4));
+        presenter.record_blit(Duration::from_millis(1));
+        presenter.record_encode_queue_wait(Duration::from_millis(3));
+        presenter.set_encode_queue_depth(2);
+        presenter.set_encode_in_flight(1);
+        presenter.set_l2_hit_rate(0.25);
+
+        let aggregate = build_aggregate_report(&runtime, &presenter, &[12.0, 16.0]);
+
+        assert_eq!(aggregate.wall_time_ms.count, 2);
+        assert_eq!(aggregate.wall_time_ms.avg_ms, 14.0);
+        assert_eq!(aggregate.phase_metrics.render_ms.count, 1);
+        assert_eq!(aggregate.redraw.total, 1);
+        assert_eq!(aggregate.queues.render_depth.max, 3.0);
+        assert_eq!(aggregate.queues.encode_depth.max, 2.0);
+        assert_eq!(aggregate.cache.l1_hit_rate, 0.5);
+        assert_eq!(aggregate.cache.l2_hit_rate, 0.25);
+    }
+
+    #[test]
+    fn iteration_report_includes_wall_time_and_navigation_state() {
+        let snapshot = PerfIterationSnapshot {
+            runtime: PerfStats::default(),
+            presenter: PerfStats::default(),
+            wall_time: Duration::from_millis(7),
+            final_page: 2,
+            visited_steps: 3,
+        };
+
+        let report = snapshot.into_report(4);
+
+        assert_eq!(report.iteration_index, 4);
+        assert_eq!(report.wall_time_ms, 7.0);
+        assert_eq!(report.final_page, 2);
+        assert_eq!(report.visited_steps, 3);
+    }
+
+    #[test]
+    fn runtime_smoke_returns_all_scenarios() {
+        let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should initialize");
+        let file = unique_temp_path(".pdf");
+        fs::write(&file, build_pdf(&["one", "two", "three"])).expect("test pdf should be written");
+
+        let config = PerfSuiteConfig {
+            pdf_path: file.clone(),
+            warmup_iterations: 0,
+            measured_iterations: 1,
+            page_steps: 8,
+            idle_ms: 1,
+            ..PerfSuiteConfig::default()
+        };
+        let report = runtime
+            .block_on(run_suite(config))
+            .expect("suite should run");
+
+        fs::remove_file(file).expect("test pdf should be removed");
+
+        assert_eq!(report.scenarios.len(), PerfScenarioId::all().len());
+        let rapid = report
+            .scenarios
+            .iter()
+            .find(|scenario| scenario.id == PerfScenarioId::RapidNextPage)
+            .expect("rapid scenario should be reported");
+        assert!(rapid.iterations[0].final_page < 3);
+        let idle = report
+            .scenarios
+            .iter()
+            .find(|scenario| scenario.id == PerfScenarioId::IdleSettledRedraw)
+            .expect("idle scenario should be reported");
+        assert_eq!(idle.parameters.idle_duration_ms, 1);
+    }
+
+    fn unique_temp_path(suffix: &str) -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("pvf-perf-{}-{nanos}{suffix}", process::id()))
+    }
+
+    fn build_pdf(page_texts: &[&str]) -> Vec<u8> {
+        let page_texts = if page_texts.is_empty() {
+            vec!["".to_string()]
+        } else {
+            page_texts
+                .iter()
+                .map(|text| format!("BT /F1 14 Tf 36 260 Td ({text}) Tj ET"))
+                .collect()
+        };
+
+        let page_count = page_texts.len();
+        let page_ids: Vec<usize> = (0..page_count).map(|i| 4 + i * 2).collect();
+
+        let mut objects = Vec::new();
+        objects.push("<< /Type /Catalog /Pages 2 0 R >>".to_string());
+        let kids = page_ids
+            .iter()
+            .map(|id| format!("{id} 0 R"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        objects.push(format!(
+            "<< /Type /Pages /Kids [{kids}] /Count {page_count} >>"
+        ));
+        objects.push("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string());
+
+        for (index, stream) in page_texts.iter().enumerate() {
+            let content_id = 5 + index * 2;
+            objects.push(format!(
+                "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Resources << /Font << /F1 3 0 R >> >> /Contents {content_id} 0 R >>"
+            ));
+            objects.push(format!(
+                "<< /Length {} >>\nstream\n{}\nendstream",
+                stream.len(),
+                stream
+            ));
+        }
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
+        let mut offsets = vec![0_usize];
+        for (index, object) in objects.iter().enumerate() {
+            let object_id = index + 1;
+            offsets.push(bytes.len());
+            bytes.extend_from_slice(format!("{object_id} 0 obj\n{object}\nendobj\n").as_bytes());
+        }
+
+        let xref_start = bytes.len();
+        bytes.extend_from_slice(format!("xref\n0 {}\n", objects.len() + 1).as_bytes());
+        bytes.extend_from_slice(b"0000000000 65535 f \n");
+        for offset in offsets.iter().skip(1) {
+            bytes.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+        }
+        bytes.extend_from_slice(
+            format!(
+                "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+                objects.len() + 1,
+                xref_start
+            )
+            .as_bytes(),
+        );
+        bytes
     }
 }

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -569,7 +569,7 @@ pub async fn run_suite(config: PerfSuiteConfig) -> AppResult<PerfSuiteReport> {
     let doc_id = doc_id.ok_or_else(|| AppError::unsupported("perf run did not open the PDF"))?;
 
     Ok(PerfSuiteReport::new(
-        &PathBuf::from(&config.pdf_path),
+        &config.pdf_path,
         doc_id,
         &config,
         scenario_reports,


### PR DESCRIPTION
## Summary
- remove the public `pvf perf` CLI path and keep `pvf <file.pdf>` as the user-facing entry point
- add a custom `cargo bench --bench perf` diagnostics binary with scenario selection and JSON output
- redesign display-path perf scenarios and reports around suite/scenario aggregates
- document developer performance diagnostics

## Rationale
Perf diagnostics exercise the real app event loop, rendering, encode, cache, and redraw paths, so they fit better as developer bench tooling than as a public viewer subcommand.

## Verification
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- measured `/home/shiguri/downloads/20251016_introduction_to_web_accessibility.pdf` with `cargo bench --bench perf`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a developer-facing headless performance benchmark CLI that runs multi-scenario suites and emits richer JSON reports (including wall-time, final page, and visited steps).

* **Chores**
  * Removed the public perf subcommand from the viewer CLI; diagnostics are now provided via the benchmark tool.

* **Documentation**
  * Added comprehensive performance-diagnostics docs and updated runtime/reading-order guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->