### PR TITLE
feat(search): prewarm and split search caches

### DIFF
--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -59,6 +59,10 @@ Rules:
   - search runs asynchronously and reports progress while active
   - positioned text extraction may be prewarmed in the background from the
     start of the document so later searches can reuse cached page text
+  - search text and highlight geometry are cached separately; cached text can
+    complete later searches even when highlight geometry has been evicted
+  - missing cached highlight geometry is resolved in the background, with the
+    current visible page prioritized over broad prewarm work
   - visible search hits are highlighted through the generic highlight overlay
     layer
   - if highlight extraction fails for matched pages, search results are kept and

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -57,6 +57,8 @@ Rules:
     no hit on the page, search falls back to a whitespace-insensitive substring
     match to tolerate PDF text extraction that omits or inserts whitespace
   - search runs asynchronously and reports progress while active
+  - positioned text extraction may be prewarmed in the background from the
+    start of the document so later searches can reuse cached page text
   - visible search hits are highlighted through the generic highlight overlay
     layer
   - if highlight extraction fails for matched pages, search results are kept and

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -715,6 +715,13 @@ impl App {
                         .extensions
                         .host
                         .prewarm_search_text(Arc::clone(&pdf));
+                    self.interaction
+                        .extensions
+                        .host
+                        .resolve_search_priority_geometry(
+                            Arc::clone(&pdf),
+                            [Some(self.state.current_page), None],
+                        );
                 }
                 match dispatch.outcome {
                     CommandOutcome::QuitRequested => {

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -266,6 +266,10 @@ impl App {
             render_actor.nav_mut().intent(),
             tracked_scale,
         );
+        self.interaction
+            .extensions
+            .host
+            .prewarm_search_text(Arc::clone(&pdf));
 
         Ok(LoopRuntime {
             page_count,
@@ -687,6 +691,7 @@ impl App {
             }
             WaitEvent::Event(DomainEvent::Command(request)) => {
                 let request = self.resolve_command_request(&runtime.session, request);
+                let previous_page = self.state.current_page;
                 let dispatch = match self.interaction.dispatch_command(
                     &mut self.state,
                     request,
@@ -704,6 +709,12 @@ impl App {
                 }
                 if self.interaction.apply_palette_requests(&mut self.state) {
                     self.request_redraw(runtime, RedrawReason::StateChanged);
+                }
+                if self.state.current_page != previous_page {
+                    self.interaction
+                        .extensions
+                        .host
+                        .prewarm_search_text(Arc::clone(&pdf));
                 }
                 match dispatch.outcome {
                     CommandOutcome::QuitRequested => {

--- a/src/extension/host.rs
+++ b/src/extension/host.rs
@@ -90,6 +90,10 @@ impl ExtensionHost {
         self.search.submit(app, pdf, query, matcher)
     }
 
+    pub fn prewarm_search_text(&mut self, pdf: SharedPdfBackend) {
+        self.search.prewarm(pdf);
+    }
+
     pub fn open_search_results_palette(
         &mut self,
         app: &mut AppState,

--- a/src/extension/host.rs
+++ b/src/extension/host.rs
@@ -94,6 +94,14 @@ impl ExtensionHost {
         self.search.prewarm(pdf);
     }
 
+    pub fn resolve_search_priority_geometry(
+        &mut self,
+        pdf: SharedPdfBackend,
+        visible_pages: [Option<usize>; 2],
+    ) {
+        self.search.resolve_priority_geometry(pdf, visible_pages);
+    }
+
     pub fn open_search_results_palette(
         &mut self,
         app: &mut AppState,

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -125,6 +125,19 @@ enum WorkerControl {
     Shutdown,
 }
 
+enum PrewarmControl {
+    Finished,
+    Interrupted(PrewarmJob),
+    Shutdown,
+}
+
+#[derive(Default)]
+struct PendingWorkerWork {
+    query: Option<SearchJob>,
+    geometry: Option<GeometryJob>,
+    prewarm: Option<PrewarmJob>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct SearchPageCacheKey {
     doc_id: u64,
@@ -487,17 +500,17 @@ fn worker_main(
     mut request_rx: UnboundedReceiver<WorkerRequest>,
     event_tx: UnboundedSender<SearchEvent>,
 ) {
-    let mut pending: Option<SearchJob> = None;
-    let mut pending_geometry: Option<GeometryJob> = None;
+    let mut pending = PendingWorkerWork::default();
     let mut text_cache = SearchTextCache::new();
     let mut geometry_cache = SearchGeometryCache::new();
     let mut prewarm_finished_doc_ids = HashSet::new();
 
     loop {
-        let job = match pending.take() {
+        let job = match pending.query.take() {
             Some(job) => job,
-            None if pending_geometry.is_some() => {
-                let job = pending_geometry
+            None if pending.geometry.is_some() => {
+                let job = pending
+                    .geometry
                     .take()
                     .expect("pending geometry checked above");
                 match run_geometry_job(
@@ -505,12 +518,30 @@ fn worker_main(
                     &mut request_rx,
                     &event_tx,
                     &mut pending,
-                    &mut pending_geometry,
                     &mut text_cache,
                     &mut geometry_cache,
                 ) {
                     WorkerControl::Continue => {}
                     WorkerControl::Shutdown => break,
+                }
+                continue;
+            }
+            None if pending.prewarm.is_some() => {
+                let job = pending
+                    .prewarm
+                    .take()
+                    .expect("pending prewarm checked above");
+                match run_prewarm_job(
+                    job,
+                    &mut request_rx,
+                    &mut pending,
+                    &mut text_cache,
+                    &mut geometry_cache,
+                    &mut prewarm_finished_doc_ids,
+                ) {
+                    PrewarmControl::Finished => {}
+                    PrewarmControl::Interrupted(job) => pending.prewarm = Some(job),
+                    PrewarmControl::Shutdown => break,
                 }
                 continue;
             }
@@ -522,7 +553,6 @@ fn worker_main(
                         &mut request_rx,
                         &event_tx,
                         &mut pending,
-                        &mut pending_geometry,
                         &mut text_cache,
                         &mut geometry_cache,
                     ) {
@@ -536,13 +566,13 @@ fn worker_main(
                         job,
                         &mut request_rx,
                         &mut pending,
-                        &mut pending_geometry,
                         &mut text_cache,
                         &mut geometry_cache,
                         &mut prewarm_finished_doc_ids,
                     ) {
-                        WorkerControl::Continue => {}
-                        WorkerControl::Shutdown => break,
+                        PrewarmControl::Finished => {}
+                        PrewarmControl::Interrupted(job) => pending.prewarm = Some(job),
+                        PrewarmControl::Shutdown => break,
                     }
                     continue;
                 }
@@ -555,7 +585,6 @@ fn worker_main(
             &mut request_rx,
             &event_tx,
             &mut pending,
-            &mut pending_geometry,
             &mut text_cache,
             &mut geometry_cache,
         ) {
@@ -583,35 +612,35 @@ fn wait_for_job(request_rx: &mut UnboundedReceiver<WorkerRequest>) -> Option<Wor
 fn run_prewarm_job(
     job: PrewarmJob,
     request_rx: &mut UnboundedReceiver<WorkerRequest>,
-    pending: &mut Option<SearchJob>,
-    pending_geometry: &mut Option<GeometryJob>,
+    pending: &mut PendingWorkerWork,
     text_cache: &mut SearchTextCache,
     geometry_cache: &mut SearchGeometryCache,
     prewarm_finished_doc_ids: &mut HashSet<u64>,
-) -> WorkerControl {
-    let doc = job.pdf;
+) -> PrewarmControl {
+    let doc = job.pdf.clone();
     let total_pages = doc.page_count();
     if total_pages == 0 {
-        return WorkerControl::Continue;
+        return PrewarmControl::Finished;
     }
 
     let doc_id = doc.doc_id();
     if prewarm_finished_doc_ids.contains(&doc_id) {
-        return WorkerControl::Continue;
+        return PrewarmControl::Finished;
     }
 
     for page in 0..total_pages {
-        match flush_requests(request_rx, pending, pending_geometry) {
+        match flush_requests(request_rx, pending) {
             WorkerControl::Continue => {
-                if pending.is_some()
-                    || pending_geometry
+                if pending.query.is_some()
+                    || pending
+                        .geometry
                         .as_ref()
                         .is_some_and(|job| job.priority == GeometryPriority::High)
                 {
-                    return WorkerControl::Continue;
+                    return PrewarmControl::Interrupted(job);
                 }
             }
-            WorkerControl::Shutdown => return WorkerControl::Shutdown,
+            WorkerControl::Shutdown => return PrewarmControl::Shutdown,
         }
         if text_cache.get(doc_id, page).is_some() {
             continue;
@@ -628,15 +657,14 @@ fn run_prewarm_job(
     }
 
     prewarm_finished_doc_ids.insert(doc_id);
-    WorkerControl::Continue
+    PrewarmControl::Finished
 }
 
 fn run_job(
     job: SearchJob,
     request_rx: &mut UnboundedReceiver<WorkerRequest>,
     event_tx: &UnboundedSender<SearchEvent>,
-    pending: &mut Option<SearchJob>,
-    pending_geometry: &mut Option<GeometryJob>,
+    pending: &mut PendingWorkerWork,
     text_cache: &mut SearchTextCache,
     geometry_cache: &mut SearchGeometryCache,
 ) -> WorkerControl {
@@ -666,9 +694,9 @@ fn run_job(
     let mut hits = Vec::new();
     let mut highlight_unavailable = false;
     for page in 0..total_pages {
-        match flush_requests(request_rx, pending, pending_geometry) {
+        match flush_requests(request_rx, pending) {
             WorkerControl::Continue => {
-                if pending.is_some() {
+                if pending.query.is_some() {
                     return WorkerControl::Continue;
                 }
             }
@@ -751,8 +779,7 @@ fn run_geometry_job(
     job: GeometryJob,
     request_rx: &mut UnboundedReceiver<WorkerRequest>,
     event_tx: &UnboundedSender<SearchEvent>,
-    pending: &mut Option<SearchJob>,
-    pending_geometry: &mut Option<GeometryJob>,
+    pending: &mut PendingWorkerWork,
     text_cache: &mut SearchTextCache,
     geometry_cache: &mut SearchGeometryCache,
 ) -> WorkerControl {
@@ -770,10 +797,11 @@ fn run_geometry_job(
         if !seen.insert(page) {
             continue;
         }
-        match flush_requests(request_rx, pending, pending_geometry) {
+        match flush_requests(request_rx, pending) {
             WorkerControl::Continue => {
-                if pending.is_some()
-                    || pending_geometry
+                if pending.query.is_some()
+                    || pending
+                        .geometry
                         .as_ref()
                         .is_some_and(|queued| queued.priority == GeometryPriority::High)
                 {
@@ -1320,22 +1348,22 @@ fn normalize_text_for_search(text: &str, case_sensitive: bool, ignore_whitespace
 
 fn flush_requests(
     request_rx: &mut UnboundedReceiver<WorkerRequest>,
-    pending: &mut Option<SearchJob>,
-    pending_geometry: &mut Option<GeometryJob>,
+    pending: &mut PendingWorkerWork,
 ) -> WorkerControl {
     loop {
         match request_rx.try_recv() {
-            Ok(WorkerRequest::Query(job)) => *pending = Some(job),
-            Ok(WorkerRequest::Prewarm(_)) => {}
+            Ok(WorkerRequest::Query(job)) => pending.query = Some(job),
+            Ok(WorkerRequest::Prewarm(job)) => pending.prewarm = Some(job),
             Ok(WorkerRequest::ResolveGeometry(job)) => {
                 // Geometry work is opportunistic. Keep only the newest high-priority request
                 // so navigation can preempt broad background hit-page warming.
                 if job.priority == GeometryPriority::High
-                    || pending_geometry
+                    || pending
+                        .geometry
                         .as_ref()
                         .is_none_or(|queued| queued.priority == GeometryPriority::Background)
                 {
-                    *pending_geometry = Some(job);
+                    pending.geometry = Some(job);
                 }
             }
             Ok(WorkerRequest::Shutdown) => return WorkerControl::Shutdown,
@@ -1371,10 +1399,11 @@ mod tests {
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     use super::{
-        PrewarmJob, SearchEngine, SearchEvent, SearchGeometryCache, SearchMatcher,
-        SearchOccurrence, SearchPageCache, SearchPageHit, SearchTextCache, WorkerControl,
-        estimate_search_text_bytes, estimate_text_page_bytes, locate_occurrences,
-        merge_occurrence_rects, page_matches_contains, prepare_contains_query, run_prewarm_job,
+        PendingWorkerWork, PrewarmControl, PrewarmJob, SearchEngine, SearchEvent,
+        SearchGeometryCache, SearchJob, SearchMatcher, SearchOccurrence, SearchPageCache,
+        SearchPageHit, SearchTextCache, WorkerRequest, estimate_search_text_bytes,
+        estimate_text_page_bytes, locate_occurrences, merge_occurrence_rects,
+        page_matches_contains, prepare_contains_query, run_prewarm_job,
     };
     use crate::backend::open_default_backend;
     use crate::backend::{OutlineNode, PdfBackend, PdfRect, RgbaFrame, TextGlyph, TextPage};
@@ -1905,8 +1934,7 @@ mod tests {
         let (_request_tx, request_rx) = unbounded_channel();
         let (_event_tx, _event_rx) = unbounded_channel::<SearchEvent>();
         let mut request_rx = request_rx;
-        let mut pending = None;
-        let mut pending_geometry = None;
+        let mut pending = PendingWorkerWork::default();
         let mut text_cache = SearchTextCache::with_limits(4, budget);
         let mut geometry_cache = SearchGeometryCache::with_limits(4, usize::MAX);
         let mut prewarm_finished_doc_ids = HashSet::new();
@@ -1916,12 +1944,11 @@ mod tests {
                 PrewarmJob { pdf: pdf.clone() },
                 &mut request_rx,
                 &mut pending,
-                &mut pending_geometry,
                 &mut text_cache,
                 &mut geometry_cache,
                 &mut prewarm_finished_doc_ids,
             ),
-            WorkerControl::Continue
+            PrewarmControl::Finished
         ));
         assert_eq!(pdf.positioned_calls(), vec![1, 1]);
 
@@ -1930,12 +1957,67 @@ mod tests {
                 PrewarmJob { pdf: pdf.clone() },
                 &mut request_rx,
                 &mut pending,
-                &mut pending_geometry,
                 &mut text_cache,
                 &mut geometry_cache,
                 &mut prewarm_finished_doc_ids,
             ),
-            WorkerControl::Continue
+            PrewarmControl::Finished
+        ));
+        assert_eq!(pdf.positioned_calls(), vec![1, 1]);
+    }
+
+    #[test]
+    fn interrupted_prewarm_can_resume_after_priority_work() {
+        let pdf = Arc::new(CountingPositionedStubPdf::new(
+            303,
+            vec![text_page("alpha"), text_page("beta")],
+        ));
+        let (request_tx, request_rx) = unbounded_channel();
+        let (_event_tx, _event_rx) = unbounded_channel::<SearchEvent>();
+        let mut request_rx = request_rx;
+        let mut pending = PendingWorkerWork::default();
+        let mut text_cache = SearchTextCache::with_limits(4, usize::MAX);
+        let mut geometry_cache = SearchGeometryCache::with_limits(4, usize::MAX);
+        let mut prewarm_finished_doc_ids = HashSet::new();
+
+        request_tx
+            .send(WorkerRequest::Query(SearchJob {
+                generation: 1,
+                pdf: pdf.clone(),
+                query: "alpha".to_string(),
+                matcher: Arc::new(ContainsMatcher {
+                    case_sensitive: false,
+                }),
+            }))
+            .expect("query request should be queued");
+
+        let interrupted = match run_prewarm_job(
+            PrewarmJob { pdf: pdf.clone() },
+            &mut request_rx,
+            &mut pending,
+            &mut text_cache,
+            &mut geometry_cache,
+            &mut prewarm_finished_doc_ids,
+        ) {
+            PrewarmControl::Interrupted(job) => job,
+            PrewarmControl::Finished => panic!("prewarm should be interrupted"),
+            PrewarmControl::Shutdown => panic!("worker should not shut down"),
+        };
+
+        assert!(pending.query.is_some());
+        assert_eq!(pdf.positioned_calls(), vec![0, 0]);
+
+        pending.query = None;
+        assert!(matches!(
+            run_prewarm_job(
+                interrupted,
+                &mut request_rx,
+                &mut pending,
+                &mut text_cache,
+                &mut geometry_cache,
+                &mut prewarm_finished_doc_ids,
+            ),
+            PrewarmControl::Finished
         ));
         assert_eq!(pdf.positioned_calls(), vec![1, 1]);
     }

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -30,6 +30,12 @@ pub enum SearchEvent {
         hits: Vec<SearchPageHit>,
         highlight_unavailable: bool,
     },
+    GeometryResolved {
+        generation: u64,
+        page: usize,
+        occurrences: Vec<SearchOccurrence>,
+        highlight_unavailable: bool,
+    },
     Failed {
         generation: u64,
         message: String,
@@ -38,8 +44,8 @@ pub enum SearchEvent {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SearchOccurrence {
-    pub glyph_start: usize,
-    pub glyph_end: usize,
+    pub match_start: usize,
+    pub match_end: usize,
     pub rects: Vec<PdfRect>,
     pub snippet: String,
     pub snippet_match_start: Option<usize>,
@@ -55,6 +61,7 @@ pub struct SearchPageHit {
 pub trait SearchMatcher: Send + Sync {
     fn prepare_query(&self, raw_query: &str) -> String;
     fn matches_page(&self, page_text: &str, prepared_query: &str) -> bool;
+    fn locate_text_matches(&self, page_text: &str, prepared_query: &str) -> Vec<SearchOccurrence>;
     fn locate_matches(&self, page: &TextPage, prepared_query: &str) -> Vec<SearchOccurrence>;
 }
 
@@ -90,9 +97,26 @@ struct PrewarmJob {
     pdf: SharedPdfBackend,
 }
 
+#[derive(Clone)]
+struct GeometryJob {
+    generation: u64,
+    pdf: SharedPdfBackend,
+    query: String,
+    matcher: Arc<dyn SearchMatcher>,
+    pages: Vec<usize>,
+    priority: GeometryPriority,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GeometryPriority {
+    High,
+    Background,
+}
+
 enum WorkerRequest {
     Query(SearchJob),
     Prewarm(PrewarmJob),
+    ResolveGeometry(GeometryJob),
     Shutdown,
 }
 
@@ -107,21 +131,35 @@ struct SearchPageCacheKey {
     page: usize,
 }
 
-struct SearchPageCache {
+struct SearchTextPage {
+    text: Arc<str>,
+    estimated_bytes: usize,
+}
+
+struct SearchTextCache {
+    pages: LruCache<SearchPageCacheKey, SearchTextPage>,
+    memory_budget_bytes: usize,
+    memory_bytes: usize,
+}
+
+struct SearchGeometryCache {
     pages: LruCache<SearchPageCacheKey, CachedTextPage>,
     memory_budget_bytes: usize,
     memory_bytes: usize,
 }
+
+#[cfg(test)]
+type SearchPageCache = SearchGeometryCache;
 
 struct CachedTextPage {
     page: Arc<TextPage>,
     estimated_bytes: usize,
 }
 
-impl SearchPageCache {
+impl SearchTextCache {
     // Search wants broad page reuse; memory budget is the real safety limit.
     const DEFAULT_MAX_ENTRIES: usize = 16_384;
-    const DEFAULT_MEMORY_BUDGET_BYTES: usize = 64 * 1024 * 1024;
+    const DEFAULT_MEMORY_BUDGET_BYTES: usize = 48 * 1024 * 1024;
 
     fn new() -> Self {
         Self::with_limits(Self::DEFAULT_MAX_ENTRIES, Self::DEFAULT_MEMORY_BUDGET_BYTES)
@@ -130,6 +168,70 @@ impl SearchPageCache {
     fn with_limits(max_entries: usize, memory_budget_bytes: usize) -> Self {
         let max_entries =
             NonZeroUsize::new(max_entries).expect("search page cache entries must be non-zero");
+        Self {
+            pages: LruCache::new(max_entries),
+            memory_budget_bytes,
+            memory_bytes: 0,
+        }
+    }
+
+    fn get(&mut self, doc_id: u64, page: usize) -> Option<Arc<str>> {
+        self.pages
+            .get(&SearchPageCacheKey { doc_id, page })
+            .map(|cached| Arc::clone(&cached.text))
+    }
+
+    fn insert(&mut self, doc_id: u64, page: usize, text: Arc<str>) {
+        let estimated_bytes = estimate_search_text_bytes(&text);
+        let key = SearchPageCacheKey { doc_id, page };
+        if let Some(replaced) = self.pages.pop(&key) {
+            self.memory_bytes = self.memory_bytes.saturating_sub(replaced.estimated_bytes);
+        }
+        if let Some((_key, removed)) = self.pages.push(
+            key,
+            SearchTextPage {
+                text,
+                estimated_bytes,
+            },
+        ) {
+            self.memory_bytes = self.memory_bytes.saturating_sub(removed.estimated_bytes);
+        }
+        self.memory_bytes = self.memory_bytes.saturating_add(estimated_bytes);
+        self.enforce_memory_budget();
+    }
+
+    fn try_insert_without_eviction(&mut self, doc_id: u64, page: usize, text: Arc<str>) -> bool {
+        let estimated_bytes = estimate_search_text_bytes(&text);
+        if self.memory_bytes.saturating_add(estimated_bytes) > self.memory_budget_bytes {
+            return false;
+        }
+
+        self.insert(doc_id, page, text);
+        true
+    }
+
+    fn enforce_memory_budget(&mut self) {
+        while self.memory_bytes > self.memory_budget_bytes {
+            let Some((_key, evicted)) = self.pages.pop_lru() else {
+                self.memory_bytes = 0;
+                break;
+            };
+            self.memory_bytes = self.memory_bytes.saturating_sub(evicted.estimated_bytes);
+        }
+    }
+}
+
+impl SearchGeometryCache {
+    const DEFAULT_MAX_ENTRIES: usize = 16_384;
+    const DEFAULT_MEMORY_BUDGET_BYTES: usize = 16 * 1024 * 1024;
+
+    fn new() -> Self {
+        Self::with_limits(Self::DEFAULT_MAX_ENTRIES, Self::DEFAULT_MEMORY_BUDGET_BYTES)
+    }
+
+    fn with_limits(max_entries: usize, memory_budget_bytes: usize) -> Self {
+        let max_entries =
+            NonZeroUsize::new(max_entries).expect("search geometry cache entries must be non-zero");
         Self {
             pages: LruCache::new(max_entries),
             memory_budget_bytes,
@@ -196,6 +298,10 @@ impl SearchPageCache {
     fn memory_bytes(&self) -> usize {
         self.memory_bytes
     }
+}
+
+fn estimate_search_text_bytes(text: &Arc<str>) -> usize {
+    size_of::<Arc<str>>() + text.len()
 }
 
 fn estimate_text_page_bytes(text_page: &TextPage) -> usize {
@@ -299,6 +405,35 @@ impl SearchEngine {
             .send(WorkerRequest::Prewarm(PrewarmJob { pdf }));
     }
 
+    pub fn resolve_geometry(
+        &mut self,
+        pdf: SharedPdfBackend,
+        generation: u64,
+        query: impl Into<String>,
+        matcher: Arc<dyn SearchMatcher>,
+        pages: Vec<usize>,
+        high_priority: bool,
+    ) {
+        if pages.is_empty() {
+            return;
+        }
+        let priority = if high_priority {
+            GeometryPriority::High
+        } else {
+            GeometryPriority::Background
+        };
+        let _ = self
+            .request_tx
+            .send(WorkerRequest::ResolveGeometry(GeometryJob {
+                generation,
+                pdf,
+                query: query.into(),
+                matcher,
+                pages,
+                priority,
+            }));
+    }
+
     pub fn drain_events(&mut self) -> Vec<SearchEvent> {
         let mut drained = Vec::new();
 
@@ -326,6 +461,14 @@ impl SearchMatcher for CancelMatcher {
         false
     }
 
+    fn locate_text_matches(
+        &self,
+        _page_text: &str,
+        _prepared_query: &str,
+    ) -> Vec<SearchOccurrence> {
+        Vec::new()
+    }
+
     fn locate_matches(&self, _page: &TextPage, _prepared_query: &str) -> Vec<SearchOccurrence> {
         Vec::new()
     }
@@ -345,20 +488,57 @@ fn worker_main(
     event_tx: UnboundedSender<SearchEvent>,
 ) {
     let mut pending: Option<SearchJob> = None;
-    let mut page_cache = SearchPageCache::new();
+    let mut pending_geometry: Option<GeometryJob> = None;
+    let mut text_cache = SearchTextCache::new();
+    let mut geometry_cache = SearchGeometryCache::new();
     let mut prewarm_finished_doc_ids = HashSet::new();
 
     loop {
         let job = match pending.take() {
             Some(job) => job,
+            None if pending_geometry.is_some() => {
+                let job = pending_geometry
+                    .take()
+                    .expect("pending geometry checked above");
+                match run_geometry_job(
+                    job,
+                    &mut request_rx,
+                    &event_tx,
+                    &mut pending,
+                    &mut pending_geometry,
+                    &mut text_cache,
+                    &mut geometry_cache,
+                ) {
+                    WorkerControl::Continue => {}
+                    WorkerControl::Shutdown => break,
+                }
+                continue;
+            }
             None => match wait_for_job(&mut request_rx) {
                 Some(WorkerWork::Query(job)) => job,
+                Some(WorkerWork::Geometry(job)) => {
+                    match run_geometry_job(
+                        job,
+                        &mut request_rx,
+                        &event_tx,
+                        &mut pending,
+                        &mut pending_geometry,
+                        &mut text_cache,
+                        &mut geometry_cache,
+                    ) {
+                        WorkerControl::Continue => {}
+                        WorkerControl::Shutdown => break,
+                    }
+                    continue;
+                }
                 Some(WorkerWork::Prewarm(job)) => {
                     match run_prewarm_job(
                         job,
                         &mut request_rx,
                         &mut pending,
-                        &mut page_cache,
+                        &mut pending_geometry,
+                        &mut text_cache,
+                        &mut geometry_cache,
                         &mut prewarm_finished_doc_ids,
                     ) {
                         WorkerControl::Continue => {}
@@ -375,7 +555,9 @@ fn worker_main(
             &mut request_rx,
             &event_tx,
             &mut pending,
-            &mut page_cache,
+            &mut pending_geometry,
+            &mut text_cache,
+            &mut geometry_cache,
         ) {
             WorkerControl::Continue => {}
             WorkerControl::Shutdown => break,
@@ -386,12 +568,14 @@ fn worker_main(
 enum WorkerWork {
     Query(SearchJob),
     Prewarm(PrewarmJob),
+    Geometry(GeometryJob),
 }
 
 fn wait_for_job(request_rx: &mut UnboundedReceiver<WorkerRequest>) -> Option<WorkerWork> {
     match request_rx.blocking_recv() {
         Some(WorkerRequest::Query(job)) => Some(WorkerWork::Query(job)),
         Some(WorkerRequest::Prewarm(job)) => Some(WorkerWork::Prewarm(job)),
+        Some(WorkerRequest::ResolveGeometry(job)) => Some(WorkerWork::Geometry(job)),
         Some(WorkerRequest::Shutdown) | None => None,
     }
 }
@@ -400,7 +584,9 @@ fn run_prewarm_job(
     job: PrewarmJob,
     request_rx: &mut UnboundedReceiver<WorkerRequest>,
     pending: &mut Option<SearchJob>,
-    page_cache: &mut SearchPageCache,
+    pending_geometry: &mut Option<GeometryJob>,
+    text_cache: &mut SearchTextCache,
+    geometry_cache: &mut SearchGeometryCache,
     prewarm_finished_doc_ids: &mut HashSet<u64>,
 ) -> WorkerControl {
     let doc = job.pdf;
@@ -415,22 +601,29 @@ fn run_prewarm_job(
     }
 
     for page in 0..total_pages {
-        match flush_requests(request_rx, pending) {
+        match flush_requests(request_rx, pending, pending_geometry) {
             WorkerControl::Continue => {
-                if pending.is_some() {
+                if pending.is_some()
+                    || pending_geometry
+                        .as_ref()
+                        .is_some_and(|job| job.priority == GeometryPriority::High)
+                {
                     return WorkerControl::Continue;
                 }
             }
             WorkerControl::Shutdown => return WorkerControl::Shutdown,
         }
-        if page_cache.get(doc_id, page).is_some() {
+        if text_cache.get(doc_id, page).is_some() {
             continue;
         }
         if let Ok(text_page) = doc.extract_positioned_text(page) {
-            if !page_cache.try_insert_without_eviction(doc_id, page, Arc::new(text_page)) {
+            let text_page = Arc::new(text_page);
+            let text: Arc<str> = Arc::from(text_page.extracted_text());
+            if !text_cache.try_insert_without_eviction(doc_id, page, text) {
                 prewarm_finished_doc_ids.insert(doc_id);
                 break;
             }
+            geometry_cache.try_insert_without_eviction(doc_id, page, text_page);
         }
     }
 
@@ -443,7 +636,9 @@ fn run_job(
     request_rx: &mut UnboundedReceiver<WorkerRequest>,
     event_tx: &UnboundedSender<SearchEvent>,
     pending: &mut Option<SearchJob>,
-    page_cache: &mut SearchPageCache,
+    pending_geometry: &mut Option<GeometryJob>,
+    text_cache: &mut SearchTextCache,
+    geometry_cache: &mut SearchGeometryCache,
 ) -> WorkerControl {
     let query = job.matcher.prepare_query(job.query.trim());
     if query.is_empty() {
@@ -471,7 +666,7 @@ fn run_job(
     let mut hits = Vec::new();
     let mut highlight_unavailable = false;
     for page in 0..total_pages {
-        match flush_requests(request_rx, pending) {
+        match flush_requests(request_rx, pending, pending_geometry) {
             WorkerControl::Continue => {
                 if pending.is_some() {
                     return WorkerControl::Continue;
@@ -480,27 +675,34 @@ fn run_job(
             WorkerControl::Shutdown => return WorkerControl::Shutdown,
         }
 
-        let positioned_text = match page_cache.get(doc_id, page) {
-            Some(text_page) => Ok(text_page),
+        let page_text = match text_cache.get(doc_id, page) {
+            Some(text) => Ok(text),
             None => doc.extract_positioned_text(page).map(|text_page| {
                 let text_page = Arc::new(text_page);
-                page_cache.try_insert_without_eviction(doc_id, page, Arc::clone(&text_page));
-                text_page
+                let text: Arc<str> = Arc::from(text_page.extracted_text());
+                text_cache.try_insert_without_eviction(doc_id, page, Arc::clone(&text));
+                geometry_cache.try_insert_without_eviction(doc_id, page, text_page);
+                text
             }),
         };
 
-        match positioned_text {
-            Ok(text_page) => {
-                let mut occurrences = job.matcher.locate_matches(text_page.as_ref(), &query);
-                // Keep `extract_text` out of the primary search path: once positioned text is
-                // available, the glyph stream is the searchable source of truth.
-                if !occurrences.is_empty() {
-                    for occurrence in &mut occurrences {
-                        if occurrence_highlight_unavailable(occurrence, &text_page.glyphs) {
-                            highlight_unavailable = true;
+        match page_text {
+            Ok(text) => {
+                let occurrences = match geometry_cache.get(doc_id, page) {
+                    Some(text_page) => {
+                        let mut occurrences =
+                            job.matcher.locate_matches(text_page.as_ref(), &query);
+                        for occurrence in &mut occurrences {
+                            if occurrence_highlight_unavailable(occurrence, &text_page.glyphs) {
+                                highlight_unavailable = true;
+                            }
+                            apply_hit_snippet(occurrence, &text_page.glyphs);
                         }
-                        apply_hit_snippet(occurrence, &text_page.glyphs);
+                        occurrences
                     }
+                    None => job.matcher.locate_text_matches(&text, &query),
+                };
+                if !occurrences.is_empty() {
                     hits.push(SearchPageHit { page, occurrences });
                 }
             }
@@ -545,12 +747,84 @@ fn run_job(
     WorkerControl::Continue
 }
 
+fn run_geometry_job(
+    job: GeometryJob,
+    request_rx: &mut UnboundedReceiver<WorkerRequest>,
+    event_tx: &UnboundedSender<SearchEvent>,
+    pending: &mut Option<SearchJob>,
+    pending_geometry: &mut Option<GeometryJob>,
+    text_cache: &mut SearchTextCache,
+    geometry_cache: &mut SearchGeometryCache,
+) -> WorkerControl {
+    let query = job.matcher.prepare_query(job.query.trim());
+    if query.is_empty() {
+        return WorkerControl::Continue;
+    }
+
+    let doc = job.pdf;
+    let doc_id = doc.doc_id();
+    let total_pages = doc.page_count();
+    let mut seen = HashSet::new();
+
+    for page in job.pages.into_iter().filter(|page| *page < total_pages) {
+        if !seen.insert(page) {
+            continue;
+        }
+        match flush_requests(request_rx, pending, pending_geometry) {
+            WorkerControl::Continue => {
+                if pending.is_some()
+                    || pending_geometry
+                        .as_ref()
+                        .is_some_and(|queued| queued.priority == GeometryPriority::High)
+                {
+                    return WorkerControl::Continue;
+                }
+            }
+            WorkerControl::Shutdown => return WorkerControl::Shutdown,
+        }
+
+        let positioned_text = match geometry_cache.get(doc_id, page) {
+            Some(text_page) => Ok(text_page),
+            None => doc.extract_positioned_text(page).map(|text_page| {
+                let text_page = Arc::new(text_page);
+                if text_cache.get(doc_id, page).is_none() {
+                    let text: Arc<str> = Arc::from(text_page.extracted_text());
+                    text_cache.try_insert_without_eviction(doc_id, page, text);
+                }
+                geometry_cache.insert(doc_id, page, Arc::clone(&text_page));
+                text_page
+            }),
+        };
+
+        let Ok(text_page) = positioned_text else {
+            continue;
+        };
+
+        let mut occurrences = job.matcher.locate_matches(text_page.as_ref(), &query);
+        let mut highlight_unavailable = false;
+        for occurrence in &mut occurrences {
+            if occurrence_highlight_unavailable(occurrence, &text_page.glyphs) {
+                highlight_unavailable = true;
+            }
+            apply_hit_snippet(occurrence, &text_page.glyphs);
+        }
+        let _ = event_tx.send(SearchEvent::GeometryResolved {
+            generation: job.generation,
+            page,
+            occurrences,
+            highlight_unavailable,
+        });
+    }
+
+    WorkerControl::Continue
+}
+
 fn occurrence_highlight_unavailable(occurrence: &SearchOccurrence, glyphs: &[TextGlyph]) -> bool {
     if occurrence.rects.is_empty() {
         return true;
     }
 
-    let Some(slice) = glyphs.get(occurrence.glyph_start..=occurrence.glyph_end) else {
+    let Some(slice) = glyphs.get(occurrence.match_start..=occurrence.match_end) else {
         return true;
     };
 
@@ -573,6 +847,20 @@ pub(crate) fn locate_occurrences(
     locate_occurrences_with_strategy(glyphs, prepared_query, case_sensitive, true)
 }
 
+pub(crate) fn locate_text_occurrences(
+    text: &str,
+    prepared_query: &str,
+    case_sensitive: bool,
+) -> Vec<SearchOccurrence> {
+    let occurrences =
+        locate_text_occurrences_with_strategy(text, prepared_query, case_sensitive, false);
+    if !occurrences.is_empty() {
+        return occurrences;
+    }
+
+    locate_text_occurrences_with_strategy(text, prepared_query, case_sensitive, true)
+}
+
 struct SnippetPresentation {
     text: String,
     match_start: Option<usize>,
@@ -580,7 +868,7 @@ struct SnippetPresentation {
 }
 
 fn apply_hit_snippet(occurrence: &mut SearchOccurrence, glyphs: &[TextGlyph]) {
-    let snippet = build_hit_snippet(glyphs, occurrence.glyph_start, occurrence.glyph_end);
+    let snippet = build_hit_snippet(glyphs, occurrence.match_start, occurrence.match_end);
     occurrence.snippet = snippet.text;
     occurrence.snippet_match_start = snippet.match_start;
     occurrence.snippet_match_end = snippet.match_end;
@@ -588,12 +876,12 @@ fn apply_hit_snippet(occurrence: &mut SearchOccurrence, glyphs: &[TextGlyph]) {
 
 fn build_hit_snippet(
     glyphs: &[TextGlyph],
-    glyph_start: usize,
-    glyph_end: usize,
+    match_start: usize,
+    match_end: usize,
 ) -> SnippetPresentation {
     const CONTEXT_CHARS: usize = 16;
 
-    if glyphs.is_empty() || glyph_start >= glyphs.len() || glyph_end < glyph_start {
+    if glyphs.is_empty() || match_start >= glyphs.len() || match_end < match_start {
         return SnippetPresentation {
             text: String::new(),
             match_start: None,
@@ -601,22 +889,22 @@ fn build_hit_snippet(
         };
     }
 
-    let glyph_end = glyph_end.min(glyphs.len() - 1);
-    let context_start = glyph_start.saturating_sub(CONTEXT_CHARS);
-    let context_end = glyph_end
+    let match_end = match_end.min(glyphs.len() - 1);
+    let context_start = match_start.saturating_sub(CONTEXT_CHARS);
+    let context_end = match_end
         .saturating_add(CONTEXT_CHARS)
         .saturating_add(1)
         .min(glyphs.len());
 
-    let before = glyphs[context_start..glyph_start]
+    let before = glyphs[context_start..match_start]
         .iter()
         .map(|glyph| glyph.ch)
         .collect::<String>();
-    let matched = glyphs[glyph_start..=glyph_end]
+    let matched = glyphs[match_start..=match_end]
         .iter()
         .map(|glyph| glyph.ch)
         .collect::<String>();
-    let after = glyphs[glyph_end + 1..context_end]
+    let after = glyphs[match_end + 1..context_end]
         .iter()
         .map(|glyph| glyph.ch)
         .collect::<String>();
@@ -637,6 +925,135 @@ fn build_hit_snippet(
     }
     snippet.push_str(&after);
     if context_end < glyphs.len() {
+        snippet.push('…');
+    }
+
+    SnippetPresentation {
+        text: snippet,
+        match_start,
+        match_end,
+    }
+}
+
+fn locate_text_occurrences_with_strategy(
+    text: &str,
+    prepared_query: &str,
+    case_sensitive: bool,
+    ignore_whitespace: bool,
+) -> Vec<SearchOccurrence> {
+    if prepared_query.is_empty() {
+        return Vec::new();
+    }
+
+    let (search_text, char_map) =
+        normalize_text_with_char_map(text, case_sensitive, ignore_whitespace);
+    if search_text.is_empty() {
+        return Vec::new();
+    }
+
+    let query_text = normalize_text_for_search(prepared_query, true, ignore_whitespace);
+    if query_text.is_empty() || query_text.len() > search_text.len() {
+        return Vec::new();
+    }
+
+    let char_byte_offsets: Vec<usize> = search_text
+        .char_indices()
+        .map(|(offset, _)| offset)
+        .collect();
+    let query_char_len = query_text.chars().count();
+    if query_char_len == 0 || query_char_len > char_map.len() {
+        return Vec::new();
+    }
+
+    let mut occurrences = Vec::new();
+    let mut cursor_byte = 0;
+    while cursor_byte <= search_text.len() {
+        let Some(relative_match_byte) = search_text[cursor_byte..].find(&query_text) else {
+            break;
+        };
+        let match_byte = cursor_byte + relative_match_byte;
+        let match_char_start = char_byte_offsets
+            .binary_search(&match_byte)
+            .expect("str::find returned a non-character-boundary offset");
+        let char_start = char_map[match_char_start];
+        let char_end = char_map[match_char_start + query_char_len - 1];
+        let snippet = build_text_hit_snippet(text, char_start, char_end);
+        occurrences.push(SearchOccurrence {
+            match_start: char_start,
+            match_end: char_end,
+            rects: Vec::new(),
+            snippet: snippet.text,
+            snippet_match_start: snippet.match_start,
+            snippet_match_end: snippet.match_end,
+        });
+        cursor_byte = match_byte + query_text.len();
+    }
+
+    occurrences
+}
+
+fn normalize_text_with_char_map(
+    text: &str,
+    case_sensitive: bool,
+    ignore_whitespace: bool,
+) -> (String, Vec<usize>) {
+    let mut search_text = String::new();
+    let mut char_map = Vec::new();
+
+    for (char_index, ch) in text.chars().enumerate() {
+        if ignore_whitespace && ch.is_whitespace() {
+            continue;
+        }
+        push_normalized_chars(ch, case_sensitive, |normalized| {
+            if !ignore_whitespace || !normalized.is_whitespace() {
+                search_text.push(normalized);
+                char_map.push(char_index);
+            }
+        });
+    }
+
+    (search_text, char_map)
+}
+
+fn build_text_hit_snippet(text: &str, char_start: usize, char_end: usize) -> SnippetPresentation {
+    const CONTEXT_CHARS: usize = 16;
+
+    let chars: Vec<char> = text.chars().collect();
+    if chars.is_empty() || char_start >= chars.len() || char_end < char_start {
+        return SnippetPresentation {
+            text: String::new(),
+            match_start: None,
+            match_end: None,
+        };
+    }
+
+    let char_end = char_end.min(chars.len() - 1);
+    let context_start = char_start.saturating_sub(CONTEXT_CHARS);
+    let context_end = char_end
+        .saturating_add(CONTEXT_CHARS)
+        .saturating_add(1)
+        .min(chars.len());
+
+    let before = chars[context_start..char_start].iter().collect::<String>();
+    let matched = chars[char_start..=char_end].iter().collect::<String>();
+    let after = chars[char_end + 1..context_end].iter().collect::<String>();
+
+    let mut snippet = String::new();
+    let mut match_start = None;
+    let mut match_end = None;
+    if context_start > 0 {
+        snippet.push('…');
+    }
+    snippet.push_str(&before);
+    if !matched.is_empty() {
+        match_start = Some(snippet.len());
+    }
+    snippet.push_str(&matched);
+    if !matched.is_empty() {
+        match_end = Some(snippet.len());
+    }
+    snippet.push_str(&after);
+    if context_end < chars.len() {
         snippet.push('…');
     }
 
@@ -702,8 +1119,8 @@ fn locate_occurrences_with_strategy(
         let glyph_end = char_map[match_char_start + query_char_len - 1];
         let rects = merge_occurrence_rects(&glyphs[glyph_start..=glyph_end]);
         occurrences.push(SearchOccurrence {
-            glyph_start,
-            glyph_end,
+            match_start: glyph_start,
+            match_end: glyph_end,
             rects,
             snippet: String::new(),
             snippet_match_start: None,
@@ -904,11 +1321,23 @@ fn normalize_text_for_search(text: &str, case_sensitive: bool, ignore_whitespace
 fn flush_requests(
     request_rx: &mut UnboundedReceiver<WorkerRequest>,
     pending: &mut Option<SearchJob>,
+    pending_geometry: &mut Option<GeometryJob>,
 ) -> WorkerControl {
     loop {
         match request_rx.try_recv() {
             Ok(WorkerRequest::Query(job)) => *pending = Some(job),
             Ok(WorkerRequest::Prewarm(_)) => {}
+            Ok(WorkerRequest::ResolveGeometry(job)) => {
+                // Geometry work is opportunistic. Keep only the newest high-priority request
+                // so navigation can preempt broad background hit-page warming.
+                if job.priority == GeometryPriority::High
+                    || pending_geometry
+                        .as_ref()
+                        .is_none_or(|queued| queued.priority == GeometryPriority::Background)
+                {
+                    *pending_geometry = Some(job);
+                }
+            }
             Ok(WorkerRequest::Shutdown) => return WorkerControl::Shutdown,
             Err(TryRecvError::Empty) => break,
             Err(TryRecvError::Disconnected) => return WorkerControl::Shutdown,
@@ -942,8 +1371,9 @@ mod tests {
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     use super::{
-        PrewarmJob, SearchEngine, SearchEvent, SearchMatcher, SearchOccurrence, SearchPageCache,
-        SearchPageHit, WorkerControl, estimate_text_page_bytes, locate_occurrences,
+        PrewarmJob, SearchEngine, SearchEvent, SearchGeometryCache, SearchMatcher,
+        SearchOccurrence, SearchPageCache, SearchPageHit, SearchTextCache, WorkerControl,
+        estimate_search_text_bytes, estimate_text_page_bytes, locate_occurrences,
         merge_occurrence_rects, page_matches_contains, prepare_contains_query, run_prewarm_job,
     };
     use crate::backend::open_default_backend;
@@ -963,6 +1393,14 @@ mod tests {
 
         fn matches_page(&self, page_text: &str, prepared_query: &str) -> bool {
             page_matches_contains(page_text, prepared_query, self.case_sensitive)
+        }
+
+        fn locate_text_matches(
+            &self,
+            page_text: &str,
+            prepared_query: &str,
+        ) -> Vec<SearchOccurrence> {
+            super::locate_text_occurrences(page_text, prepared_query, self.case_sensitive)
         }
 
         fn locate_matches(&self, page: &TextPage, prepared_query: &str) -> Vec<SearchOccurrence> {
@@ -1459,7 +1897,7 @@ mod tests {
     fn prewarm_does_not_retry_after_memory_budget_is_reached() {
         let first_page = text_page("alpha");
         let second_page = text_page("beta gamma");
-        let budget = estimate_text_page_bytes(&first_page);
+        let budget = estimate_search_text_bytes(&Arc::from(first_page.extracted_text()));
         let pdf = Arc::new(CountingPositionedStubPdf::new(
             302,
             vec![first_page, second_page],
@@ -1468,7 +1906,9 @@ mod tests {
         let (_event_tx, _event_rx) = unbounded_channel::<SearchEvent>();
         let mut request_rx = request_rx;
         let mut pending = None;
-        let mut page_cache = SearchPageCache::with_limits(4, budget);
+        let mut pending_geometry = None;
+        let mut text_cache = SearchTextCache::with_limits(4, budget);
+        let mut geometry_cache = SearchGeometryCache::with_limits(4, usize::MAX);
         let mut prewarm_finished_doc_ids = HashSet::new();
 
         assert!(matches!(
@@ -1476,7 +1916,9 @@ mod tests {
                 PrewarmJob { pdf: pdf.clone() },
                 &mut request_rx,
                 &mut pending,
-                &mut page_cache,
+                &mut pending_geometry,
+                &mut text_cache,
+                &mut geometry_cache,
                 &mut prewarm_finished_doc_ids,
             ),
             WorkerControl::Continue
@@ -1488,7 +1930,9 @@ mod tests {
                 PrewarmJob { pdf: pdf.clone() },
                 &mut request_rx,
                 &mut pending,
-                &mut page_cache,
+                &mut pending_geometry,
+                &mut text_cache,
+                &mut geometry_cache,
                 &mut prewarm_finished_doc_ids,
             ),
             WorkerControl::Continue
@@ -1844,8 +2288,8 @@ mod tests {
         let occurrences = locate_occurrences(&glyphs, "foobar", false);
 
         assert_eq!(occurrences.len(), 1);
-        assert_eq!(occurrences[0].glyph_start, 0);
-        assert_eq!(occurrences[0].glyph_end, 5);
+        assert_eq!(occurrences[0].match_start, 0);
+        assert_eq!(occurrences[0].match_end, 5);
     }
 
     #[test]
@@ -1862,8 +2306,8 @@ mod tests {
         let occurrences = locate_occurrences(&glyphs, "foo bar", false);
 
         assert_eq!(occurrences.len(), 1);
-        assert_eq!(occurrences[0].glyph_start, 0);
-        assert_eq!(occurrences[0].glyph_end, 5);
+        assert_eq!(occurrences[0].match_start, 0);
+        assert_eq!(occurrences[0].match_end, 5);
     }
 
     #[test]
@@ -1877,8 +2321,8 @@ mod tests {
         let occurrences = locate_occurrences(&glyphs, "aa", true);
 
         assert_eq!(occurrences.len(), 1);
-        assert_eq!(occurrences[0].glyph_start, 0);
-        assert_eq!(occurrences[0].glyph_end, 1);
+        assert_eq!(occurrences[0].match_start, 0);
+        assert_eq!(occurrences[0].match_end, 1);
     }
 
     #[test]
@@ -1893,8 +2337,8 @@ mod tests {
         let occurrences = locate_occurrences(&glyphs, "βa", true);
 
         assert_eq!(occurrences.len(), 1);
-        assert_eq!(occurrences[0].glyph_start, 1);
-        assert_eq!(occurrences[0].glyph_end, 2);
+        assert_eq!(occurrences[0].match_start, 1);
+        assert_eq!(occurrences[0].match_end, 2);
     }
 
     #[test]
@@ -1904,8 +2348,8 @@ mod tests {
         let occurrences = locate_occurrences(&glyphs, "i\u{307}", false);
 
         assert_eq!(occurrences.len(), 1);
-        assert_eq!(occurrences[0].glyph_start, 0);
-        assert_eq!(occurrences[0].glyph_end, 0);
+        assert_eq!(occurrences[0].match_start, 0);
+        assert_eq!(occurrences[0].match_end, 0);
     }
 
     #[test]
@@ -1945,8 +2389,8 @@ mod tests {
             glyph('x', 20.0, 20.0, 28.0, 32.0),
         ];
         let mut occurrence = SearchOccurrence {
-            glyph_start: 0,
-            glyph_end: 0,
+            match_start: 0,
+            match_end: 0,
             rects: vec![PdfRect {
                 x0: 10.0,
                 y0: 20.0,

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::mem::size_of;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -84,8 +85,14 @@ struct SearchJob {
     matcher: Arc<dyn SearchMatcher>,
 }
 
+#[derive(Clone)]
+struct PrewarmJob {
+    pdf: SharedPdfBackend,
+}
+
 enum WorkerRequest {
     Query(SearchJob),
+    Prewarm(PrewarmJob),
     Shutdown,
 }
 
@@ -138,8 +145,12 @@ impl SearchPageCache {
 
     fn insert(&mut self, doc_id: u64, page: usize, text_page: Arc<TextPage>) {
         let estimated_bytes = estimate_text_page_bytes(&text_page);
+        let key = SearchPageCacheKey { doc_id, page };
+        if let Some(replaced) = self.pages.pop(&key) {
+            self.memory_bytes = self.memory_bytes.saturating_sub(replaced.estimated_bytes);
+        }
         if let Some((_key, removed)) = self.pages.push(
-            SearchPageCacheKey { doc_id, page },
+            key,
             CachedTextPage {
                 page: text_page,
                 estimated_bytes,
@@ -149,6 +160,21 @@ impl SearchPageCache {
         }
         self.memory_bytes = self.memory_bytes.saturating_add(estimated_bytes);
         self.enforce_memory_budget();
+    }
+
+    fn try_insert_without_eviction(
+        &mut self,
+        doc_id: u64,
+        page: usize,
+        text_page: Arc<TextPage>,
+    ) -> bool {
+        let estimated_bytes = estimate_text_page_bytes(&text_page);
+        if self.memory_bytes.saturating_add(estimated_bytes) > self.memory_budget_bytes {
+            return false;
+        }
+
+        self.insert(doc_id, page, text_page);
+        true
     }
 
     fn enforce_memory_budget(&mut self) {
@@ -267,6 +293,12 @@ impl SearchEngine {
         self.submit(pdf, String::new(), Arc::new(CancelMatcher))
     }
 
+    pub fn prewarm(&mut self, pdf: SharedPdfBackend) {
+        let _ = self
+            .request_tx
+            .send(WorkerRequest::Prewarm(PrewarmJob { pdf }));
+    }
+
     pub fn drain_events(&mut self) -> Vec<SearchEvent> {
         let mut drained = Vec::new();
 
@@ -314,12 +346,26 @@ fn worker_main(
 ) {
     let mut pending: Option<SearchJob> = None;
     let mut page_cache = SearchPageCache::new();
+    let mut prewarm_finished_doc_ids = HashSet::new();
 
     loop {
         let job = match pending.take() {
             Some(job) => job,
             None => match wait_for_job(&mut request_rx) {
-                Some(job) => job,
+                Some(WorkerWork::Query(job)) => job,
+                Some(WorkerWork::Prewarm(job)) => {
+                    match run_prewarm_job(
+                        job,
+                        &mut request_rx,
+                        &mut pending,
+                        &mut page_cache,
+                        &mut prewarm_finished_doc_ids,
+                    ) {
+                        WorkerControl::Continue => {}
+                        WorkerControl::Shutdown => break,
+                    }
+                    continue;
+                }
                 None => break,
             },
         };
@@ -337,11 +383,59 @@ fn worker_main(
     }
 }
 
-fn wait_for_job(request_rx: &mut UnboundedReceiver<WorkerRequest>) -> Option<SearchJob> {
+enum WorkerWork {
+    Query(SearchJob),
+    Prewarm(PrewarmJob),
+}
+
+fn wait_for_job(request_rx: &mut UnboundedReceiver<WorkerRequest>) -> Option<WorkerWork> {
     match request_rx.blocking_recv() {
-        Some(WorkerRequest::Query(job)) => Some(job),
+        Some(WorkerRequest::Query(job)) => Some(WorkerWork::Query(job)),
+        Some(WorkerRequest::Prewarm(job)) => Some(WorkerWork::Prewarm(job)),
         Some(WorkerRequest::Shutdown) | None => None,
     }
+}
+
+fn run_prewarm_job(
+    job: PrewarmJob,
+    request_rx: &mut UnboundedReceiver<WorkerRequest>,
+    pending: &mut Option<SearchJob>,
+    page_cache: &mut SearchPageCache,
+    prewarm_finished_doc_ids: &mut HashSet<u64>,
+) -> WorkerControl {
+    let doc = job.pdf;
+    let total_pages = doc.page_count();
+    if total_pages == 0 {
+        return WorkerControl::Continue;
+    }
+
+    let doc_id = doc.doc_id();
+    if prewarm_finished_doc_ids.contains(&doc_id) {
+        return WorkerControl::Continue;
+    }
+
+    for page in 0..total_pages {
+        match flush_requests(request_rx, pending) {
+            WorkerControl::Continue => {
+                if pending.is_some() {
+                    return WorkerControl::Continue;
+                }
+            }
+            WorkerControl::Shutdown => return WorkerControl::Shutdown,
+        }
+        if page_cache.get(doc_id, page).is_some() {
+            continue;
+        }
+        if let Ok(text_page) = doc.extract_positioned_text(page) {
+            if !page_cache.try_insert_without_eviction(doc_id, page, Arc::new(text_page)) {
+                prewarm_finished_doc_ids.insert(doc_id);
+                break;
+            }
+        }
+    }
+
+    prewarm_finished_doc_ids.insert(doc_id);
+    WorkerControl::Continue
 }
 
 fn run_job(
@@ -390,7 +484,7 @@ fn run_job(
             Some(text_page) => Ok(text_page),
             None => doc.extract_positioned_text(page).map(|text_page| {
                 let text_page = Arc::new(text_page);
-                page_cache.insert(doc_id, page, Arc::clone(&text_page));
+                page_cache.try_insert_without_eviction(doc_id, page, Arc::clone(&text_page));
                 text_page
             }),
         };
@@ -814,6 +908,7 @@ fn flush_requests(
     loop {
         match request_rx.try_recv() {
             Ok(WorkerRequest::Query(job)) => *pending = Some(job),
+            Ok(WorkerRequest::Prewarm(_)) => {}
             Ok(WorkerRequest::Shutdown) => return WorkerControl::Shutdown,
             Err(TryRecvError::Empty) => break,
             Err(TryRecvError::Disconnected) => return WorkerControl::Shutdown,
@@ -837,6 +932,7 @@ enum RectExtent {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::fs;
     use std::path::Path;
     use std::path::PathBuf;
@@ -846,13 +942,14 @@ mod tests {
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     use super::{
-        SearchEngine, SearchEvent, SearchMatcher, SearchOccurrence, SearchPageCache, SearchPageHit,
-        estimate_text_page_bytes, locate_occurrences, merge_occurrence_rects,
-        page_matches_contains, prepare_contains_query,
+        PrewarmJob, SearchEngine, SearchEvent, SearchMatcher, SearchOccurrence, SearchPageCache,
+        SearchPageHit, WorkerControl, estimate_text_page_bytes, locate_occurrences,
+        merge_occurrence_rects, page_matches_contains, prepare_contains_query, run_prewarm_job,
     };
     use crate::backend::open_default_backend;
     use crate::backend::{OutlineNode, PdfBackend, PdfRect, RgbaFrame, TextGlyph, TextPage};
     use crate::error::{AppError, AppResult};
+    use tokio::sync::mpsc::unbounded_channel;
 
     #[derive(Debug)]
     struct ContainsMatcher {
@@ -1043,6 +1140,22 @@ mod tests {
     }
 
     #[test]
+    fn search_page_cache_insert_without_eviction_stops_at_memory_budget() {
+        let first = Arc::new(text_page("alpha"));
+        let second = Arc::new(text_page("beta gamma"));
+        let budget = estimate_text_page_bytes(&first);
+        let mut cache = SearchPageCache::with_limits(4, budget);
+
+        assert!(cache.try_insert_without_eviction(1, 0, Arc::clone(&first)));
+        assert!(!cache.try_insert_without_eviction(1, 1, Arc::clone(&second)));
+
+        assert!(cache.get(1, 0).is_some());
+        assert!(cache.get(1, 1).is_none());
+        assert_eq!(cache.len(), 1);
+        assert!(cache.memory_bytes() <= budget);
+    }
+
+    #[test]
     fn search_page_cache_separates_documents() {
         let mut cache = SearchPageCache::with_limits(4, usize::MAX);
         cache.insert(1, 0, Arc::new(text_page("alpha")));
@@ -1074,6 +1187,20 @@ mod tests {
         cache.insert(1, 0, Arc::new(replacement));
 
         assert_eq!(cache.len(), 1);
+        assert_eq!(cache.memory_bytes(), expected_bytes);
+    }
+
+    #[test]
+    fn search_page_cache_reinsertion_does_not_trigger_budget_eviction() {
+        let page = Arc::new(text_page("a"));
+        let expected_bytes = estimate_text_page_bytes(&page);
+        let mut cache = SearchPageCache::with_limits(4, expected_bytes);
+
+        cache.insert(1, 0, Arc::clone(&page));
+        cache.insert(1, 0, Arc::clone(&page));
+
+        assert_eq!(cache.len(), 1);
+        assert!(cache.get(1, 0).is_some());
         assert_eq!(cache.memory_bytes(), expected_bytes);
     }
 
@@ -1296,6 +1423,77 @@ mod tests {
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].occurrences.len(), 1);
         assert!(!highlight_unavailable);
+    }
+
+    #[test]
+    fn prewarm_populates_positioned_text_cache_for_later_search() {
+        let mut engine = SearchEngine::new();
+        let pdf = Arc::new(CountingPositionedStubPdf::new(
+            301,
+            vec![
+                text_page("alpha"),
+                text_page("beta"),
+                text_page("gamma alpha"),
+            ],
+        ));
+
+        engine.prewarm(pdf.clone());
+        wait_until(|| pdf.positioned_calls() == vec![1, 1, 1], "prewarm calls");
+
+        let generation = engine
+            .submit(
+                pdf.clone(),
+                "alpha",
+                Arc::new(ContainsMatcher {
+                    case_sensitive: false,
+                }),
+            )
+            .expect("submit should succeed");
+        let (hits, _) = wait_for_completed_hits(&mut engine, generation);
+
+        assert_eq!(hit_pages(&hits), vec![0, 2]);
+        assert_eq!(pdf.positioned_calls(), vec![1, 1, 1]);
+    }
+
+    #[test]
+    fn prewarm_does_not_retry_after_memory_budget_is_reached() {
+        let first_page = text_page("alpha");
+        let second_page = text_page("beta gamma");
+        let budget = estimate_text_page_bytes(&first_page);
+        let pdf = Arc::new(CountingPositionedStubPdf::new(
+            302,
+            vec![first_page, second_page],
+        ));
+        let (_request_tx, request_rx) = unbounded_channel();
+        let (_event_tx, _event_rx) = unbounded_channel::<SearchEvent>();
+        let mut request_rx = request_rx;
+        let mut pending = None;
+        let mut page_cache = SearchPageCache::with_limits(4, budget);
+        let mut prewarm_finished_doc_ids = HashSet::new();
+
+        assert!(matches!(
+            run_prewarm_job(
+                PrewarmJob { pdf: pdf.clone() },
+                &mut request_rx,
+                &mut pending,
+                &mut page_cache,
+                &mut prewarm_finished_doc_ids,
+            ),
+            WorkerControl::Continue
+        ));
+        assert_eq!(pdf.positioned_calls(), vec![1, 1]);
+
+        assert!(matches!(
+            run_prewarm_job(
+                PrewarmJob { pdf: pdf.clone() },
+                &mut request_rx,
+                &mut pending,
+                &mut page_cache,
+                &mut prewarm_finished_doc_ids,
+            ),
+            WorkerControl::Continue
+        ));
+        assert_eq!(pdf.positioned_calls(), vec![1, 1]);
     }
 
     #[test]
@@ -1791,6 +1989,19 @@ mod tests {
                 start.elapsed() <= timeout,
                 "timed out waiting for search completion"
             );
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    fn wait_until(mut condition: impl FnMut() -> bool, label: &str) {
+        let timeout = Duration::from_secs(3);
+        let start = Instant::now();
+
+        loop {
+            if condition() {
+                return;
+            }
+            assert!(start.elapsed() <= timeout, "timed out waiting for {label}");
             thread::sleep(Duration::from_millis(10));
         }
     }

--- a/src/search/state.rs
+++ b/src/search/state.rs
@@ -79,6 +79,10 @@ impl SearchRuntime {
         self.state.on_background(app, &mut self.engine)
     }
 
+    pub fn prewarm(&mut self, pdf: SharedPdfBackend) {
+        self.engine.prewarm(pdf);
+    }
+
     pub fn matcher(&self) -> SearchMatcherKind {
         self.state.matcher()
     }

--- a/src/search/state.rs
+++ b/src/search/state.rs
@@ -10,7 +10,7 @@ use crate::palette::{PaletteKind, PaletteOpenPayload};
 
 use super::engine::{
     SearchEngine, SearchEvent, SearchMatcher, SearchOccurrence, SearchPageHit, locate_occurrences,
-    page_matches_contains, prepare_contains_query,
+    locate_text_occurrences, page_matches_contains, prepare_contains_query,
 };
 
 #[derive(Default)]
@@ -83,6 +83,26 @@ impl SearchRuntime {
         self.engine.prewarm(pdf);
     }
 
+    pub fn resolve_priority_geometry(
+        &mut self,
+        pdf: SharedPdfBackend,
+        visible_pages: [Option<usize>; 2],
+    ) {
+        if self.state.query.is_empty() {
+            return;
+        }
+        let pages = self.state.geometry_priority_pages(visible_pages, false);
+        let matcher = matcher_for_kind(self.state.matcher);
+        self.engine.resolve_geometry(
+            pdf,
+            self.state.generation,
+            self.state.query.clone(),
+            matcher,
+            pages,
+            true,
+        );
+    }
+
     pub fn matcher(&self) -> SearchMatcherKind {
         self.state.matcher()
     }
@@ -121,7 +141,7 @@ pub struct SearchPaletteEntry {
     pub snippet_match_end: Option<usize>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SearchState {
     query: String,
     matcher: SearchMatcherKind,
@@ -134,12 +154,13 @@ pub struct SearchState {
     /// Number of matched pages observed so far while scanning.
     /// This is progress-oriented and may change before completion.
     hit_pages_progress: usize,
-    /// Final matched page list with occurrence rects, available on completion.
+    /// Final matched page list. Occurrence rects may be filled after completion by geometry events.
     hits: Vec<SearchPageHit>,
     /// Final matched occurrences for the results palette, ordered by page/match order.
     palette_entries: Arc<[SearchPaletteEntry]>,
     current_hit: Option<usize>,
     last_error: Option<String>,
+    active_pdf: Option<SharedPdfBackend>,
 }
 
 impl Default for SearchState {
@@ -156,6 +177,7 @@ impl Default for SearchState {
             palette_entries: Arc::from([]),
             current_hit: None,
             last_error: None,
+            active_pdf: None,
         }
     }
 }
@@ -230,6 +252,7 @@ impl SearchState {
         self.palette_entries = Arc::from([]);
         self.current_hit = None;
         self.last_error = None;
+        self.active_pdf = Some(Arc::clone(&pdf));
         Ok((CommandOutcome::Applied, NoticeAction::Clear))
     }
 
@@ -319,12 +342,46 @@ impl SearchState {
                     self.current_hit = None;
                     self.palette_entries = build_palette_entries(&hits);
                     self.hits = hits;
+                    let pages = self.geometry_priority_pages([Some(app.current_page), None], true);
+                    if !pages.is_empty()
+                        && let Some(pdf) = &self.active_pdf
+                    {
+                        let matcher = matcher_for_kind(self.matcher);
+                        search_engine.resolve_geometry(
+                            Arc::clone(pdf),
+                            self.generation,
+                            self.query.clone(),
+                            matcher,
+                            pages,
+                            false,
+                        );
+                    }
                     if highlight_unavailable {
                         app.apply_notice_action(NoticeAction::warning(
                             Self::HIGHLIGHT_UNAVAILABLE_NOTICE,
                         ));
                     }
                     changed = true;
+                }
+                SearchEvent::GeometryResolved {
+                    generation,
+                    page,
+                    occurrences,
+                    highlight_unavailable,
+                } => {
+                    if generation != self.generation {
+                        continue;
+                    }
+                    if let Some(hit) = self.hits.iter_mut().find(|hit| hit.page == page) {
+                        hit.occurrences = occurrences;
+                        self.palette_entries = build_palette_entries(&self.hits);
+                        if highlight_unavailable {
+                            app.apply_notice_action(NoticeAction::warning(
+                                Self::HIGHLIGHT_UNAVAILABLE_NOTICE,
+                            ));
+                        }
+                        changed = true;
+                    }
                 }
                 SearchEvent::Failed {
                     generation,
@@ -383,6 +440,42 @@ impl SearchState {
 
     pub fn palette_entries(&self) -> Arc<[SearchPaletteEntry]> {
         Arc::clone(&self.palette_entries)
+    }
+
+    fn geometry_priority_pages(
+        &self,
+        visible_pages: [Option<usize>; 2],
+        include_all_hits: bool,
+    ) -> Vec<usize> {
+        let mut pages = Vec::new();
+        for page in visible_pages.into_iter().flatten() {
+            push_unique_page(&mut pages, page);
+        }
+
+        if let Some(current_hit) = self.current_hit {
+            if let Some(hit) = self.hits.get(current_hit) {
+                push_unique_page(&mut pages, hit.page);
+            }
+            if let Some(hit) = self.hits.get((current_hit + 1) % self.hits.len().max(1)) {
+                push_unique_page(&mut pages, hit.page);
+            }
+            if !self.hits.is_empty() {
+                let prev = if current_hit == 0 {
+                    self.hits.len() - 1
+                } else {
+                    current_hit - 1
+                };
+                if let Some(hit) = self.hits.get(prev) {
+                    push_unique_page(&mut pages, hit.page);
+                }
+            }
+        }
+        if include_all_hits {
+            for hit in &self.hits {
+                push_unique_page(&mut pages, hit.page);
+            }
+        }
+        pages
     }
 
     fn move_hit(&mut self, app: &mut AppState, forward: bool) -> (CommandOutcome, NoticeAction) {
@@ -458,6 +551,13 @@ impl SearchState {
         self.palette_entries = Arc::from([]);
         self.current_hit = None;
         self.last_error = None;
+        self.active_pdf = None;
+    }
+}
+
+fn push_unique_page(pages: &mut Vec<usize>, page: usize) {
+    if !pages.contains(&page) {
+        pages.push(page);
     }
 }
 
@@ -502,6 +602,10 @@ impl SearchMatcher for ContainsMatcher {
 
     fn matches_page(&self, page_text: &str, prepared_query: &str) -> bool {
         page_matches_contains(page_text, prepared_query, self.case_sensitive)
+    }
+
+    fn locate_text_matches(&self, page_text: &str, prepared_query: &str) -> Vec<SearchOccurrence> {
+        locate_text_occurrences(page_text, prepared_query, self.case_sensitive)
     }
 
     fn locate_matches(


### PR DESCRIPTION
## Summary

This speeds up repeated full-document search by prewarming page text and separating the cache used for search text from the cache used for highlight geometry.

Previously search reuse depended on cached positioned `TextPage` entries, which bundle searchable text with glyph bounding boxes. That made bbox-heavy geometry compete with the text needed to answer future searches. This PR keeps broader cached page text for search, while treating highlight geometry as a smaller, deferred cache.

## Approach

- Prewarm positioned text from the start of the document in the background.
- Store extracted searchable page text separately from bbox-backed `TextPage` geometry.
- Use cached text to complete full-document search even when geometry has been evicted.
- Resolve missing highlight geometry after search completion, prioritizing the current visible page and search navigation targets.
- Keep search results, result palette entries, and `n/N` navigation independent from geometry availability.

## Behavior

When both caches miss, the worker still extracts positioned text once and fans the result into both caches when budgets allow. If geometry is unavailable later, search can still complete from cached text; highlights are filled in when geometry resolution catches up.

High-priority geometry requests from navigation can preempt broad background geometry warming, so jumping through results favors the page the user is actually viewing.

In local manual testing, the 1000-page benchmark PDF appeared to keep enough text cached for searches across the full document, where the previous bbox-backed cache seemed to hit its limit around page 600 and then re-extract text for later pages. A separate roughly 60-page PDF also felt responsive after this change. These are observational UI checks rather than formal benchmark numbers.

## Verification

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search text extraction is prewarmed at startup for faster initial searches.
  * Cached text and highlight geometry are stored separately; cached text can satisfy searches even if highlights were evicted.
  * Missing highlight geometry is repaired asynchronously, prioritizing currently visible pages.
  * Geometry resolution work can be prioritized to surface highlights and snippets sooner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->