### PR TITLE
perf(app): avoid per-frame render key vecs

### DIFF
--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -21,7 +21,9 @@ use super::event_bus::EventBusRuntime;
 use super::perf_runner::{
     HeadlessTerminalSession, PERF_HEADLESS_HEIGHT, PERF_HEADLESS_WIDTH, PerfLoopDriver,
 };
-use super::render_ops::{CurrentTaskContext, PrefetchDispatchContext};
+use super::render_ops::{
+    CurrentInterestKeys, CurrentTaskContext, PrefetchDispatchContext, RequiredRenderPages,
+};
 use super::scale::select_input_poll_timeout;
 use super::state::notice_action_for_error;
 use super::terminal_session::{InteractiveTerminalSession, TerminalSurface};
@@ -52,9 +54,8 @@ struct LoopStep {
     enable_crop: bool,
     interactive: bool,
     visible_pages: super::state::VisiblePageSlots,
-    required_pages: Vec<usize>,
-    required_render_keys: Vec<RenderedPageKey>,
-    current_interest_keys: Vec<RenderedPageKey>,
+    required: RequiredRenderPages,
+    current_interest_keys: CurrentInterestKeys,
     initial_preview: Option<InitialPreviewPlan>,
     presenter_key: RenderedPageKey,
     current_cached: bool,
@@ -374,9 +375,8 @@ impl App {
             &mut runtime.render_worker,
             CurrentTaskContext {
                 current_scale: step.current_scale,
-                required_pages: step.required_pages.clone(),
-                required_keys: step.required_render_keys.clone(),
-                current_interest_keys: step.current_interest_keys.clone(),
+                required: step.required,
+                current_interest_keys: step.current_interest_keys,
                 current_cached: step.current_cached,
                 preview_tasks: step
                     .initial_preview
@@ -407,7 +407,7 @@ impl App {
             &mut runtime.render_actor,
             &mut runtime.render_worker,
             PrefetchDispatchContext {
-                required_keys: step.required_render_keys.clone(),
+                required: step.required,
                 current_cached: step.current_cached,
                 overlay_stamp: step.overlay_stamp,
                 prefetch_viewport: step.prefetch_viewport,
@@ -479,15 +479,18 @@ impl App {
         let base_pan = self.current_pan();
         let enable_crop = self.state.zoom > 1.0;
         let interactive = input_actor.is_interactive(prefetch_pause_after_input);
-        let mut required_pages = vec![visible_pages.anchor_page];
+        let mut required = RequiredRenderPages::new(
+            visible_pages.anchor_page,
+            RenderedPageKey::new(pdf.doc_id(), visible_pages.anchor_page, current_scale),
+        );
         if let Some(trailing_page) = visible_pages.trailing_page {
-            required_pages.push(trailing_page);
+            required.push_trailing(
+                trailing_page,
+                RenderedPageKey::new(pdf.doc_id(), trailing_page, current_scale),
+            );
         }
-        let required_render_keys = required_pages
-            .iter()
-            .map(|page| RenderedPageKey::new(pdf.doc_id(), *page, current_scale))
-            .collect::<Vec<_>>();
-        let current_cached = required_render_keys
+        let current_cached = required
+            .keys()
             .iter()
             .all(|key| self.render.runtime.has_cached_frame(key));
         let presenter_layout_tag = self
@@ -502,7 +505,7 @@ impl App {
             current_scale,
             presenter_layout_tag,
         );
-        let mut current_interest_keys = required_render_keys.clone();
+        let mut current_interest_keys = CurrentInterestKeys::from_required(&required);
         if let Some(preview_plan) = initial_preview.as_ref() {
             current_interest_keys.extend(preview_plan.page_keys.iter().copied());
         }
@@ -521,8 +524,7 @@ impl App {
             enable_crop,
             interactive,
             visible_pages,
-            required_pages,
-            required_render_keys,
+            required,
             current_interest_keys,
             initial_preview,
             presenter_key,

--- a/src/app/render_ops.rs
+++ b/src/app/render_ops.rs
@@ -11,17 +11,77 @@ use super::frame_ops::{encode_work_class_for_completed_render, prepare_presenter
 use super::scale::{scale_eq, zoom_eq};
 use super::state::AppState;
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RequiredRenderPages {
+    pages: [usize; 2],
+    keys: [RenderedPageKey; 2],
+    len: usize,
+}
+
+impl RequiredRenderPages {
+    pub(crate) fn new(anchor_page: usize, anchor_key: RenderedPageKey) -> Self {
+        Self {
+            pages: [anchor_page, 0],
+            keys: [anchor_key, anchor_key],
+            len: 1,
+        }
+    }
+
+    pub(crate) fn push_trailing(&mut self, page: usize, key: RenderedPageKey) {
+        debug_assert!(self.len < self.pages.len());
+        self.pages[self.len] = page;
+        self.keys[self.len] = key;
+        self.len += 1;
+    }
+
+    pub(crate) fn keys(&self) -> &[RenderedPageKey] {
+        &self.keys[..self.len]
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (usize, usize, RenderedPageKey)> + '_ {
+        (0..self.len).map(|idx| (idx, self.pages[idx], self.keys[idx]))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CurrentInterestKeys {
+    keys: [RenderedPageKey; 4],
+    len: usize,
+}
+
+impl CurrentInterestKeys {
+    pub(crate) fn from_required(required: &RequiredRenderPages) -> Self {
+        let mut keys = [required.keys[0]; 4];
+        keys[..required.len].copy_from_slice(required.keys());
+        Self {
+            keys,
+            len: required.len,
+        }
+    }
+
+    pub(crate) fn extend(&mut self, keys: impl IntoIterator<Item = RenderedPageKey>) {
+        for key in keys {
+            debug_assert!(self.len < self.keys.len());
+            self.keys[self.len] = key;
+            self.len += 1;
+        }
+    }
+
+    pub(crate) fn as_slice(&self) -> &[RenderedPageKey] {
+        &self.keys[..self.len]
+    }
+}
+
 pub(crate) struct CurrentTaskContext {
     pub(crate) current_scale: f32,
-    pub(crate) required_pages: Vec<usize>,
-    pub(crate) required_keys: Vec<RenderedPageKey>,
-    pub(crate) current_interest_keys: Vec<RenderedPageKey>,
+    pub(crate) required: RequiredRenderPages,
+    pub(crate) current_interest_keys: CurrentInterestKeys,
     pub(crate) current_cached: bool,
     pub(crate) preview_tasks: Vec<RenderTask>,
 }
 
 pub(crate) struct PrefetchDispatchContext {
-    pub(crate) required_keys: Vec<RenderedPageKey>,
+    pub(crate) required: RequiredRenderPages,
     pub(crate) current_cached: bool,
     pub(crate) overlay_stamp: u64,
     pub(crate) prefetch_viewport: Option<Viewport>,
@@ -149,8 +209,10 @@ impl RenderSubsystem {
         render_worker: &mut RenderWorker,
         ctx: CurrentTaskContext,
     ) {
-        let canceled = render_worker
-            .cancel_stale_prefetch_except(render_actor.generation(), &ctx.current_interest_keys);
+        let canceled = render_worker.cancel_stale_prefetch_except(
+            render_actor.generation(),
+            ctx.current_interest_keys.as_slice(),
+        );
         if canceled > 0 {
             self.runtime.perf_stats.add_canceled_tasks(canceled);
         }
@@ -170,7 +232,7 @@ impl RenderSubsystem {
                 let (enqueued, preempted) = render_worker.enqueue_current_with_preemption(
                     preview_task,
                     render_actor.generation(),
-                    &ctx.current_interest_keys,
+                    ctx.current_interest_keys.as_slice(),
                 );
                 if preempted > 0 {
                     self.runtime.perf_stats.add_canceled_tasks(preempted);
@@ -183,13 +245,7 @@ impl RenderSubsystem {
             }
         }
 
-        debug_assert_eq!(
-            ctx.required_pages.len(),
-            ctx.required_keys.len(),
-            "required_pages and required_keys must have equal lengths"
-        );
-        for (idx, page) in ctx.required_pages.into_iter().enumerate() {
-            let key = ctx.required_keys[idx];
+        for (idx, page, key) in ctx.required.iter() {
             if self.runtime.has_cached_frame(&key) || render_worker.has_in_flight(&key) {
                 continue;
             }
@@ -208,7 +264,7 @@ impl RenderSubsystem {
                     },
                 },
                 render_actor.generation(),
-                &ctx.current_interest_keys,
+                ctx.current_interest_keys.as_slice(),
             );
             if preempted > 0 {
                 self.runtime.perf_stats.add_canceled_tasks(preempted);
@@ -235,7 +291,7 @@ impl RenderSubsystem {
                 };
                 ctx.dispatch_budget -= 1;
                 let key = RenderedPageKey::new(task.doc_id, task.page, task.scale);
-                if ctx.required_keys.contains(&key) {
+                if ctx.required.keys().contains(&key) {
                     continue;
                 }
                 if !self.runtime.has_cached_frame(&key) {


### PR DESCRIPTION
Replace the tiny per-frame required page/key Vecs in the render loop with fixed-size page/key sets. This keeps the current render and prefetch paths using slices while avoiding repeated allocation and cloning for the visible page set.

Verification:
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings