### PR TITLE
test(backend): extract shared PDF fixture support

### DIFF
--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -908,11 +908,9 @@ mod tests {
     use std::fs;
     use std::future::Future;
     use std::io;
-    use std::path::PathBuf;
     use std::pin::Pin;
-    use std::process;
     use std::sync::Arc;
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::time::Duration;
 
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
     use ratatui::layout::Size;
@@ -924,6 +922,7 @@ mod tests {
     use crate::app::core::InteractionSubsystem;
     use crate::app::state::{PageLayoutMode, VisiblePageSlots};
     use crate::app::terminal_session::TerminalSurface;
+    use crate::backend::test_support::{build_pdf, unique_temp_path};
     use crate::backend::{PdfDoc, SharedPdfBackend};
     use crate::command::{
         Command, CommandInvocationSource, CommandRequest, PanAmount, PanDirection,
@@ -1031,77 +1030,6 @@ mod tests {
         fn restore(&mut self) -> io::Result<()> {
             Ok(())
         }
-    }
-
-    fn unique_temp_path(suffix: &str) -> PathBuf {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system time should be after unix epoch")
-            .as_nanos();
-        std::env::temp_dir().join(format!("pvf-event-loop-{}-{nanos}{suffix}", process::id()))
-    }
-
-    fn build_pdf(page_texts: &[&str]) -> Vec<u8> {
-        let page_texts = if page_texts.is_empty() {
-            vec!["".to_string()]
-        } else {
-            page_texts
-                .iter()
-                .map(|text| format!("BT /F1 14 Tf 36 260 Td ({text}) Tj ET"))
-                .collect()
-        };
-
-        let page_count = page_texts.len();
-        let page_ids: Vec<usize> = (0..page_count).map(|i| 4 + i * 2).collect();
-
-        let mut objects = Vec::new();
-        objects.push("<< /Type /Catalog /Pages 2 0 R >>".to_string());
-        let kids = page_ids
-            .iter()
-            .map(|id| format!("{id} 0 R"))
-            .collect::<Vec<_>>()
-            .join(" ");
-        objects.push(format!(
-            "<< /Type /Pages /Kids [{kids}] /Count {page_count} >>"
-        ));
-        objects.push("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string());
-
-        for (index, stream) in page_texts.iter().enumerate() {
-            let content_id = 5 + index * 2;
-            objects.push(format!(
-                "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Resources << /Font << /F1 3 0 R >> >> /Contents {content_id} 0 R >>"
-            ));
-            objects.push(format!(
-                "<< /Length {} >>\nstream\n{}\nendstream",
-                stream.len(),
-                stream
-            ));
-        }
-
-        let mut bytes = Vec::new();
-        bytes.extend_from_slice(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
-        let mut offsets = vec![0_usize];
-        for (index, object) in objects.iter().enumerate() {
-            let object_id = index + 1;
-            offsets.push(bytes.len());
-            bytes.extend_from_slice(format!("{object_id} 0 obj\n{object}\nendobj\n").as_bytes());
-        }
-
-        let xref_start = bytes.len();
-        bytes.extend_from_slice(format!("xref\n0 {}\n", objects.len() + 1).as_bytes());
-        bytes.extend_from_slice(b"0000000000 65535 f \n");
-        for offset in offsets.iter().skip(1) {
-            bytes.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
-        }
-        bytes.extend_from_slice(
-            format!(
-                "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
-                objects.len() + 1,
-                xref_start
-            )
-            .as_bytes(),
-        );
-        bytes
     }
 
     fn idle_render_worker() -> RenderWorker {

--- a/src/app/input_ops.rs
+++ b/src/app/input_ops.rs
@@ -399,16 +399,15 @@ impl InteractionSubsystem {
 mod tests {
     use std::fs;
     use std::io;
-    use std::path::PathBuf;
     use std::sync::Arc;
     use std::time::Duration;
-    use std::time::{SystemTime, UNIX_EPOCH};
 
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ratatui::layout::Size;
 
     use crate::app::terminal_session::TerminalSurface;
     use crate::app::{AppState, Mode, PaletteRequest};
+    use crate::backend::test_support::{build_pdf, unique_temp_path};
     use crate::backend::{PdfDoc, SharedPdfBackend};
     use crate::command::{Command, CommandInvocationSource, CommandRequest};
     use crate::config::Config;
@@ -450,77 +449,6 @@ mod tests {
         {
             Ok(())
         }
-    }
-
-    fn unique_temp_path(suffix: &str) -> PathBuf {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system time should be after unix epoch")
-            .as_nanos();
-        std::env::temp_dir().join(format!("pvf-input-ops-{nanos}{suffix}"))
-    }
-
-    fn build_pdf(page_texts: &[&str]) -> Vec<u8> {
-        let page_texts = if page_texts.is_empty() {
-            vec!["".to_string()]
-        } else {
-            page_texts
-                .iter()
-                .map(|text| format!("BT /F1 14 Tf 36 260 Td ({text}) Tj ET"))
-                .collect()
-        };
-
-        let page_count = page_texts.len();
-        let page_ids: Vec<usize> = (0..page_count).map(|i| 4 + i * 2).collect();
-
-        let mut objects = Vec::new();
-        objects.push("<< /Type /Catalog /Pages 2 0 R >>".to_string());
-        let kids = page_ids
-            .iter()
-            .map(|id| format!("{id} 0 R"))
-            .collect::<Vec<_>>()
-            .join(" ");
-        objects.push(format!(
-            "<< /Type /Pages /Kids [{kids}] /Count {page_count} >>"
-        ));
-        objects.push("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string());
-
-        for (index, stream) in page_texts.iter().enumerate() {
-            let content_id = 5 + index * 2;
-            objects.push(format!(
-                "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Resources << /Font << /F1 3 0 R >> >> /Contents {content_id} 0 R >>"
-            ));
-            objects.push(format!(
-                "<< /Length {} >>\nstream\n{}\nendstream",
-                stream.len(),
-                stream
-            ));
-        }
-
-        let mut bytes = Vec::new();
-        bytes.extend_from_slice(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
-        let mut offsets = vec![0_usize];
-        for (index, object) in objects.iter().enumerate() {
-            let object_id = index + 1;
-            offsets.push(bytes.len());
-            bytes.extend_from_slice(format!("{object_id} 0 obj\n{object}\nendobj\n").as_bytes());
-        }
-
-        let xref_start = bytes.len();
-        bytes.extend_from_slice(format!("xref\n0 {}\n", objects.len() + 1).as_bytes());
-        bytes.extend_from_slice(b"0000000000 65535 f \n");
-        for offset in offsets.iter().skip(1) {
-            bytes.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
-        }
-        bytes.extend_from_slice(
-            format!(
-                "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
-                objects.len() + 1,
-                xref_start
-            )
-            .as_bytes(),
-        );
-        bytes
     }
 
     fn test_pdf_backend() -> SharedPdfBackend {

--- a/src/app/tests/runtime_worker.rs
+++ b/src/app/tests/runtime_worker.rs
@@ -1,15 +1,14 @@
 use std::fs;
-use std::path::PathBuf;
-use std::process;
 use std::sync::Arc;
 use std::thread;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
 use ratatui::layout::Rect;
 
 use super::super::runtime::RenderRuntime;
+use crate::backend::test_support::{build_pdf, unique_temp_path};
 use crate::backend::{OutlineNode, PdfBackend, PdfDoc, PdfRect, RgbaFrame, SharedPdfBackend};
 use crate::error::{AppError, AppResult};
 use crate::highlight::{HighlightOverlaySnapshot, HighlightSource, HighlightSpan, HighlightStyle};
@@ -464,104 +463,4 @@ fn drain_render_results(worker: &mut RenderWorker) -> Vec<RenderedPageKey> {
         }
     }
     completed
-}
-
-fn unique_temp_path(suffix: &str) -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("clock should be after unix epoch")
-        .as_nanos();
-
-    let mut path = std::env::temp_dir();
-    path.push(format!("pvf_{suffix}_{}_{}", process::id(), nanos));
-    path
-}
-
-fn build_pdf(page_texts: &[&str]) -> Vec<u8> {
-    let page_texts = if page_texts.is_empty() {
-        vec![""]
-    } else {
-        page_texts.to_vec()
-    };
-
-    let page_count = page_texts.len();
-    let page_ids: Vec<usize> = (0..page_count).map(|i| 4 + i * 2).collect();
-
-    let mut objects = Vec::new();
-    objects.push("<< /Type /Catalog /Pages 2 0 R >>".to_string());
-
-    let kids = page_ids
-        .iter()
-        .map(|id| format!("{id} 0 R"))
-        .collect::<Vec<_>>()
-        .join(" ");
-    objects.push(format!(
-        "<< /Type /Pages /Kids [{kids}] /Count {page_count} >>"
-    ));
-    objects.push("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string());
-
-    for (index, text) in page_texts.iter().enumerate() {
-        let content_id = 5 + index * 2;
-        let escaped = escape_literal_string(text);
-        let stream = format!("BT /F1 14 Tf 36 260 Td ({escaped}) Tj ET");
-
-        let page_obj = format!(
-            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Resources << /Font << /F1 3 0 R >> >> /Contents {content_id} 0 R >>"
-        );
-        let content_obj = format!(
-            "<< /Length {} >>\nstream\n{}\nendstream",
-            stream.len(),
-            stream
-        );
-
-        objects.push(page_obj);
-        objects.push(content_obj);
-    }
-
-    let mut bytes = Vec::new();
-    bytes.extend_from_slice(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
-
-    let mut offsets = Vec::new();
-    offsets.push(0_usize);
-    for (index, object) in objects.iter().enumerate() {
-        let object_id = index + 1;
-        offsets.push(bytes.len());
-        bytes.extend_from_slice(format!("{object_id} 0 obj\n{object}\nendobj\n").as_bytes());
-    }
-
-    let xref_start = bytes.len();
-    bytes.extend_from_slice(format!("xref\n0 {}\n", objects.len() + 1).as_bytes());
-    bytes.extend_from_slice(b"0000000000 65535 f \n");
-    for offset in offsets.iter().skip(1) {
-        bytes.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
-    }
-
-    bytes.extend_from_slice(
-        format!(
-            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
-            objects.len() + 1,
-            xref_start
-        )
-        .as_bytes(),
-    );
-
-    bytes
-}
-
-fn escape_literal_string(text: &str) -> String {
-    let mut out = String::with_capacity(text.len());
-
-    for ch in text.chars() {
-        match ch {
-            '\\' => out.push_str("\\\\"),
-            '(' => out.push_str("\\("),
-            ')' => out.push_str("\\)"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            _ => out.push(ch),
-        }
-    }
-
-    out
 }

--- a/src/backend/hayro.rs
+++ b/src/backend/hayro.rs
@@ -928,12 +928,12 @@ fn pixel_buffer_from_pixmap(pixmap: Pixmap) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use std::fs;
-    use std::path::PathBuf;
-    use std::process;
-    use std::time::{SystemTime, UNIX_EPOCH};
 
     use hayro::vello_cpu::Pixmap;
 
+    use crate::backend::test_support::{
+        build_pdf, build_pdf_from_objects, build_pdf_with_raw_streams, unique_temp_path,
+    };
     use crate::error::AppError;
 
     use crate::backend::{PdfBackend, PdfRect};
@@ -942,17 +942,6 @@ mod tests {
         PdfDoc, PlainTextExtractDevice, PositionedTextExtractDevice, decode_pdf_text_string,
         pixel_buffer_from_pixmap,
     };
-
-    fn unique_temp_path(suffix: &str) -> PathBuf {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock should be after unix epoch")
-            .as_nanos();
-
-        let mut path = std::env::temp_dir();
-        path.push(format!("pvf_{suffix}_{}_{}", process::id(), nanos));
-        path
-    }
 
     #[test]
     fn open_rejects_directory_path() {
@@ -1206,98 +1195,6 @@ mod tests {
         fs::remove_file(&file).expect("test file should be removed");
     }
 
-    fn build_pdf(page_texts: &[&str]) -> Vec<u8> {
-        let page_texts = if page_texts.is_empty() {
-            vec!["".to_string()]
-        } else {
-            page_texts
-                .iter()
-                .map(|text| {
-                    let escaped = escape_literal_string(text);
-                    format!("BT /F1 14 Tf 36 260 Td ({escaped}) Tj ET")
-                })
-                .collect()
-        };
-
-        build_pdf_from_streams(&page_texts)
-    }
-
-    fn build_pdf_with_raw_streams(page_streams: &[&str]) -> Vec<u8> {
-        let page_streams = if page_streams.is_empty() {
-            vec!["".to_string()]
-        } else {
-            page_streams
-                .iter()
-                .map(|stream| (*stream).to_string())
-                .collect()
-        };
-
-        build_pdf_from_streams(&page_streams)
-    }
-
-    fn build_pdf_from_streams(page_streams: &[String]) -> Vec<u8> {
-        let page_count = page_streams.len();
-        let page_ids: Vec<usize> = (0..page_count).map(|i| 4 + i * 2).collect();
-
-        let mut objects = Vec::new();
-        objects.push("<< /Type /Catalog /Pages 2 0 R >>".to_string());
-
-        let kids = page_ids
-            .iter()
-            .map(|id| format!("{id} 0 R"))
-            .collect::<Vec<_>>()
-            .join(" ");
-        objects.push(format!(
-            "<< /Type /Pages /Kids [{kids}] /Count {page_count} >>"
-        ));
-        objects.push("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string());
-
-        for (index, stream) in page_streams.iter().enumerate() {
-            let content_id = 5 + index * 2;
-
-            let page_obj = format!(
-                "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Resources << /Font << /F1 3 0 R >> >> /Contents {content_id} 0 R >>"
-            );
-            let content_obj = format!(
-                "<< /Length {} >>\nstream\n{}\nendstream",
-                stream.len(),
-                stream
-            );
-
-            objects.push(page_obj);
-            objects.push(content_obj);
-        }
-
-        let mut bytes = Vec::new();
-        bytes.extend_from_slice(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
-
-        let mut offsets = Vec::new();
-        offsets.push(0_usize);
-        for (index, object) in objects.iter().enumerate() {
-            let object_id = index + 1;
-            offsets.push(bytes.len());
-            bytes.extend_from_slice(format!("{object_id} 0 obj\n{object}\nendobj\n").as_bytes());
-        }
-
-        let xref_start = bytes.len();
-        bytes.extend_from_slice(format!("xref\n0 {}\n", objects.len() + 1).as_bytes());
-        bytes.extend_from_slice(b"0000000000 65535 f \n");
-        for offset in offsets.iter().skip(1) {
-            bytes.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
-        }
-
-        bytes.extend_from_slice(
-            format!(
-                "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
-                objects.len() + 1,
-                xref_start
-            )
-            .as_bytes(),
-        );
-
-        bytes
-    }
-
     fn build_pdf_with_named_outline() -> Vec<u8> {
         let objects = vec![
             "<< /Type /Catalog /Pages 2 0 R /Outlines 4 0 R /Names << /Dests 7 0 R >> >>"
@@ -1345,54 +1242,5 @@ mod tests {
         ];
 
         build_pdf_from_objects(&objects)
-    }
-
-    fn build_pdf_from_objects(objects: &[String]) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        bytes.extend_from_slice(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
-
-        let mut offsets = Vec::new();
-        offsets.push(0_usize);
-        for (index, object) in objects.iter().enumerate() {
-            let object_id = index + 1;
-            offsets.push(bytes.len());
-            bytes.extend_from_slice(format!("{object_id} 0 obj\n{object}\nendobj\n").as_bytes());
-        }
-
-        let xref_start = bytes.len();
-        bytes.extend_from_slice(format!("xref\n0 {}\n", objects.len() + 1).as_bytes());
-        bytes.extend_from_slice(b"0000000000 65535 f \n");
-        for offset in offsets.iter().skip(1) {
-            bytes.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
-        }
-
-        bytes.extend_from_slice(
-            format!(
-                "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
-                objects.len() + 1,
-                xref_start
-            )
-            .as_bytes(),
-        );
-
-        bytes
-    }
-
-    fn escape_literal_string(text: &str) -> String {
-        let mut out = String::with_capacity(text.len());
-
-        for ch in text.chars() {
-            match ch {
-                '\\' => out.push_str("\\\\"),
-                '(' => out.push_str("\\("),
-                ')' => out.push_str("\\)"),
-                '\n' => out.push_str("\\n"),
-                '\r' => out.push_str("\\r"),
-                '\t' => out.push_str("\\t"),
-                _ => out.push(ch),
-            }
-        }
-
-        out
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 use crate::error::AppResult;
 
 mod hayro;
+#[cfg(test)]
+pub(crate) mod test_support;
 mod traits;
 
 pub use hayro::{HayroPdfBackend, PdfDoc};

--- a/src/backend/test_support.rs
+++ b/src/backend/test_support.rs
@@ -1,0 +1,129 @@
+use std::path::PathBuf;
+use std::process;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub(crate) fn unique_temp_path(suffix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after unix epoch")
+        .as_nanos();
+
+    let mut path = std::env::temp_dir();
+    std::fs::create_dir_all(&path).expect("test temp directory should be created");
+    path.push(format!("pvf_{suffix}_{}_{}", process::id(), nanos));
+    path
+}
+
+pub(crate) fn build_pdf(page_texts: &[&str]) -> Vec<u8> {
+    let page_texts = if page_texts.is_empty() {
+        vec!["".to_string()]
+    } else {
+        page_texts
+            .iter()
+            .map(|text| {
+                let escaped = escape_literal_string(text);
+                format!("BT /F1 14 Tf 36 260 Td ({escaped}) Tj ET")
+            })
+            .collect()
+    };
+
+    build_pdf_from_streams(&page_texts)
+}
+
+pub(crate) fn build_pdf_with_raw_streams(page_streams: &[&str]) -> Vec<u8> {
+    let page_streams = if page_streams.is_empty() {
+        vec!["".to_string()]
+    } else {
+        page_streams
+            .iter()
+            .map(|stream| (*stream).to_string())
+            .collect()
+    };
+
+    build_pdf_from_streams(&page_streams)
+}
+
+fn build_pdf_from_streams(page_streams: &[String]) -> Vec<u8> {
+    let page_count = page_streams.len();
+    let page_ids: Vec<usize> = (0..page_count).map(|i| 4 + i * 2).collect();
+
+    let mut objects = Vec::new();
+    objects.push("<< /Type /Catalog /Pages 2 0 R >>".to_string());
+
+    let kids = page_ids
+        .iter()
+        .map(|id| format!("{id} 0 R"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    objects.push(format!(
+        "<< /Type /Pages /Kids [{kids}] /Count {page_count} >>"
+    ));
+    objects.push("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string());
+
+    for (index, stream) in page_streams.iter().enumerate() {
+        let content_id = 5 + index * 2;
+
+        let page_obj = format!(
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Resources << /Font << /F1 3 0 R >> >> /Contents {content_id} 0 R >>"
+        );
+        let content_obj = format!(
+            "<< /Length {} >>\nstream\n{}\nendstream",
+            stream.len(),
+            stream
+        );
+
+        objects.push(page_obj);
+        objects.push(content_obj);
+    }
+
+    build_pdf_from_objects(&objects)
+}
+
+pub(crate) fn build_pdf_from_objects(objects: &[String]) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
+
+    let mut offsets = Vec::new();
+    offsets.push(0_usize);
+    for (index, object) in objects.iter().enumerate() {
+        let object_id = index + 1;
+        offsets.push(bytes.len());
+        bytes.extend_from_slice(format!("{object_id} 0 obj\n{object}\nendobj\n").as_bytes());
+    }
+
+    let xref_start = bytes.len();
+    bytes.extend_from_slice(format!("xref\n0 {}\n", objects.len() + 1).as_bytes());
+    bytes.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in offsets.iter().skip(1) {
+        bytes.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+
+    bytes.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            objects.len() + 1,
+            xref_start
+        )
+        .as_bytes(),
+    );
+
+    bytes
+}
+
+fn escape_literal_string(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+
+    for ch in text.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '(' => out.push_str("\\("),
+            ')' => out.push_str("\\)"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(ch),
+        }
+    }
+
+    out
+}

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -868,15 +868,15 @@ fn percentile(sorted: &[f64], percentile: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use std::fs;
-    use std::process;
     use std::str::FromStr;
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::time::Duration;
 
     use super::{
         PerfIterationSnapshot, PerfScenarioId, PerfStats, PerfSuiteConfig, RedrawReason,
         build_aggregate_report, merge_stats, run_suite, summarize_metric, summarize_scalar,
         validate_suite_config,
     };
+    use crate::backend::test_support::{build_pdf, unique_temp_path};
 
     #[test]
     fn records_milliseconds_and_clamped_rates() {
@@ -1212,76 +1212,5 @@ mod tests {
             .find(|scenario| scenario.id == PerfScenarioId::IdleSettledRedraw)
             .expect("idle scenario should be reported");
         assert_eq!(idle.parameters.idle_duration_ms, 1);
-    }
-
-    fn unique_temp_path(suffix: &str) -> std::path::PathBuf {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system time should be after unix epoch")
-            .as_nanos();
-        std::env::temp_dir().join(format!("pvf-perf-{}-{nanos}{suffix}", process::id()))
-    }
-
-    fn build_pdf(page_texts: &[&str]) -> Vec<u8> {
-        let page_texts = if page_texts.is_empty() {
-            vec!["".to_string()]
-        } else {
-            page_texts
-                .iter()
-                .map(|text| format!("BT /F1 14 Tf 36 260 Td ({text}) Tj ET"))
-                .collect()
-        };
-
-        let page_count = page_texts.len();
-        let page_ids: Vec<usize> = (0..page_count).map(|i| 4 + i * 2).collect();
-
-        let mut objects = Vec::new();
-        objects.push("<< /Type /Catalog /Pages 2 0 R >>".to_string());
-        let kids = page_ids
-            .iter()
-            .map(|id| format!("{id} 0 R"))
-            .collect::<Vec<_>>()
-            .join(" ");
-        objects.push(format!(
-            "<< /Type /Pages /Kids [{kids}] /Count {page_count} >>"
-        ));
-        objects.push("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string());
-
-        for (index, stream) in page_texts.iter().enumerate() {
-            let content_id = 5 + index * 2;
-            objects.push(format!(
-                "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Resources << /Font << /F1 3 0 R >> >> /Contents {content_id} 0 R >>"
-            ));
-            objects.push(format!(
-                "<< /Length {} >>\nstream\n{}\nendstream",
-                stream.len(),
-                stream
-            ));
-        }
-
-        let mut bytes = Vec::new();
-        bytes.extend_from_slice(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
-        let mut offsets = vec![0_usize];
-        for (index, object) in objects.iter().enumerate() {
-            let object_id = index + 1;
-            offsets.push(bytes.len());
-            bytes.extend_from_slice(format!("{object_id} 0 obj\n{object}\nendobj\n").as_bytes());
-        }
-
-        let xref_start = bytes.len();
-        bytes.extend_from_slice(format!("xref\n0 {}\n", objects.len() + 1).as_bytes());
-        bytes.extend_from_slice(b"0000000000 65535 f \n");
-        for offset in offsets.iter().skip(1) {
-            bytes.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
-        }
-        bytes.extend_from_slice(
-            format!(
-                "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
-                objects.len() + 1,
-                xref_start
-            )
-            .as_bytes(),
-        );
-        bytes
     }
 }

--- a/src/render/worker.rs
+++ b/src/render/worker.rs
@@ -343,13 +343,12 @@ fn render_worker_main(
 #[cfg(test)]
 mod tests {
     use std::fs;
-    use std::path::PathBuf;
-    use std::process;
     use std::sync::Arc;
     use std::thread;
-    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, Instant};
 
     use super::RenderWorker;
+    use crate::backend::test_support::{build_pdf, unique_temp_path};
     use crate::backend::{PdfBackend, PdfDoc, SharedPdfBackend};
     use crate::render::cache::RenderedPageKey;
     use crate::render::scheduler::RenderTask;
@@ -476,105 +475,5 @@ mod tests {
             }
         }
         completed
-    }
-
-    fn unique_temp_path(suffix: &str) -> PathBuf {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock should be after unix epoch")
-            .as_nanos();
-
-        let mut path = std::env::temp_dir();
-        path.push(format!("pvf_{suffix}_{}_{}", process::id(), nanos));
-        path
-    }
-
-    fn build_pdf(page_texts: &[&str]) -> Vec<u8> {
-        let page_texts = if page_texts.is_empty() {
-            vec![""]
-        } else {
-            page_texts.to_vec()
-        };
-
-        let page_count = page_texts.len();
-        let page_ids: Vec<usize> = (0..page_count).map(|i| 4 + i * 2).collect();
-
-        let mut objects = Vec::new();
-        objects.push("<< /Type /Catalog /Pages 2 0 R >>".to_string());
-
-        let kids = page_ids
-            .iter()
-            .map(|id| format!("{id} 0 R"))
-            .collect::<Vec<_>>()
-            .join(" ");
-        objects.push(format!(
-            "<< /Type /Pages /Kids [{kids}] /Count {page_count} >>"
-        ));
-        objects.push("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string());
-
-        for (index, text) in page_texts.iter().enumerate() {
-            let content_id = 5 + index * 2;
-            let escaped = escape_literal_string(text);
-            let stream = format!("BT /F1 14 Tf 36 260 Td ({escaped}) Tj ET");
-
-            let page_obj = format!(
-                "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Resources << /Font << /F1 3 0 R >> >> /Contents {content_id} 0 R >>"
-            );
-            let content_obj = format!(
-                "<< /Length {} >>\nstream\n{}\nendstream",
-                stream.len(),
-                stream
-            );
-
-            objects.push(page_obj);
-            objects.push(content_obj);
-        }
-
-        let mut bytes = Vec::new();
-        bytes.extend_from_slice(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
-
-        let mut offsets = Vec::new();
-        offsets.push(0_usize);
-        for (index, object) in objects.iter().enumerate() {
-            let object_id = index + 1;
-            offsets.push(bytes.len());
-            bytes.extend_from_slice(format!("{object_id} 0 obj\n{object}\nendobj\n").as_bytes());
-        }
-
-        let xref_start = bytes.len();
-        bytes.extend_from_slice(format!("xref\n0 {}\n", objects.len() + 1).as_bytes());
-        bytes.extend_from_slice(b"0000000000 65535 f \n");
-        for offset in offsets.iter().skip(1) {
-            bytes.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
-        }
-
-        bytes.extend_from_slice(
-            format!(
-                "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
-                objects.len() + 1,
-                xref_start
-            )
-            .as_bytes(),
-        );
-
-        bytes
-    }
-
-    fn escape_literal_string(text: &str) -> String {
-        let mut out = String::with_capacity(text.len());
-
-        for ch in text.chars() {
-            match ch {
-                '\\' => out.push_str("\\\\"),
-                '(' => out.push_str("\\("),
-                ')' => out.push_str("\\)"),
-                '\n' => out.push_str("\\n"),
-                '\r' => out.push_str("\\r"),
-                '\t' => out.push_str("\\t"),
-                _ => out.push(ch),
-            }
-        }
-
-        out
     }
 }


### PR DESCRIPTION
## Summary
- add shared backend test support for minimal PDF fixtures
- replace duplicated PDF builders across app, render, perf, and hayro tests
- keep the helper behind cfg(test) so production builds are unchanged

## Rationale
Multiple tests carried similar PDF fixture builders, making future fixture changes require synchronized edits across modules.

Closes #86

## Verification
- cargo fmt --check
- TMPDIR=/tmp/preview-pdf-issue86/.tmp CARGO_TARGET_DIR=/tmp/preview-pdf-issue86/.cargo-target CARGO_INCREMENTAL=0 cargo test
- TMPDIR=/tmp/preview-pdf-issue86/.tmp CARGO_TARGET_DIR=/tmp/preview-pdf-issue86/.cargo-target CARGO_INCREMENTAL=0 cargo clippy --all-targets --all-features -- -D warnings