### PR TITLE
perf(presenter): reuse SIMD resize worker

### DIFF
--- a/src/presenter/image_ops.rs
+++ b/src/presenter/image_ops.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use fast_image_resize as fr;
 use image::{DynamicImage, RgbaImage};
 use ratatui::layout::Rect;
@@ -8,6 +10,10 @@ use crate::backend::RgbaFrame;
 use crate::error::{AppError, AppResult};
 
 pub(crate) const SIMD_DOWNSCALE_FILTER: fr::FilterType = fr::FilterType::CatmullRom;
+
+thread_local! {
+    static SIMD_RESIZER: RefCell<fr::Resizer> = RefCell::new(fr::Resizer::new());
+}
 
 pub(crate) fn create_protocol_with_picker(
     picker: &Picker,
@@ -121,13 +127,14 @@ fn resize_rgba_bytes_simd(
         })?;
 
     let mut dst = fr::images::Image::new(dst_width, dst_height, fr::PixelType::U8x4);
-    let mut resizer = fr::Resizer::new();
     let options =
         fr::ResizeOptions::new().resize_alg(fr::ResizeAlg::Convolution(SIMD_DOWNSCALE_FILTER));
 
-    resizer
-        .resize(&src, &mut dst, &options)
-        .map_err(|_| AppError::unsupported("failed to resize frame with SIMD"))?;
+    SIMD_RESIZER.with_borrow_mut(|resizer| {
+        resizer
+            .resize(&src, &mut dst, &options)
+            .map_err(|_| AppError::unsupported("failed to resize frame with SIMD"))
+    })?;
 
     Ok(dst.into_vec())
 }


### PR DESCRIPTION
## Summary

Reuse a thread-local `fast_image_resize::Resizer` in the presenter resize path instead of constructing a new resizer for each encode resize.

The benchmark improvement is small enough that it may include noise, but the code change is also small and keeps the optimization local to `image_ops`.

## Benchmark

Compared against `main` with:

```bash
cargo bench --bench perf -- --pdf /home/shiguri/downloads/20251016_introduction_to_web_accessibility.pdf --warmup 2 --iterations 10 --page-steps 8
```

Wall time averages:

- `steady-next-page`: `327.9ms -> 323.3ms`
- `steady-prev-page`: `304.4ms -> 288.6ms`
- `rapid-next-page`: `216.7ms -> 213.3ms`
- `idle-settled-redraw`: `254.2ms -> 254.8ms`

Encode averages:

- `steady-next-page`: `18.55ms -> 18.63ms`
- `steady-prev-page`: `17.81ms -> 16.50ms`
- `rapid-next-page`: `19.24ms -> 18.85ms`
- `idle-settled-redraw`: `20.66ms -> 19.11ms`

## Verification

```bash
cargo fmt --check
cargo test
cargo clippy --all-targets --all-features -- -D warnings
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal performance improvements to image resize operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->