### PR TITLE
perf(presenter): track L2 pending work count

### DIFF
--- a/src/presenter/l2_cache.rs
+++ b/src/presenter/l2_cache.rs
@@ -19,8 +19,15 @@ pub(crate) enum TerminalFrameState {
 }
 
 pub(crate) struct TerminalFrameEntry {
-    pub(crate) state: TerminalFrameState,
-    pub(crate) approx_bytes: usize,
+    state: TerminalFrameState,
+    approx_bytes: usize,
+}
+
+impl TerminalFrameEntry {
+    #[cfg(test)]
+    pub(crate) fn state(&self) -> &TerminalFrameState {
+        &self.state
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -42,6 +49,7 @@ pub(crate) struct TerminalFrameCache {
     memory_budget_bytes: usize,
     pub(crate) entries: LruCache<TerminalFrameKey, TerminalFrameEntry>,
     pub(crate) memory_bytes: usize,
+    pending_work_count: usize,
     counters: CacheCounters,
 }
 
@@ -61,6 +69,7 @@ impl TerminalFrameCache {
                 NonZeroUsize::new(max_entries).expect("l2 cache entries is non-zero"),
             ),
             memory_bytes: 0,
+            pending_work_count: 0,
             counters: CacheCounters::default(),
         }
     }
@@ -92,9 +101,7 @@ impl TerminalFrameCache {
                 return false;
             }
 
-            if let Some(prev) = self.entries.pop(&key) {
-                self.memory_bytes = self.memory_bytes.saturating_sub(prev.approx_bytes);
-            }
+            self.pop_entry(&key);
 
             // Keep the visible ready frame resident while swapping in an oversize current
             // entry. We allow this narrow over-budget state so the viewer never regresses
@@ -107,13 +114,17 @@ impl TerminalFrameCache {
                 .filter(|protected| *protected != key);
             self.retain_only(protected_key);
             self.memory_bytes = self.memory_bytes.saturating_add(approx_bytes);
-            self.entries.put(
+            self.pending_work_count += 1;
+            if let Some((_evicted_key, evicted)) = self.entries.push(
                 key,
                 TerminalFrameEntry {
                     state: TerminalFrameState::PendingFrame(frame),
                     approx_bytes,
                 },
-            );
+            ) {
+                self.memory_bytes = self.memory_bytes.saturating_sub(evicted.approx_bytes);
+                self.note_removed_state(&evicted.state);
+            }
             return true;
         }
 
@@ -127,29 +138,19 @@ impl TerminalFrameCache {
             return false;
         }
 
-        if let Some(prev) = self.entries.pop(&key) {
-            self.memory_bytes = self.memory_bytes.saturating_sub(prev.approx_bytes);
-        }
-
-        let implicit_evicted_bytes =
-            if self.entries.len() >= self.max_entries && self.entries.peek(&key).is_none() {
-                self.entries
-                    .peek_lru()
-                    .map(|(_key, entry)| entry.approx_bytes)
-            } else {
-                None
-            };
+        self.pop_entry(&key);
 
         self.memory_bytes += approx_bytes;
