### PR TITLE
perf(frame): skip highlight overlay copy without visible spans

### DIFF
--- a/src/app/frame_ops.rs
+++ b/src/app/frame_ops.rs
@@ -33,6 +33,14 @@ pub(crate) fn apply_highlight_overlay(
         return frame.clone();
     }
 
+    if !overlay
+        .spans
+        .iter()
+        .any(|span| pages.iter().any(|page| page.page == span.page))
+    {
+        return frame.clone();
+    }
+
     let mut pixels = frame_ops_pixel_pool().take(frame.byte_len());
     pixels.copy_from_slice(&frame.pixels);
     for span in &overlay.spans {

--- a/src/app/frame_ops.rs
+++ b/src/app/frame_ops.rs
@@ -33,24 +33,24 @@ pub(crate) fn apply_highlight_overlay(
         return frame.clone();
     }
 
-    if !overlay
-        .spans
-        .iter()
-        .any(|span| pages.iter().any(|page| page.page == span.page))
-    {
-        return frame.clone();
-    }
-
-    let mut pixels = frame_ops_pixel_pool().take(frame.byte_len());
-    pixels.copy_from_slice(&frame.pixels);
+    let mut pixels = None;
     for span in &overlay.spans {
         for page in pages {
             if page.page != span.page {
                 continue;
             }
-            draw_span(&mut pixels, frame.width, frame.height, span, *page);
+            let pixels = pixels.get_or_insert_with(|| {
+                let mut pixels = frame_ops_pixel_pool().take(frame.byte_len());
+                pixels.copy_from_slice(&frame.pixels);
+                pixels
+            });
+            draw_span(pixels, frame.width, frame.height, span, *page);
         }
     }
+
+    let Some(pixels) = pixels else {
+        return frame.clone();
+    };
 
     RgbaFrame {
         width: frame.width,
@@ -284,9 +284,48 @@ fn fill_rect(
 
 #[cfg(test)]
 mod tests {
-    use super::{compose_spread_frame, crop_frame_for_viewport, prepare_presenter_frame};
-    use crate::backend::RgbaFrame;
+    use super::{
+        PageRenderSpace, apply_highlight_overlay, compose_spread_frame, crop_frame_for_viewport,
+        prepare_presenter_frame,
+    };
+    use crate::backend::{PdfRect, RgbaFrame};
+    use crate::highlight::{
+        HighlightOverlaySnapshot, HighlightSource, HighlightSpan, HighlightStyle,
+    };
     use crate::presenter::{PanOffset, Viewport};
+
+    #[test]
+    fn apply_highlight_overlay_without_visible_span_reuses_pixel_buffer() {
+        let frame = RgbaFrame {
+            width: 2,
+            height: 2,
+            pixels: vec![7; 16].into(),
+        };
+        let overlay = HighlightOverlaySnapshot::new(vec![HighlightSpan {
+            source: HighlightSource::Search,
+            page: 3,
+            rects: vec![PdfRect {
+                x0: 0.0,
+                y0: 0.0,
+                x1: 1.0,
+                y1: 1.0,
+            }],
+            style: HighlightStyle::SEARCH_HIT,
+        }]);
+        let pages = [PageRenderSpace {
+            page: 1,
+            origin_x_px: 0,
+            origin_y_px: 0,
+            width_px: 2,
+            height_px: 2,
+            width_pt: 2.0,
+            height_pt: 2.0,
+        }];
+
+        let highlighted = apply_highlight_overlay(&frame, &overlay, &pages);
+
+        assert!(frame.pixels.ptr_eq(&highlighted.pixels));
+    }
 
     #[test]
     fn crop_frame_for_viewport_applies_pan_offset() {


### PR DESCRIPTION
Avoid copying the full frame when the active highlight overlay has no spans for the currently visible pages.

Verification:
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized highlight overlay processing to improve performance when no visible overlay spans are present.

* **Tests**
  * Added test to validate efficient pixel buffer reuse behavior in highlight overlay scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->