### PR TITLE
chore: update hayro to 0.6 and reuse render cache per worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +279,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -703,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "euclid"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
 ]
@@ -740,18 +776,6 @@ name = "fast-srgb8"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
-
-[[package]]
-name = "fast_image_resize"
-version = "5.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc7fe45cf92b43817ff62a3723e862b85bd1d06288f63007f7645d1d2f7a060"
-dependencies = [
- "cfg-if",
- "document-features",
- "num-traits",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "fast_image_resize"
@@ -802,12 +826,9 @@ dependencies = [
 
 [[package]]
 name = "fearless_simd"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb2907d1f08b2b316b9223ced5b0e89d87028ba8deae9764741dba8ff7f3903"
-dependencies = [
- "bytemuck",
-]
+checksum = "76258897e51fd156ee03b6246ea53f3e0eb395d0b327e9961c4fc4c8b2fa151a"
 
 [[package]]
 name = "filedescriptor"
@@ -881,18 +902,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
-version = "0.10.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "font-types"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4d2d0cf79d38430cc9dc9aadec84774bff2e1ba30ae2bf6c16cfce9385a23"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
 dependencies = [
  "bytemuck",
 ]
@@ -1004,6 +1016,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "guillotiere"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b17e70c989c36bad147b27a58d148c0741c51448aa5653436547323e524d0ab"
+dependencies = [
+ "euclid",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,12 +1059,12 @@ dependencies = [
 
 [[package]]
 name = "hayro"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ec16ea18d2ab01c94ab300f9415f8900cd056085c6926f70a7c3e7391192769"
+checksum = "4b38770cae4e1217b6ea7d7d217f25db8fece792a05e477ef951ddf3f82be42d"
 dependencies = [
  "bytemuck",
- "fast_image_resize 5.5.0",
+ "fast_image_resize",
  "hayro-interpret",
  "image",
  "kurbo",
@@ -1052,70 +1073,75 @@ dependencies = [
 
 [[package]]
 name = "hayro-ccitt"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2db6494c3070f0e3cd9de52ee1a562ba3b2f832cd17b5537180c28294ca088eb"
+checksum = "9f4d0e94ddd48749f06bbe4e5389fb9799a0c45bcaf00495042076ef05e3241a"
 
 [[package]]
-name = "hayro-font"
-version = "0.4.0"
+name = "hayro-cmap"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d688da07ebfa1f0508697bdcc739a80a840706e2cfba39360820003a9bc49ed2"
+checksum = "24d285dc30731c8485de5fa732fbdf2b3affdf01e4da7c2135022ca6fa664bf6"
 dependencies = [
- "log",
- "phf 0.13.1",
+ "brotli",
+ "hayro-postscript",
 ]
 
 [[package]]
 name = "hayro-interpret"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298f36b94e75fa4055b4a71db9c641085d6197b214a4e13f3c4aedebb5cea234"
+checksum = "0750546426b301ab32fcde4889b0839573e3cd62aff8dd347bb46200c8e13f04"
 dependencies = [
  "bitflags 2.11.0",
- "hayro-font",
+ "hayro-cmap",
  "hayro-syntax",
  "kurbo",
- "log",
- "moxcms",
+ "moxcms 0.8.1",
  "phf 0.13.1",
  "rustc-hash",
  "siphasher",
- "skrifa 0.40.0",
+ "skrifa 0.42.1",
  "smallvec",
  "yoke",
 ]
 
 [[package]]
 name = "hayro-jbig2"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7d4358462d3e5aeeb4dcfdea5467821d6551f6cb4607cc037ac99131bc1e32"
+checksum = "69374b3668dd45aeb3d3145cda68f2c7b4f223aaa2511e67d076f1c7d741388d"
 dependencies = [
+ "fearless_simd",
  "hayro-ccitt",
 ]
 
 [[package]]
 name = "hayro-jpeg2000"
-version = "0.2.0"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d8a5e080cc7429956acf933caf1ef8d4880ae70cbb26eeaec3ae228c7c5f61"
+checksum = "c75ab947623ef4ccaa7acf0579edf7cbb5a73838e3839a7be73335e522f433a1"
 dependencies = [
  "fearless_simd",
- "log",
 ]
 
 [[package]]
-name = "hayro-syntax"
-version = "0.5.0"
+name = "hayro-postscript"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08efad1aa85ea1e19ae3bb46832779222c32887fae7b30d53a07b1d1c0ba553"
+checksum = "885c5ef0654933139a9b9546fc2c69e18d37f38aa2520f079092b1be18f1fcaa"
+
+[[package]]
+name = "hayro-syntax"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1099009c2a8e3ab8b65b19e74b37e870251e508e4b528ea549ee19a925f081a9"
 dependencies = [
  "flate2",
  "hayro-ccitt",
  "hayro-jbig2",
  "hayro-jpeg2000",
- "log",
+ "memchr",
  "rustc-hash",
  "smallvec",
  "zune-jpeg 0.5.12",
@@ -1167,9 +1193,9 @@ dependencies = [
  "exr",
  "gif",
  "image-webp",
- "moxcms",
+ "moxcms 0.7.11",
  "num-traits",
- "png 0.18.1",
+ "png",
  "qoi",
  "ravif",
  "rayon",
@@ -1303,9 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce9729cc38c18d86123ab736fd2e7151763ba226ac2490ec092d1dd148825e32"
+checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
 dependencies = [
  "arrayvec",
  "euclid",
@@ -1507,6 +1533,16 @@ name = "moxcms"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -1728,9 +1764,9 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "peniko"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c76095c9a636173600478e0373218c7b955335048c2bcd12dc6a79657649d8"
+checksum = "9a2b6aadb221872732e87d465213e9be5af2849b0e8cc5300a8ba98fffa2e00a"
 dependencies = [
  "bytemuck",
  "color",
@@ -1800,7 +1836,6 @@ checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros 0.13.1",
  "phf_shared 0.13.1",
- "serde",
 ]
 
 [[package]]
@@ -1885,19 +1920,6 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
-name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
@@ -1947,7 +1969,7 @@ dependencies = [
  "bytemuck",
  "clap",
  "crossterm 0.28.1",
- "fast_image_resize 6.0.0",
+ "fast_image_resize",
  "flume",
  "futures-util",
  "hayro",
@@ -2321,22 +2343,22 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
-dependencies = [
- "bytemuck",
- "font-types 0.10.1",
-]
-
-[[package]]
-name = "read-fonts"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
 dependencies = [
  "bytemuck",
- "font-types 0.11.0",
+ "font-types",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
+dependencies = [
+ "bytemuck",
+ "font-types",
 ]
 
 [[package]]
@@ -2600,22 +2622,22 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skrifa"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
-dependencies = [
- "bytemuck",
- "read-fonts 0.35.0",
-]
-
-[[package]]
-name = "skrifa"
 version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
 dependencies = [
  "bytemuck",
  "read-fonts 0.37.0",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.39.2",
 ]
 
 [[package]]
@@ -3041,29 +3063,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "vello_common"
-version = "0.0.5"
+name = "vello_api"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc01cc9e1e2511e5e77024e8d4c2287b9272cafc05ba669ed1056579219dd73"
+checksum = "a5088cd0113bc5332c753f24503825e3bc93e26c7883c9dc3ad9637bb62c4634"
+dependencies = [
+ "bytemuck",
+ "peniko",
+]
+
+[[package]]
+name = "vello_common"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986dc49a501a683477614bf07b8e7b6c79ae4828efce3bf22e51850f4a0a8a4c"
 dependencies = [
  "bytemuck",
  "fearless_simd",
- "hashbrown 0.15.5",
+ "guillotiere",
+ "hashbrown 0.16.1",
  "log",
  "peniko",
- "png 0.17.16",
- "skrifa 0.37.0",
+ "png",
+ "skrifa 0.40.0",
  "smallvec",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "vello_cpu"
-version = "0.0.5"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9228d8ed0f1f030de9a09b66b4750012194c0f171030ec74214ba1ca3b9eed23"
+checksum = "a678f91c7524a3a9ac9a19df9f83552866ec70b2ca26441b916a6b219b6aa2de"
 dependencies = [
  "bytemuck",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
+ "vello_api",
  "vello_common",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ harness = false
 
 [dependencies]
 bytemuck = { version = "1.25.0", features = ["extern_crate_alloc"] }
-hayro = "0.5.0"
-kurbo = "0.12.0"
+hayro = "0.6.0"
+kurbo = "0.13.0"
 crossterm = { version = "0.28.1", features = ["event-stream"] }
 clap = { version = "4.5.49", features = ["derive"] }
 ratatui = "0.30.0"

--- a/docs/rendering-pipeline.md
+++ b/docs/rendering-pipeline.md
@@ -37,6 +37,11 @@ Primary backend API:
 fn render_page(&self, page: usize, scale: f32) -> AppResult<RgbaFrame>
 ```
 
+Render workers may create a backend-specific render context before processing
+tasks. The hayro backend uses this context to keep hayro's document-scoped
+`RenderCache` local to each worker thread while preserving the shared
+`PdfBackend` contract.
+
 Search and overlay extraction use a separate text-page path that exposes glyph
 rectangles in page coordinates.
 

--- a/src/backend/hayro.rs
+++ b/src/backend/hayro.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet, hash_map::DefaultHasher};
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
@@ -33,6 +34,65 @@ pub struct PdfDoc {
 }
 
 pub type HayroPdfBackend = PdfDoc;
+
+const MAX_DOC_RENDER_CACHES_PER_THREAD: usize = 8;
+
+thread_local! {
+    static THREAD_RENDER_CACHES: RefCell<ThreadRenderCaches> = RefCell::new(ThreadRenderCaches::default());
+}
+
+struct ThreadRenderCaches {
+    order: Vec<u64>,
+    by_doc: HashMap<u64, RenderCache>,
+    max_entries: usize,
+}
+
+impl Default for ThreadRenderCaches {
+    fn default() -> Self {
+        Self::with_capacity(MAX_DOC_RENDER_CACHES_PER_THREAD)
+    }
+}
+
+impl ThreadRenderCaches {
+    fn with_capacity(max_entries: usize) -> Self {
+        Self {
+            order: Vec::new(),
+            by_doc: HashMap::new(),
+            max_entries: max_entries.max(1),
+        }
+    }
+
+    fn get(&mut self, doc_id: u64) -> &RenderCache {
+        if self.by_doc.contains_key(&doc_id) {
+            self.touch(doc_id);
+        } else {
+            self.evict_if_full();
+            self.order.push(doc_id);
+            self.by_doc.insert(doc_id, RenderCache::new());
+        }
+
+        self.by_doc
+            .get(&doc_id)
+            .expect("render cache entry should exist")
+    }
+
+    fn touch(&mut self, doc_id: u64) {
+        if let Some(index) = self.order.iter().position(|id| *id == doc_id) {
+            self.order.remove(index);
+        }
+        self.order.push(doc_id);
+    }
+
+    fn evict_if_full(&mut self) {
+        if self.by_doc.len() < self.max_entries {
+            return;
+        }
+        if let Some(evicted_doc_id) = self.order.first().copied() {
+            self.order.remove(0);
+            self.by_doc.remove(&evicted_doc_id);
+        }
+    }
+}
 
 impl PdfBackend for PdfDoc {
     fn path(&self) -> &Path {
@@ -168,11 +228,10 @@ impl PdfDoc {
             bg_color: WHITE,
             ..Default::default()
         };
-        let render_cache = RenderCache::new();
         let interpreter_settings = InterpreterSettings::default();
-        let pixmap = render(
+        let pixmap = render_with_thread_local_cache(
+            self.doc_id,
             page_ref,
-            &render_cache,
             &interpreter_settings,
             &render_settings,
         );
@@ -215,6 +274,19 @@ impl PdfDoc {
     pub fn extract_outline(&self) -> AppResult<Vec<OutlineNode>> {
         extract_outline_nodes(&self.pdf)
     }
+}
+
+fn render_with_thread_local_cache(
+    doc_id: u64,
+    page: &Page<'_>,
+    interpreter_settings: &InterpreterSettings,
+    render_settings: &RenderSettings,
+) -> Pixmap {
+    THREAD_RENDER_CACHES.with(|thread_caches| {
+        let mut thread_caches = thread_caches.borrow_mut();
+        let render_cache = thread_caches.get(doc_id);
+        render(page, render_cache, interpreter_settings, render_settings)
+    })
 }
 
 fn extract_outline_nodes(pdf: &Pdf) -> AppResult<Vec<OutlineNode>> {
@@ -892,7 +964,38 @@ mod tests {
 
     use crate::error::AppError;
 
-    use super::{PdfDoc, decode_pdf_text_string, pixel_buffer_from_pixmap};
+    use super::{
+        PdfDoc, ThreadRenderCaches, decode_pdf_text_string, pixel_buffer_from_pixmap,
+    };
+
+    #[test]
+    fn thread_render_caches_evict_oldest_document_when_capacity_is_reached() {
+        let mut caches = ThreadRenderCaches::with_capacity(2);
+
+        let _ = caches.get(10);
+        let _ = caches.get(20);
+        let _ = caches.get(30);
+
+        assert_eq!(caches.by_doc.len(), 2);
+        assert!(!caches.by_doc.contains_key(&10));
+        assert!(caches.by_doc.contains_key(&20));
+        assert!(caches.by_doc.contains_key(&30));
+    }
+
+    #[test]
+    fn thread_render_caches_refresh_recency_on_access() {
+        let mut caches = ThreadRenderCaches::with_capacity(2);
+
+        let _ = caches.get(10);
+        let _ = caches.get(20);
+        let _ = caches.get(10);
+        let _ = caches.get(30);
+
+        assert_eq!(caches.by_doc.len(), 2);
+        assert!(caches.by_doc.contains_key(&10));
+        assert!(!caches.by_doc.contains_key(&20));
+        assert!(caches.by_doc.contains_key(&30));
+    }
 
     fn unique_temp_path(suffix: &str) -> PathBuf {
         let nanos = SystemTime::now()

--- a/src/backend/hayro.rs
+++ b/src/backend/hayro.rs
@@ -5,10 +5,11 @@ use std::sync::Arc;
 
 use bytemuck::allocation::cast_vec;
 use hayro::hayro_interpret::font::Glyph;
-use hayro::hayro_interpret::util::{PageExt, RectExt};
+use hayro::hayro_interpret::hayro_cmap::BfString;
+use hayro::hayro_interpret::util::{RectExt, TransformExt};
 use hayro::hayro_interpret::{
-    BlendMode, ClipPath, Context, Device, GlyphDrawMode, Image, InterpreterSettings, Paint,
-    PathDrawMode, SoftMask, interpret_page,
+    BlendMode, ClipPath, Context, Device, GlyphDrawMode, Image, InterpreterCache,
+    InterpreterSettings, Paint, PathDrawMode, SoftMask, interpret_page,
 };
 use hayro::hayro_syntax::Pdf;
 use hayro::hayro_syntax::object::dict::keys::{
@@ -18,7 +19,7 @@ use hayro::hayro_syntax::object::{Array, Dict, MaybeRef, Name, ObjRef, Object, O
 use hayro::hayro_syntax::page::Page;
 use hayro::vello_cpu::color::palette::css::WHITE;
 use hayro::vello_cpu::{Pixmap, color::PremulRgba8};
-use hayro::{RenderSettings, render};
+use hayro::{RenderCache, RenderSettings, render};
 use kurbo::{Affine, BezPath, Point, Shape};
 
 use crate::error::{AppError, AppResult};
@@ -167,8 +168,14 @@ impl PdfDoc {
             bg_color: WHITE,
             ..Default::default()
         };
+        let render_cache = RenderCache::new();
         let interpreter_settings = InterpreterSettings::default();
-        let pixmap = render(page_ref, &interpreter_settings, &render_settings);
+        let pixmap = render(
+            page_ref,
+            &render_cache,
+            &interpreter_settings,
+            &render_settings,
+        );
 
         Ok(RgbaFrame {
             width: pixmap.width() as u32,
@@ -359,7 +366,7 @@ fn resolve_destination<'a>(
             visited_names,
         ),
         Object::String(string) => resolve_named_destination(
-            string.get().as_ref(),
+            string.as_bytes(),
             xref,
             page_index,
             named_destinations,
@@ -388,9 +395,7 @@ fn outline_title(item: &Dict<'_>) -> String {
         return "(untitled)".to_string();
     };
 
-    let decoded = decode_pdf_text_string(title.get().as_ref())
-        .trim()
-        .to_string();
+    let decoded = decode_pdf_text_string(title.as_bytes()).trim().to_string();
     if decoded.is_empty() {
         "(untitled)".to_string()
     } else {
@@ -510,7 +515,7 @@ fn destination_name_key(value: MaybeRef<Object<'_>>) -> Option<Vec<u8>> {
     match value {
         MaybeRef::Ref(_) => None,
         MaybeRef::NotRef(Object::Name(name)) => Some(name.as_ref().to_vec()),
-        MaybeRef::NotRef(Object::String(string)) => Some(string.get().into_owned()),
+        MaybeRef::NotRef(Object::String(string)) => Some(string.as_bytes().to_vec()),
         MaybeRef::NotRef(_) => None,
     }
 }
@@ -607,9 +612,11 @@ impl<'a> NamedDestination<'a> {
 }
 
 fn extract_text_with_device(page: &Page<'_>) -> String {
+    let cache = InterpreterCache::new();
     let mut context = Context::new(
-        page.initial_transform(true),
+        page.initial_transform(true).to_kurbo(),
         page.intersected_crop_box().to_kurbo(),
+        &cache,
         page.xref(),
         InterpreterSettings::default(),
     );
@@ -698,12 +705,14 @@ impl<'a> Device<'a> for PlainTextExtractDevice {
         };
 
         let position = (transform * glyph_transform) * Point::ORIGIN;
-        if self.is_duplicate_glyph(ch, position.x, position.y) {
-            return;
-        }
+        for ch in bf_string_chars(ch) {
+            if self.is_duplicate_glyph(ch, position.x, position.y) {
+                continue;
+            }
 
-        self.set_last_glyph(ch, position.x, position.y);
-        self.push_char(ch, position.x, position.y);
+            self.set_last_glyph(ch, position.x, position.y);
+            self.push_char(ch, position.x, position.y);
+        }
     }
 
     fn draw_image(&mut self, _image: Image<'a, '_>, _transform: Affine) {}
@@ -714,9 +723,11 @@ impl<'a> Device<'a> for PlainTextExtractDevice {
 }
 
 fn extract_positioned_text_with_device(page: &Page<'_>) -> TextPage {
+    let cache = InterpreterCache::new();
     let mut context = Context::new(
-        page.initial_transform(true),
+        page.initial_transform(true).to_kurbo(),
         page.intersected_crop_box().to_kurbo(),
+        &cache,
         page.xref(),
         InterpreterSettings::default(),
     );
@@ -789,16 +800,18 @@ impl<'a> Device<'a> for PositionedTextExtractDevice {
         };
 
         let position = (transform * glyph_transform) * Point::ORIGIN;
-        if self.is_duplicate_glyph(ch, position.x, position.y) {
-            return;
-        }
-
-        self.set_last_glyph(ch, position.x, position.y);
         let bbox = glyph_bbox(glyph, transform, glyph_transform);
         if bbox.is_none() {
             self.dropped_glyphs += 1;
         }
-        self.glyphs.push(TextGlyph { ch, bbox });
+        for ch in bf_string_chars(ch) {
+            if self.is_duplicate_glyph(ch, position.x, position.y) {
+                continue;
+            }
+
+            self.set_last_glyph(ch, position.x, position.y);
+            self.glyphs.push(TextGlyph { ch, bbox });
+        }
     }
 
     fn draw_image(&mut self, _image: Image<'a, '_>, _transform: Affine) {}
@@ -842,6 +855,14 @@ fn glyph_bbox(glyph: &Glyph<'_>, transform: Affine, glyph_transform: Affine) -> 
         x1: bbox.x1 as f32,
         y1: bbox.y1 as f32,
     })
+}
+
+fn bf_string_chars(value: BfString) -> impl Iterator<Item = char> {
+    match value {
+        BfString::Char(ch) => vec![ch],
+        BfString::String(text) => text.chars().collect(),
+    }
+    .into_iter()
 }
 
 fn calculate_doc_id(path: &Path, byte_len: usize) -> u64 {

--- a/src/backend/hayro.rs
+++ b/src/backend/hayro.rs
@@ -689,15 +689,15 @@ impl PlainTextExtractDevice {
         self.last_point = Some(Point::new(x, y));
     }
 
-    fn push_glyph_text(&mut self, text: &str, x: f64, y: f64) {
-        if self.is_duplicate_glyph(text, x, y) {
+    fn push_glyph_text(&mut self, text: String, x: f64, y: f64) {
+        if self.is_duplicate_glyph(&text, x, y) {
             return;
         }
 
-        self.set_last_glyph(text, x, y);
         for ch in text.chars() {
             self.push_char(ch, x, y);
         }
+        self.set_last_glyph(text, x, y);
     }
 
     fn is_duplicate_glyph(&self, text: &str, x: f64, y: f64) -> bool {
@@ -708,8 +708,8 @@ impl PlainTextExtractDevice {
             })
     }
 
-    fn set_last_glyph(&mut self, text: &str, x: f64, y: f64) {
-        self.last_glyph = Some((text.to_owned(), quantize_coord(x), quantize_coord(y)));
+    fn set_last_glyph(&mut self, text: String, x: f64, y: f64) {
+        self.last_glyph = Some((text, quantize_coord(x), quantize_coord(y)));
     }
 }
 
@@ -750,7 +750,7 @@ impl<'a> Device<'a> for PlainTextExtractDevice {
         };
 
         let position = (transform * glyph_transform) * Point::ORIGIN;
-        self.push_glyph_text(&bf_string_text(ch), position.x, position.y);
+        self.push_glyph_text(bf_string_text(ch), position.x, position.y);
     }
 
     fn draw_image(&mut self, _image: Image<'a, '_>, _transform: Affine) {}
@@ -792,14 +792,14 @@ impl PositionedTextExtractDevice {
         }
     }
 
-    fn push_glyph_text(&mut self, text: &str, bbox: Option<PdfRect>, x: f64, y: f64) {
-        if self.is_duplicate_glyph(text, x, y) {
+    fn push_glyph_text(&mut self, text: String, bbox: Option<PdfRect>, x: f64, y: f64) {
+        if self.is_duplicate_glyph(&text, x, y) {
             return;
         }
 
-        self.set_last_glyph(text, x, y);
         self.glyphs
             .extend(text.chars().map(|ch| TextGlyph { ch, bbox }));
+        self.set_last_glyph(text, x, y);
     }
 
     fn is_duplicate_glyph(&self, text: &str, x: f64, y: f64) -> bool {
@@ -810,8 +810,8 @@ impl PositionedTextExtractDevice {
             })
     }
 
-    fn set_last_glyph(&mut self, text: &str, x: f64, y: f64) {
-        self.last_glyph = Some((text.to_owned(), quantize_coord(x), quantize_coord(y)));
+    fn set_last_glyph(&mut self, text: String, x: f64, y: f64) {
+        self.last_glyph = Some((text, quantize_coord(x), quantize_coord(y)));
     }
 }
 
@@ -856,7 +856,7 @@ impl<'a> Device<'a> for PositionedTextExtractDevice {
         if bbox.is_none() {
             self.dropped_glyphs += 1;
         }
-        self.push_glyph_text(&bf_string_text(ch), bbox, position.x, position.y);
+        self.push_glyph_text(bf_string_text(ch), bbox, position.x, position.y);
     }
 
     fn draw_image(&mut self, _image: Image<'a, '_>, _transform: Affine) {}
@@ -1094,8 +1094,8 @@ mod tests {
     fn plain_text_duplicate_filter_preserves_repeated_chars_in_same_glyph_token() {
         let mut device = PlainTextExtractDevice::default();
 
-        device.push_glyph_text("ll", 10.0, 20.0);
-        device.push_glyph_text("ll", 10.0, 20.0);
+        device.push_glyph_text("ll".to_owned(), 10.0, 20.0);
+        device.push_glyph_text("ll".to_owned(), 10.0, 20.0);
 
         assert_eq!(device.finish(), "ll");
     }
@@ -1110,8 +1110,8 @@ mod tests {
             y1: 4.0,
         });
 
-        device.push_glyph_text("ff", bbox, 10.0, 20.0);
-        device.push_glyph_text("ff", bbox, 10.0, 20.0);
+        device.push_glyph_text("ff".to_owned(), bbox, 10.0, 20.0);
+        device.push_glyph_text("ff".to_owned(), bbox, 10.0, 20.0);
 
         let text: String = device.glyphs.iter().map(|glyph| glyph.ch).collect();
         assert_eq!(text, "ff");

--- a/src/backend/hayro.rs
+++ b/src/backend/hayro.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use std::collections::{HashMap, HashSet, hash_map::DefaultHasher};
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
@@ -25,7 +24,9 @@ use kurbo::{Affine, BezPath, Point, Shape};
 
 use crate::error::{AppError, AppResult};
 
-use super::traits::{OutlineNode, PdfBackend, PdfRect, RgbaFrame, TextGlyph, TextPage};
+use super::traits::{
+    OutlineNode, PdfBackend, PdfRect, PdfRenderContext, RgbaFrame, TextGlyph, TextPage,
+};
 
 pub struct PdfDoc {
     path: PathBuf,
@@ -35,63 +36,9 @@ pub struct PdfDoc {
 
 pub type HayroPdfBackend = PdfDoc;
 
-const MAX_DOC_RENDER_CACHES_PER_THREAD: usize = 8;
-
-thread_local! {
-    static THREAD_RENDER_CACHES: RefCell<ThreadRenderCaches> = RefCell::new(ThreadRenderCaches::default());
-}
-
-struct ThreadRenderCaches {
-    order: Vec<u64>,
-    by_doc: HashMap<u64, RenderCache>,
-    max_entries: usize,
-}
-
-impl Default for ThreadRenderCaches {
-    fn default() -> Self {
-        Self::with_capacity(MAX_DOC_RENDER_CACHES_PER_THREAD)
-    }
-}
-
-impl ThreadRenderCaches {
-    fn with_capacity(max_entries: usize) -> Self {
-        Self {
-            order: Vec::new(),
-            by_doc: HashMap::new(),
-            max_entries: max_entries.max(1),
-        }
-    }
-
-    fn get(&mut self, doc_id: u64) -> &RenderCache {
-        if self.by_doc.contains_key(&doc_id) {
-            self.touch(doc_id);
-        } else {
-            self.evict_if_full();
-            self.order.push(doc_id);
-            self.by_doc.insert(doc_id, RenderCache::new());
-        }
-
-        self.by_doc
-            .get(&doc_id)
-            .expect("render cache entry should exist")
-    }
-
-    fn touch(&mut self, doc_id: u64) {
-        if let Some(index) = self.order.iter().position(|id| *id == doc_id) {
-            self.order.remove(index);
-        }
-        self.order.push(doc_id);
-    }
-
-    fn evict_if_full(&mut self) {
-        if self.by_doc.len() < self.max_entries {
-            return;
-        }
-        if let Some(evicted_doc_id) = self.order.first().copied() {
-            self.order.remove(0);
-            self.by_doc.remove(&evicted_doc_id);
-        }
-    }
+pub struct HayroRenderContext<'a> {
+    doc: &'a PdfDoc,
+    render_cache: RenderCache<'a>,
 }
 
 impl PdfBackend for PdfDoc {
@@ -113,6 +60,13 @@ impl PdfBackend for PdfDoc {
 
     fn render_page(&self, page: usize, scale: f32) -> AppResult<RgbaFrame> {
         PdfDoc::render_page(self, page, scale)
+    }
+
+    fn render_context(&self) -> Box<dyn PdfRenderContext + '_> {
+        Box::new(HayroRenderContext {
+            doc: self,
+            render_cache: RenderCache::new(),
+        })
     }
 
     fn extract_text(&self, page: usize) -> AppResult<String> {
@@ -207,6 +161,16 @@ impl PdfDoc {
     }
 
     pub fn render_page(&self, page: usize, scale: f32) -> AppResult<RgbaFrame> {
+        let render_cache = RenderCache::new();
+        self.render_page_with_cache(page, scale, &render_cache)
+    }
+
+    fn render_page_with_cache<'a>(
+        &'a self,
+        page: usize,
+        scale: f32,
+        render_cache: &RenderCache<'a>,
+    ) -> AppResult<RgbaFrame> {
         if page >= self.page_count() {
             return Err(AppError::invalid_argument("page index is out of range"));
         }
@@ -229,9 +193,9 @@ impl PdfDoc {
             ..Default::default()
         };
         let interpreter_settings = InterpreterSettings::default();
-        let pixmap = render_with_thread_local_cache(
-            self.doc_id,
+        let pixmap = render(
             page_ref,
+            render_cache,
             &interpreter_settings,
             &render_settings,
         );
@@ -276,17 +240,11 @@ impl PdfDoc {
     }
 }
 
-fn render_with_thread_local_cache(
-    doc_id: u64,
-    page: &Page<'_>,
-    interpreter_settings: &InterpreterSettings,
-    render_settings: &RenderSettings,
-) -> Pixmap {
-    THREAD_RENDER_CACHES.with(|thread_caches| {
-        let mut thread_caches = thread_caches.borrow_mut();
-        let render_cache = thread_caches.get(doc_id);
-        render(page, render_cache, interpreter_settings, render_settings)
-    })
+impl PdfRenderContext for HayroRenderContext<'_> {
+    fn render_page(&mut self, page: usize, scale: f32) -> AppResult<RgbaFrame> {
+        self.doc
+            .render_page_with_cache(page, scale, &self.render_cache)
+    }
 }
 
 fn extract_outline_nodes(pdf: &Pdf) -> AppResult<Vec<OutlineNode>> {
@@ -964,38 +922,9 @@ mod tests {
 
     use crate::error::AppError;
 
-    use super::{
-        PdfDoc, ThreadRenderCaches, decode_pdf_text_string, pixel_buffer_from_pixmap,
-    };
+    use crate::backend::PdfBackend;
 
-    #[test]
-    fn thread_render_caches_evict_oldest_document_when_capacity_is_reached() {
-        let mut caches = ThreadRenderCaches::with_capacity(2);
-
-        let _ = caches.get(10);
-        let _ = caches.get(20);
-        let _ = caches.get(30);
-
-        assert_eq!(caches.by_doc.len(), 2);
-        assert!(!caches.by_doc.contains_key(&10));
-        assert!(caches.by_doc.contains_key(&20));
-        assert!(caches.by_doc.contains_key(&30));
-    }
-
-    #[test]
-    fn thread_render_caches_refresh_recency_on_access() {
-        let mut caches = ThreadRenderCaches::with_capacity(2);
-
-        let _ = caches.get(10);
-        let _ = caches.get(20);
-        let _ = caches.get(10);
-        let _ = caches.get(30);
-
-        assert_eq!(caches.by_doc.len(), 2);
-        assert!(caches.by_doc.contains_key(&10));
-        assert!(!caches.by_doc.contains_key(&20));
-        assert!(caches.by_doc.contains_key(&30));
-    }
+    use super::{PdfDoc, decode_pdf_text_string, pixel_buffer_from_pixmap};
 
     fn unique_temp_path(suffix: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -1113,6 +1042,32 @@ mod tests {
         assert_eq!(
             frame.pixels.len(),
             frame.width as usize * frame.height as usize * 4
+        );
+
+        fs::remove_file(&file).expect("test file should be removed");
+    }
+
+    #[test]
+    fn render_context_renders_multiple_pages_with_reused_cache() {
+        let file = unique_temp_path("render_context.pdf");
+        fs::write(&file, build_pdf(&["first", "second"])).expect("test file should be created");
+
+        let doc = PdfDoc::open(&file).expect("pdf should open");
+        let mut render_context = doc.render_context();
+        let first = render_context
+            .render_page(0, 1.0)
+            .expect("first page should render");
+        let second = render_context
+            .render_page(1, 1.0)
+            .expect("second page should render");
+
+        assert_eq!(
+            first.pixels.len(),
+            first.width as usize * first.height as usize * 4
+        );
+        assert_eq!(
+            second.pixels.len(),
+            second.width as usize * second.height as usize * 4
         );
 
         fs::remove_file(&file).expect("test file should be removed");

--- a/src/backend/hayro.rs
+++ b/src/backend/hayro.rs
@@ -659,7 +659,7 @@ fn extract_text_with_device(page: &Page<'_>) -> String {
 struct PlainTextExtractDevice {
     text: String,
     last_point: Option<Point>,
-    last_glyph: Option<(char, i32, i32)>,
+    last_glyph: Option<(String, i32, i32)>,
 }
 
 impl PlainTextExtractDevice {
@@ -689,12 +689,27 @@ impl PlainTextExtractDevice {
         self.last_point = Some(Point::new(x, y));
     }
 
-    fn is_duplicate_glyph(&self, ch: char, x: f64, y: f64) -> bool {
-        self.last_glyph == Some((ch, quantize_coord(x), quantize_coord(y)))
+    fn push_glyph_text(&mut self, text: &str, x: f64, y: f64) {
+        if self.is_duplicate_glyph(text, x, y) {
+            return;
+        }
+
+        self.set_last_glyph(text, x, y);
+        for ch in text.chars() {
+            self.push_char(ch, x, y);
+        }
     }
 
-    fn set_last_glyph(&mut self, ch: char, x: f64, y: f64) {
-        self.last_glyph = Some((ch, quantize_coord(x), quantize_coord(y)));
+    fn is_duplicate_glyph(&self, text: &str, x: f64, y: f64) -> bool {
+        self.last_glyph
+            .as_ref()
+            .is_some_and(|(last, last_x, last_y)| {
+                last == text && *last_x == quantize_coord(x) && *last_y == quantize_coord(y)
+            })
+    }
+
+    fn set_last_glyph(&mut self, text: &str, x: f64, y: f64) {
+        self.last_glyph = Some((text.to_owned(), quantize_coord(x), quantize_coord(y)));
     }
 }
 
@@ -735,14 +750,7 @@ impl<'a> Device<'a> for PlainTextExtractDevice {
         };
 
         let position = (transform * glyph_transform) * Point::ORIGIN;
-        for ch in bf_string_chars(ch) {
-            if self.is_duplicate_glyph(ch, position.x, position.y) {
-                continue;
-            }
-
-            self.set_last_glyph(ch, position.x, position.y);
-            self.push_char(ch, position.x, position.y);
-        }
+        self.push_glyph_text(&bf_string_text(ch), position.x, position.y);
     }
 
     fn draw_image(&mut self, _image: Image<'a, '_>, _transform: Affine) {}
@@ -769,7 +777,7 @@ fn extract_positioned_text_with_device(page: &Page<'_>) -> TextPage {
 
 #[derive(Default)]
 struct PositionedTextExtractDevice {
-    last_glyph: Option<(char, i32, i32)>,
+    last_glyph: Option<(String, i32, i32)>,
     glyphs: Vec<TextGlyph>,
     dropped_glyphs: usize,
 }
@@ -784,12 +792,26 @@ impl PositionedTextExtractDevice {
         }
     }
 
-    fn is_duplicate_glyph(&self, ch: char, x: f64, y: f64) -> bool {
-        self.last_glyph == Some((ch, quantize_coord(x), quantize_coord(y)))
+    fn push_glyph_text(&mut self, text: &str, bbox: Option<PdfRect>, x: f64, y: f64) {
+        if self.is_duplicate_glyph(text, x, y) {
+            return;
+        }
+
+        self.set_last_glyph(text, x, y);
+        self.glyphs
+            .extend(text.chars().map(|ch| TextGlyph { ch, bbox }));
     }
 
-    fn set_last_glyph(&mut self, ch: char, x: f64, y: f64) {
-        self.last_glyph = Some((ch, quantize_coord(x), quantize_coord(y)));
+    fn is_duplicate_glyph(&self, text: &str, x: f64, y: f64) -> bool {
+        self.last_glyph
+            .as_ref()
+            .is_some_and(|(last, last_x, last_y)| {
+                last == text && *last_x == quantize_coord(x) && *last_y == quantize_coord(y)
+            })
+    }
+
+    fn set_last_glyph(&mut self, text: &str, x: f64, y: f64) {
+        self.last_glyph = Some((text.to_owned(), quantize_coord(x), quantize_coord(y)));
     }
 }
 
@@ -834,14 +856,7 @@ impl<'a> Device<'a> for PositionedTextExtractDevice {
         if bbox.is_none() {
             self.dropped_glyphs += 1;
         }
-        for ch in bf_string_chars(ch) {
-            if self.is_duplicate_glyph(ch, position.x, position.y) {
-                continue;
-            }
-
-            self.set_last_glyph(ch, position.x, position.y);
-            self.glyphs.push(TextGlyph { ch, bbox });
-        }
+        self.push_glyph_text(&bf_string_text(ch), bbox, position.x, position.y);
     }
 
     fn draw_image(&mut self, _image: Image<'a, '_>, _transform: Affine) {}
@@ -887,12 +902,11 @@ fn glyph_bbox(glyph: &Glyph<'_>, transform: Affine, glyph_transform: Affine) -> 
     })
 }
 
-fn bf_string_chars(value: BfString) -> impl Iterator<Item = char> {
+fn bf_string_text(value: BfString) -> String {
     match value {
-        BfString::Char(ch) => vec![ch],
-        BfString::String(text) => text.chars().collect(),
+        BfString::Char(ch) => ch.to_string(),
+        BfString::String(text) => text,
     }
-    .into_iter()
 }
 
 fn calculate_doc_id(path: &Path, byte_len: usize) -> u64 {
@@ -922,9 +936,12 @@ mod tests {
 
     use crate::error::AppError;
 
-    use crate::backend::PdfBackend;
+    use crate::backend::{PdfBackend, PdfRect};
 
-    use super::{PdfDoc, decode_pdf_text_string, pixel_buffer_from_pixmap};
+    use super::{
+        PdfDoc, PlainTextExtractDevice, PositionedTextExtractDevice, decode_pdf_text_string,
+        pixel_buffer_from_pixmap,
+    };
 
     fn unique_temp_path(suffix: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -1071,6 +1088,34 @@ mod tests {
         );
 
         fs::remove_file(&file).expect("test file should be removed");
+    }
+
+    #[test]
+    fn plain_text_duplicate_filter_preserves_repeated_chars_in_same_glyph_token() {
+        let mut device = PlainTextExtractDevice::default();
+
+        device.push_glyph_text("ll", 10.0, 20.0);
+        device.push_glyph_text("ll", 10.0, 20.0);
+
+        assert_eq!(device.finish(), "ll");
+    }
+
+    #[test]
+    fn positioned_text_duplicate_filter_preserves_repeated_chars_in_same_glyph_token() {
+        let mut device = PositionedTextExtractDevice::default();
+        let bbox = Some(PdfRect {
+            x0: 1.0,
+            y0: 2.0,
+            x1: 3.0,
+            y1: 4.0,
+        });
+
+        device.push_glyph_text("ff", bbox, 10.0, 20.0);
+        device.push_glyph_text("ff", bbox, 10.0, 20.0);
+
+        let text: String = device.glyphs.iter().map(|glyph| glyph.ch).collect();
+        assert_eq!(text, "ff");
+        assert_eq!(device.glyphs.len(), 2);
     }
 
     #[test]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -8,7 +8,8 @@ mod traits;
 
 pub use hayro::{HayroPdfBackend, PdfDoc};
 pub use traits::{
-    OutlineNode, PdfBackend, PdfRect, PixelBuffer, PixelBufferPool, RgbaFrame, TextGlyph, TextPage,
+    OutlineNode, PdfBackend, PdfRect, PdfRenderContext, PixelBuffer, PixelBufferPool, RgbaFrame,
+    TextGlyph, TextPage,
 };
 
 pub type SharedPdfBackend = Arc<dyn PdfBackend>;

--- a/src/backend/traits.rs
+++ b/src/backend/traits.rs
@@ -241,9 +241,26 @@ pub trait PdfBackend: Send + Sync {
     fn page_count(&self) -> usize;
     fn page_dimensions(&self, page: usize) -> AppResult<(f32, f32)>;
     fn render_page(&self, page: usize, scale: f32) -> AppResult<RgbaFrame>;
+    fn render_context(&self) -> Box<dyn PdfRenderContext + '_> {
+        Box::new(DefaultPdfRenderContext { backend: self })
+    }
     fn extract_text(&self, page: usize) -> AppResult<String>;
     fn extract_positioned_text(&self, page: usize) -> AppResult<TextPage>;
     fn extract_outline(&self) -> AppResult<Vec<OutlineNode>>;
+}
+
+pub trait PdfRenderContext {
+    fn render_page(&mut self, page: usize, scale: f32) -> AppResult<RgbaFrame>;
+}
+
+struct DefaultPdfRenderContext<'a, T: PdfBackend + ?Sized> {
+    backend: &'a T,
+}
+
+impl<T: PdfBackend + ?Sized> PdfRenderContext for DefaultPdfRenderContext<'_, T> {
+    fn render_page(&mut self, page: usize, scale: f32) -> AppResult<RgbaFrame> {
+        self.backend.render_page(page, scale)
+    }
 }
 
 #[cfg(test)]

--- a/src/render/worker.rs
+++ b/src/render/worker.rs
@@ -296,6 +296,8 @@ fn render_worker_main(
     request_rx: Receiver<RenderWorkerRequest>,
     result_tx: UnboundedSender<RenderResultEvent>,
 ) {
+    let mut render_context = doc.render_context();
+
     loop {
         let request = request_rx.recv();
         let request = match request {
@@ -316,7 +318,8 @@ fn render_worker_main(
                         "render task does not match active document",
                     ))
                 } else {
-                    doc.render_page(task.page, task.scale)
+                    render_context
+                        .render_page(task.page, task.scale)
                         .map_err(|err| AppError::pdf_render(task.page, err))
                 };
 


### PR DESCRIPTION
## Summary
- update hayro to 0.6
- keep hayro RenderCache in a backend render context owned by each render worker
- document the backend-internal render context in the rendering pipeline spec

## Rationale
hayro 0.6 exposes RenderCache with document-scoped font/object/outline caching but it is not suitable for sharing through the Send + Sync PdfBackend object. A worker-local render context keeps the cache reusable across render tasks without crossing thread boundaries.

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- bench comparison vs main: text fixture wall time improved about 16%, high-res fixture wall time improved about 6%

close #78 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-worker render contexts for more efficient multi-page rendering

* **Bug Fixes**
  * Better text extraction for multi-character glyphs and improved duplicate filtering
  * Fixed destination/title decoding and name-tree handling

* **Documentation**
  * Rendering pipeline notes updated to document per-worker render contexts

* **Chores**
  * Bumped dependencies: hayro 0.5.0→0.6.0, kurbo 0.12.0→0.13.0

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shiguri-01/preview-pdf/pull/79)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->