-        self.entries.put(
+        self.pending_work_count += 1;
+        if let Some((_evicted_key, evicted)) = self.entries.push(
             key,
             TerminalFrameEntry {
                 state: TerminalFrameState::PendingFrame(frame),
                 approx_bytes,
             },
-        );
-        if let Some(evicted_bytes) = implicit_evicted_bytes {
-            self.memory_bytes = self.memory_bytes.saturating_sub(evicted_bytes);
+        ) {
+            self.memory_bytes = self.memory_bytes.saturating_sub(evicted.approx_bytes);
+            self.note_removed_state(&evicted.state);
         }
         self.evict_while_needed(protected_key);
         true
@@ -178,25 +179,38 @@ impl TerminalFrameCache {
     }
 
     pub(crate) fn has_pending_work(&self) -> bool {
-        self.entries.iter().any(|(_key, entry)| {
-            matches!(
-                &entry.state,
-                TerminalFrameState::PendingFrame(_) | TerminalFrameState::Encoding
-            )
-        })
+        self.pending_work_count > 0
+    }
+
+    pub(crate) fn set_state(&mut self, key: &TerminalFrameKey, state: TerminalFrameState) -> bool {
+        self.replace_state(key, state).is_some()
+    }
+
+    pub(crate) fn replace_state(
+        &mut self,
+        key: &TerminalFrameKey,
+        state: TerminalFrameState,
+    ) -> Option<TerminalFrameState> {
+        let entry = self.entries.peek_mut(key)?;
+        let old_state = std::mem::replace(&mut entry.state, state);
+        let old_pending = state_has_pending_work(&old_state);
+        let new_pending = state_has_pending_work(&entry.state);
+        match (old_pending, new_pending) {
+            (true, false) => self.pending_work_count = self.pending_work_count.saturating_sub(1),
+            (false, true) => self.pending_work_count += 1,
+            _ => {}
+        }
+        Some(old_state)
     }
 
     pub(crate) fn clear(&mut self) {
         self.entries.clear();
         self.memory_bytes = 0;
+        self.pending_work_count = 0;
     }
 
     pub(crate) fn remove(&mut self, key: &TerminalFrameKey) -> bool {
-        let Some(entry) = self.entries.pop(key) else {
-            return false;
-        };
-        self.memory_bytes = self.memory_bytes.saturating_sub(entry.approx_bytes);
-        true
+        self.pop_entry(key).is_some()
     }
 
     fn evict_while_needed(&mut self, protected_key: Option<TerminalFrameKey>) {
@@ -211,6 +225,7 @@ impl TerminalFrameCache {
                 break;
             };
             self.memory_bytes = self.memory_bytes.saturating_sub(entry.approx_bytes);
+            self.note_removed_state(&entry.state);
         }
     }
 
@@ -256,4 +271,24 @@ impl TerminalFrameCache {
             }
         }
     }
+
+    fn pop_entry(&mut self, key: &TerminalFrameKey) -> Option<TerminalFrameEntry> {
+        let entry = self.entries.pop(key)?;
+        self.memory_bytes = self.memory_bytes.saturating_sub(entry.approx_bytes);
+        self.note_removed_state(&entry.state);
+        Some(entry)
+    }
+
+    fn note_removed_state(&mut self, state: &TerminalFrameState) {
+        if state_has_pending_work(state) {
+            self.pending_work_count = self.pending_work_count.saturating_sub(1);
+        }
+    }
+}
+
+fn state_has_pending_work(state: &TerminalFrameState) -> bool {
+    matches!(
+        state,
+        TerminalFrameState::PendingFrame(_) | TerminalFrameState::Encoding
+    )
 }

--- a/src/presenter/ratatui.rs
+++ b/src/presenter/ratatui.rs
@@ -242,7 +242,7 @@ impl RatatuiImagePresenter {
                     self.state.perf_stats.record_convert(elapsed);
                 }
 
-                let Some(entry) = self.state.l2_cache.cached_mut(&key) else {
+                if self.state.l2_cache.cached_mut(&key).is_none() {
                     self.state
                         .perf_stats
                         .set_l2_hit_rate(self.state.l2_cache.hit_rate());
@@ -251,15 +251,16 @@ impl RatatuiImagePresenter {
                     });
                 };
 
-                if succeeded {
+                let state = if succeeded {
                     if let Some(protocol) = protocol {
-                        entry.state = TerminalFrameState::Ready(protocol);
+                        TerminalFrameState::Ready(protocol)
                     } else {
-                        entry.state = TerminalFrameState::Failed;
+                        TerminalFrameState::Failed
                     }
                 } else {
-                    entry.state = TerminalFrameState::Failed;
-                }
+                    TerminalFrameState::Failed
+                };
+                self.state.l2_cache.set_state(&key, state);
 
                 Some(PresenterBackgroundEvent::EncodeComplete {
                     redraw_requested: Some(key) == current_key,
@@ -358,13 +359,17 @@ impl RatatuiImagePresenter {
         area: Rect,
         key: TerminalFrameKey,
     ) -> AppResult<bool> {
-        let Some(entry) = self.state.l2_cache.cached_mut(&key) else {
+        if self.state.l2_cache.cached_mut(&key).is_none() {
             if Some(key) == self.state.last_ready_key {
                 self.state.last_ready_key = None;
             }
             return Ok(false);
         };
-        let state = std::mem::replace(&mut entry.state, TerminalFrameState::Encoding);
+        let state = self
+            .state
+            .l2_cache
+            .replace_state(&key, TerminalFrameState::Encoding)
+            .expect("entry existence checked above");
         match state {
             TerminalFrameState::Ready(mut protocol) => {
                 let blit_start = std::time::Instant::now();
@@ -372,14 +377,18 @@ impl RatatuiImagePresenter {
                 let render_area = center_rect_within(area, target_size.width, target_size.height);
                 frame.render_widget(Clear, area);
                 if let Err(err) = Self::draw_protocol(frame, render_area, &mut protocol) {
-                    entry.state = TerminalFrameState::Failed;
+                    self.state
+                        .l2_cache
+                        .set_state(&key, TerminalFrameState::Failed);
                     self.state
                         .perf_stats
                         .set_l2_hit_rate(self.state.l2_cache.hit_rate());
                     return Err(err);
                 }
                 self.state.perf_stats.record_blit(blit_start.elapsed());
-                entry.state = TerminalFrameState::Ready(protocol);
+                self.state
+                    .l2_cache
+                    .set_state(&key, TerminalFrameState::Ready(protocol));
                 self.state.last_ready_key = Some(key);
                 self.state
                     .perf_stats
@@ -387,21 +396,27 @@ impl RatatuiImagePresenter {
                 Ok(true)
             }
             TerminalFrameState::PendingFrame(frame) => {
-                entry.state = TerminalFrameState::PendingFrame(frame);
+                self.state
+                    .l2_cache
+                    .set_state(&key, TerminalFrameState::PendingFrame(frame));
                 self.state
                     .perf_stats
                     .set_l2_hit_rate(self.state.l2_cache.hit_rate());
                 Ok(false)
             }
             TerminalFrameState::Encoding => {
-                entry.state = TerminalFrameState::Encoding;
+                self.state
+                    .l2_cache
+                    .set_state(&key, TerminalFrameState::Encoding);
                 self.state
                     .perf_stats
                     .set_l2_hit_rate(self.state.l2_cache.hit_rate());
                 Ok(false)
             }
             TerminalFrameState::Failed => {
-                entry.state = TerminalFrameState::Failed;
+                self.state
+                    .l2_cache
+                    .set_state(&key, TerminalFrameState::Failed);
                 if Some(key) == self.state.last_ready_key {
                     self.state.last_ready_key = None;
                 }
@@ -514,14 +529,18 @@ impl ImagePresenter for RatatuiImagePresenter {
         );
         let font_size = self.config.picker.font_size();
         let request_tx = self.encode_request_tx(EncodeLaneKind::Background);
-        let Some(entry) = self.state.l2_cache.cached_mut(&key) else {
+        if self.state.l2_cache.cached_mut(&key).is_none() {
             self.state
                 .perf_stats
                 .set_l2_hit_rate(self.state.l2_cache.hit_rate());
             return Ok(());
         };
 
-        let state = std::mem::replace(&mut entry.state, TerminalFrameState::Encoding);
+        let state = self
+            .state
+            .l2_cache
+            .replace_state(&key, TerminalFrameState::Encoding)
+            .expect("entry existence checked above");
         match state {
             TerminalFrameState::PendingFrame(frame) => {
                 let area = centered_fit_area(frame.width, frame.height, font_size, viewport_area);
@@ -535,28 +554,31 @@ impl ImagePresenter for RatatuiImagePresenter {
                     generation,
                     enqueued_at: Instant::now(),
                 };
-                match send_encode_request(&request_tx, request) {
-                    Ok(()) => {
-                        entry.state = TerminalFrameState::Encoding;
-                    }
+                let new_state = match send_encode_request(&request_tx, request) {
+                    Ok(()) => TerminalFrameState::Encoding,
                     Err(err) => match *err {
                         EncodeWorkerRequest::Encode { frame, .. } => {
-                            entry.state = TerminalFrameState::PendingFrame(frame);
+                            TerminalFrameState::PendingFrame(frame)
                         }
-                        EncodeWorkerRequest::Shutdown => {
-                            entry.state = TerminalFrameState::Failed;
-                        }
+                        EncodeWorkerRequest::Shutdown => TerminalFrameState::Failed,
                     },
-                }
+                };
+                self.state.l2_cache.set_state(&key, new_state);
             }
             TerminalFrameState::Encoding => {
-                entry.state = TerminalFrameState::Encoding;
+                self.state
+                    .l2_cache
+                    .set_state(&key, TerminalFrameState::Encoding);
             }
             TerminalFrameState::Ready(protocol) => {
-                entry.state = TerminalFrameState::Ready(protocol);
+                self.state
+                    .l2_cache
+                    .set_state(&key, TerminalFrameState::Ready(protocol));
             }
             TerminalFrameState::Failed => {
-                entry.state = TerminalFrameState::Failed;
+                self.state
+                    .l2_cache
+                    .set_state(&key, TerminalFrameState::Failed);
             }
         }
 
@@ -612,12 +634,11 @@ impl ImagePresenter for RatatuiImagePresenter {
         }
 
         let feedback = {
-            let entry = self
+            let state = self
                 .state
                 .l2_cache
-                .cached_mut(&key)
+                .replace_state(&key, TerminalFrameState::Encoding)
                 .expect("current key existence checked above");
-            let state = std::mem::replace(&mut entry.state, TerminalFrameState::Encoding);
             match state {
                 TerminalFrameState::Ready(mut protocol) => {
                     let blit_start = std::time::Instant::now();
@@ -629,14 +650,18 @@ impl ImagePresenter for RatatuiImagePresenter {
                     let render_area =
                         center_rect_within(area, target_size.width, target_size.height);
                     if let Err(err) = Self::draw_protocol(frame, render_area, &mut protocol) {
-                        entry.state = TerminalFrameState::Failed;
+                        self.state
+                            .l2_cache
+                            .set_state(&key, TerminalFrameState::Failed);
                         self.state
                             .perf_stats
                             .set_l2_hit_rate(self.state.l2_cache.hit_rate());
                         return Err(err);
                     }
                     self.state.perf_stats.record_blit(blit_start.elapsed());
-                    entry.state = TerminalFrameState::Ready(protocol);
+                    self.state
+                        .l2_cache
+                        .set_state(&key, TerminalFrameState::Ready(protocol));
                     self.state.last_ready_key = Some(key);
                     self.state
                         .perf_stats
@@ -669,25 +694,27 @@ impl ImagePresenter for RatatuiImagePresenter {
                         enqueued_at: Instant::now(),
                     };
 
-                    match send_encode_request(&request_tx, request) {
-                        Ok(()) => {
-                            entry.state = TerminalFrameState::Encoding;
-                            PresenterFeedback::Pending
-                        }
+                    let (new_state, feedback) = match send_encode_request(&request_tx, request) {
+                        Ok(()) => (TerminalFrameState::Encoding, PresenterFeedback::Pending),
                         Err(err) => match *err {
                             EncodeWorkerRequest::Encode { .. } | EncodeWorkerRequest::Shutdown => {
-                                entry.state = TerminalFrameState::Failed;
-                                PresenterFeedback::Failed
+                                (TerminalFrameState::Failed, PresenterFeedback::Failed)
                             }
                         },
-                    }
+                    };
+                    self.state.l2_cache.set_state(&key, new_state);
+                    feedback
                 }
                 TerminalFrameState::Encoding => {
-                    entry.state = TerminalFrameState::Encoding;
+                    self.state
+                        .l2_cache
+                        .set_state(&key, TerminalFrameState::Encoding);
                     PresenterFeedback::Pending
                 }
                 TerminalFrameState::Failed => {
-                    entry.state = TerminalFrameState::Failed;
+                    self.state
+                        .l2_cache
+                        .set_state(&key, TerminalFrameState::Failed);
                     PresenterFeedback::Failed
                 }
             }

--- a/src/presenter/tests/mod.rs
+++ b/src/presenter/tests/mod.rs
@@ -271,7 +271,7 @@ fn prefetch_encode_advances_entry_to_ready() {
                 .l2_cache
                 .entries
                 .get(&key)
-                .map(|entry| &entry.state),
+                .map(|entry| entry.state()),
             Some(TerminalFrameState::Ready(_))
         );
         if ready {
@@ -596,9 +596,10 @@ fn render_returns_failed_feedback_for_failed_current_entry() {
         .state
         .current_key
         .expect("current key should exist");
-    if let Some(entry) = presenter.state.l2_cache.cached_mut(&key) {
-        entry.state = TerminalFrameState::Failed;
-    }
+    presenter
+        .state
+        .l2_cache
+        .set_state(&key, TerminalFrameState::Failed);
 
     let backend = TestBackend::new(20, 10);
     let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
@@ -656,9 +657,10 @@ fn render_failed_does_not_use_stale_fallback_when_disallowed() {
         .state
         .current_key
         .expect("current key should exist");
-    if let Some(entry) = presenter.state.l2_cache.cached_mut(&key) {
-        entry.state = TerminalFrameState::Failed;
-    }
+    presenter
+        .state
+        .l2_cache
+        .set_state(&key, TerminalFrameState::Failed);
 
     let backend = TestBackend::new(20, 10);
     let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
@@ -734,7 +736,7 @@ fn render_reports_failed_feedback_when_encode_worker_is_disconnected() {
             .l2_cache
             .entries
             .get(&key)
-            .map(|entry| &entry.state),
+            .map(|entry| entry.state()),
         Some(TerminalFrameState::Failed)
     ));
 }
@@ -940,11 +942,42 @@ fn l2_insert_keeps_pending_frame_buffer_shared() {
     let source = frame();
     let _ = cache.insert(key, source.clone(), source.byte_len(), false, None);
 
-    let stored_pixels = match cache.cached_mut(&key).map(|entry| &entry.state) {
+    let stored_pixels = match cache.cached_mut(&key).map(|entry| entry.state()) {
         Some(TerminalFrameState::PendingFrame(frame)) => &frame.pixels,
         _ => panic!("expected pending frame"),
     };
     assert!(source.pixels.ptr_eq(stored_pixels));
+}
+
+#[test]
+fn l2_pending_work_tracks_state_transitions() {
+    let mut cache = TerminalFrameCache::default();
+    let key = l2_key(0);
+    let _ = cache.insert(key, frame(), 16, false, None);
+    assert!(cache.has_pending_work());
+
+    assert!(cache.set_state(&key, TerminalFrameState::Failed));
+    assert!(!cache.has_pending_work());
+
+    assert!(cache.set_state(&key, TerminalFrameState::Encoding));
+    assert!(cache.has_pending_work());
+
+    assert!(cache.remove(&key));
+    assert!(!cache.has_pending_work());
+}
+
+#[test]
+fn l2_pending_work_tracks_eviction_and_clear() {
+    let mut cache = TerminalFrameCache::new(1, 64);
+    let first = l2_key(0);
+    let second = l2_key(1);
+    assert!(cache.insert(first, frame(), 16, false, None));
+    assert!(cache.insert(second, frame(), 16, false, None));
+    assert!(cache.cached_mut(&first).is_none());
+    assert!(cache.has_pending_work());
+
+    cache.clear();
+    assert!(!cache.has_pending_work());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Track pending L2 terminal frame work with a cache-level counter so `has_pending_work()` is O(1).
- Route cache state transitions through helper methods that maintain pending-work accounting.
- Add tests for state transitions, eviction, removal, and clear behavior.

## Rationale
`TerminalFrameCache::has_pending_work()` is called from event-loop wait decisions, so scanning every cache entry adds avoidable repeated work as the L2 cache grows.

Closes #70

## Verification
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved L2 cache efficiency with better memory accounting and pending work tracking.
  * Refactored frame state management to use consistent setter patterns, enhancing reliability and reducing potential errors in cache state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->