### PR TITLE
feat(layout): add spread cover policy

### DIFF
--- a/docs/command-system.md
+++ b/docs/command-system.md
@@ -109,12 +109,16 @@ Command-specific parsing rules:
   - overflow in `amount` clamps to `i32` bounds
 - `page-layout-single`
   - takes no arguments
-- `page-layout-spread [ltr|rtl]`
-  - accepts at most one spread direction argument
+- `page-layout-spread [ltr|rtl] [paired|cover]`
+  - accepts an optional spread direction argument followed by an optional cover
+    policy argument
   - the argument is optional to keep the common case short to type; users can
-    stop at `page-layout-spread` and let the command use its default direction
-  - omission is therefore not a separate argument value or token; it is just
-    the shorter command form
+    stop at `page-layout-spread`
+  - omitted direction keeps the current spread direction
+  - omitted cover policy uses `paired`, which groups pages as `1-2`, `3-4`, ...
+  - `cover` shows page 1 by itself, then groups pages as `2-3`, `4-5`, ...
+  - the cover policy is positional; specifying it requires specifying a
+    direction first
 - `open-palette <kind> [seed]`
   - parses palette kind first and preserves remaining text as optional seed
 - `submit-search <query> [matcher]`
@@ -182,7 +186,7 @@ Public commands:
 
 - Layout
   - `page-layout-single`
-  - `page-layout-spread [ltr|rtl]`
+  - `page-layout-spread [ltr|rtl] [paired|cover]`
 
 - Debug status
   - `debug-status-show`

--- a/docs/rendering-pipeline.md
+++ b/docs/rendering-pipeline.md
@@ -71,6 +71,8 @@ source-page identities for both single-page and spread slots.
 Rules:
 
 - spread mode splits the viewer into left and right page slots with a fixed gap
+- when spread cover policy is `cover`, page 1 is presented through the
+  single-page path; later spreads use the normal left/right slot path
 - each slot draws the same source-page frame path used by single-page mode
 - a missing partner page is represented by clearing that slot
 - each page is independently fit within its slot, so differently sized pages do

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -39,7 +39,11 @@ Rules:
   - `single` is the default layout
   - `spread` shows two logical pages side by side
   - spread direction supports `ltr` and `rtl`
-  - runtime commands are `page-layout-single` and `page-layout-spread [ltr|rtl]`
+  - spread cover policy supports `paired` and `cover`
+    - `paired` is the default and groups pages as `1-2`, `3-4`, ...
+    - `cover` shows page 1 by itself, then groups pages as `2-3`, `4-5`, ...
+  - runtime commands are `page-layout-single` and
+    `page-layout-spread [ltr|rtl] [paired|cover]`
 
 - Zoom and viewport
   - zoom uses a bounded discrete ladder

--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -44,6 +44,8 @@ Rules:
     - `cover` shows page 1 by itself, then groups pages as `2-3`, `4-5`, ...
   - runtime commands are `page-layout-single` and
     `page-layout-spread [ltr|rtl] [paired|cover]`
+  - command arguments are positional; specifying a spread cover policy requires
+    specifying a spread direction first, e.g. `page-layout-spread ltr cover`
 
 - Zoom and viewport
   - zoom uses a bounded discrete ladder

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -21,5 +21,5 @@ pub use core::App;
 pub use runtime::RenderRuntime;
 pub use state::{
     AppState, CacheHandle, CacheRefs, Mode, Notice, NoticeAction, NoticeLevel, PageLayoutMode,
-    PaletteRequest, SpreadDirection, VisiblePageSlots, notice_action_for_error,
+    PaletteRequest, SpreadCoverPolicy, SpreadDirection, VisiblePageSlots, notice_action_for_error,
 };

--- a/src/app/render_ops.rs
+++ b/src/app/render_ops.rs
@@ -159,14 +159,14 @@ pub(crate) fn cold_start_initial_preview_plan(
     current_cached: bool,
     doc_id: u64,
     visible_pages: VisiblePageSlots,
-    page_layout_mode: super::state::PageLayoutMode,
+    page_presentation: super::state::PageLayoutMode,
     current_scale: f32,
 ) -> Option<InitialPreviewPlan> {
     if !is_cold_start || current_cached {
         return None;
     }
 
-    compute_initial_preview_plan(doc_id, visible_pages, page_layout_mode, current_scale)
+    compute_initial_preview_plan(doc_id, visible_pages, page_presentation, current_scale)
 }
 
 impl RenderSubsystem {
@@ -192,14 +192,15 @@ impl RenderSubsystem {
             .keys()
             .iter()
             .all(|key| self.runtime.has_cached_frame(key));
+        let page_presentation = state.page_presentation_for_slots(visible_pages);
         let presenter_layout_tag =
-            state.presenter_layout_tag(visible_pages.trailing_page.is_some());
+            state.presenter_layout_tag(page_presentation, visible_pages.trailing_page.is_some());
         let initial_preview = cold_start_initial_preview_plan(
             is_cold_start,
             current_cached,
             pdf.doc_id(),
             visible_pages,
-            state.page_layout_mode,
+            page_presentation,
             current_scale,
         );
         let mut current_interest_keys = CurrentInterestKeys::from_required(&required);
@@ -308,9 +309,11 @@ impl RenderSubsystem {
         }
 
         if state.current_page != *parts.tracked_page {
-            parts
-                .nav
-                .on_page_change(*parts.tracked_page, state.current_page, state.page_step());
+            parts.nav.on_page_change(
+                *parts.tracked_page,
+                state.current_page,
+                state.page_step_between(*parts.tracked_page, state.current_page),
+            );
             self.runtime.schedule_navigation(
                 pdf,
                 state.current_page,

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -33,6 +33,22 @@ impl SpreadDirection {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SpreadCoverPolicy {
+    #[default]
+    Paired,
+    Cover,
+}
+
+impl SpreadCoverPolicy {
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::Paired => "paired",
+            Self::Cover => "cover",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VisiblePageSlots {
     pub anchor_page: usize,
@@ -122,6 +138,7 @@ pub struct AppState {
     pub current_page: usize,
     pub page_layout_mode: PageLayoutMode,
     pub spread_direction: SpreadDirection,
+    pub spread_cover_policy: SpreadCoverPolicy,
     pub zoom: f32,
     pub pan_x: i32,
     pub pan_y: i32,
@@ -138,6 +155,7 @@ impl Default for AppState {
             current_page: 0,
             page_layout_mode: PageLayoutMode::Single,
             spread_direction: SpreadDirection::Ltr,
+            spread_cover_policy: SpreadCoverPolicy::Paired,
             zoom: 1.0,
             pan_x: 0,
             pan_y: 0,
@@ -208,6 +226,18 @@ impl AppState {
         }
     }
 
+    pub fn page_step_between(&self, from: usize, to: usize) -> usize {
+        if self.page_layout_mode == PageLayoutMode::Spread
+            && self.spread_cover_policy == SpreadCoverPolicy::Cover
+            && from.min(to) == 0
+            && from.max(to) == 1
+        {
+            return 1;
+        }
+
+        self.page_step()
+    }
+
     pub fn normalize_page_for_layout(&self, page: usize, page_count: usize) -> usize {
         if page_count == 0 {
             return 0;
@@ -216,12 +246,59 @@ impl AppState {
         let clamped = page.min(page_count - 1);
         match self.page_layout_mode {
             PageLayoutMode::Single => clamped,
-            PageLayoutMode::Spread => clamped.saturating_sub(clamped % 2),
+            PageLayoutMode::Spread => match self.spread_cover_policy {
+                SpreadCoverPolicy::Paired => clamped.saturating_sub(clamped % 2),
+                SpreadCoverPolicy::Cover => {
+                    if clamped == 0 {
+                        0
+                    } else {
+                        clamped.saturating_sub((clamped - 1) % 2)
+                    }
+                }
+            },
         }
     }
 
     pub fn normalize_current_page(&mut self, page_count: usize) {
         self.current_page = self.normalize_page_for_layout(self.current_page, page_count);
+    }
+
+    pub fn next_page_for_layout(&self, page: usize, page_count: usize) -> usize {
+        if page_count == 0 {
+            return 0;
+        }
+
+        let anchor_page = self.normalize_page_for_layout(page, page_count);
+        match self.page_layout_mode {
+            PageLayoutMode::Single => (anchor_page + 1).min(page_count - 1),
+            PageLayoutMode::Spread => {
+                let next =
+                    if self.spread_cover_policy == SpreadCoverPolicy::Cover && anchor_page == 0 {
+                        1
+                    } else {
+                        anchor_page.saturating_add(2)
+                    };
+                if next < page_count { next } else { anchor_page }
+            }
+        }
+    }
+
+    pub fn prev_page_for_layout(&self, page: usize, page_count: usize) -> usize {
+        if page_count == 0 {
+            return 0;
+        }
+
+        let anchor_page = self.normalize_page_for_layout(page, page_count);
+        match self.page_layout_mode {
+            PageLayoutMode::Single => anchor_page.saturating_sub(1),
+            PageLayoutMode::Spread => {
+                if self.spread_cover_policy == SpreadCoverPolicy::Cover && anchor_page == 1 {
+                    0
+                } else {
+                    anchor_page.saturating_sub(2)
+                }
+            }
+        }
     }
 
     pub fn visible_page_slots(&self, page_count: usize) -> VisiblePageSlots {
@@ -248,6 +325,15 @@ impl AppState {
             };
         }
 
+        if self.spread_cover_policy == SpreadCoverPolicy::Cover && anchor_page == 0 {
+            return VisiblePageSlots {
+                anchor_page,
+                trailing_page: None,
+                left_page: Some(anchor_page),
+                right_page: None,
+            };
+        }
+
         let trailing_page = (anchor_page + 1 < page_count).then_some(anchor_page + 1);
         let (left_page, right_page) = match self.spread_direction {
             SpreadDirection::Ltr => (Some(anchor_page), trailing_page),
@@ -261,12 +347,25 @@ impl AppState {
         }
     }
 
-    pub fn presenter_layout_tag(&self, has_trailing_page: bool) -> u16 {
-        match (
-            self.page_layout_mode,
-            self.spread_direction,
-            has_trailing_page,
-        ) {
+    pub fn page_presentation_for_slots(&self, slots: VisiblePageSlots) -> PageLayoutMode {
+        match self.page_layout_mode {
+            PageLayoutMode::Single => PageLayoutMode::Single,
+            PageLayoutMode::Spread
+                if self.spread_cover_policy == SpreadCoverPolicy::Cover
+                    && slots.anchor_page == 0 =>
+            {
+                PageLayoutMode::Single
+            }
+            PageLayoutMode::Spread => PageLayoutMode::Spread,
+        }
+    }
+
+    pub fn presenter_layout_tag(
+        &self,
+        page_presentation: PageLayoutMode,
+        has_trailing_page: bool,
+    ) -> u16 {
+        match (page_presentation, self.spread_direction, has_trailing_page) {
             (PageLayoutMode::Single, _, _) => 0,
             (PageLayoutMode::Spread, SpreadDirection::Ltr, true) => 1,
             (PageLayoutMode::Spread, SpreadDirection::Rtl, true) => 2,
@@ -289,7 +388,10 @@ pub fn notice_action_for_error(err: AppError) -> NoticeAction {
 mod tests {
     use std::io;
 
-    use super::{NoticeAction, NoticeLevel, notice_action_for_error};
+    use super::{
+        AppState, NoticeAction, NoticeLevel, PageLayoutMode, SpreadCoverPolicy, SpreadDirection,
+        notice_action_for_error,
+    };
     use crate::error::AppError;
 
     #[test]
@@ -312,6 +414,68 @@ mod tests {
                 level: NoticeLevel::Error,
                 message: "I/O error: disk failed".to_string(),
             }
+        );
+    }
+
+    #[test]
+    fn paired_spread_normalizes_to_even_anchor_pages() {
+        let app = AppState {
+            page_layout_mode: PageLayoutMode::Spread,
+            spread_cover_policy: SpreadCoverPolicy::Paired,
+            ..AppState::default()
+        };
+
+        assert_eq!(app.normalize_page_for_layout(0, 8), 0);
+        assert_eq!(app.normalize_page_for_layout(1, 8), 0);
+        assert_eq!(app.normalize_page_for_layout(2, 8), 2);
+        assert_eq!(app.normalize_page_for_layout(3, 8), 2);
+    }
+
+    #[test]
+    fn cover_spread_keeps_first_page_solo_and_pairs_from_second_page() {
+        let app = AppState {
+            page_layout_mode: PageLayoutMode::Spread,
+            spread_cover_policy: SpreadCoverPolicy::Cover,
+            ..AppState::default()
+        };
+
+        assert_eq!(app.normalize_page_for_layout(0, 8), 0);
+        assert_eq!(app.normalize_page_for_layout(1, 8), 1);
+        assert_eq!(app.normalize_page_for_layout(2, 8), 1);
+        assert_eq!(app.normalize_page_for_layout(3, 8), 3);
+
+        assert_eq!(app.next_page_for_layout(0, 8), 1);
+        assert_eq!(app.next_page_for_layout(1, 8), 3);
+        assert_eq!(app.prev_page_for_layout(3, 8), 1);
+        assert_eq!(app.prev_page_for_layout(1, 8), 0);
+    }
+
+    #[test]
+    fn cover_spread_presents_first_page_as_single_page() {
+        let app = AppState {
+            page_layout_mode: PageLayoutMode::Spread,
+            spread_direction: SpreadDirection::Rtl,
+            spread_cover_policy: SpreadCoverPolicy::Cover,
+            ..AppState::default()
+        };
+
+        let cover = app.visible_page_slots_for_page(0, 8);
+        assert_eq!(cover.trailing_page, None);
+        assert_eq!(cover.left_page, Some(0));
+        assert_eq!(cover.right_page, None);
+        assert_eq!(
+            app.page_presentation_for_slots(cover),
+            PageLayoutMode::Single
+        );
+
+        let first_spread = app.visible_page_slots_for_page(1, 8);
+        assert_eq!(first_spread.anchor_page, 1);
+        assert_eq!(first_spread.trailing_page, Some(2));
+        assert_eq!(first_spread.left_page, Some(2));
+        assert_eq!(first_spread.right_page, Some(1));
+        assert_eq!(
+            app.page_presentation_for_slots(first_spread),
+            PageLayoutMode::Spread
         );
     }
 }

--- a/src/app/view_ops.rs
+++ b/src/app/view_ops.rs
@@ -62,7 +62,7 @@ struct RenderFrameDrawPlan {
     help_scroll: usize,
     debug_status_visible: bool,
     chrome: ui::ChromeViewState,
-    page_layout_mode: PageLayoutMode,
+    page_presentation: PageLayoutMode,
     enable_crop: bool,
     file_name: String,
     presenter_backend_name: &'static str,
@@ -128,6 +128,7 @@ impl RenderFrameDrawPlan {
             .unwrap_or_else(|| pdf.path().display().to_string());
         let loading_label = format_loading_target(visible_pages);
         let render_target = format_render_target(visible_pages);
+        let page_presentation = state.page_presentation_for_slots(visible_pages);
         let spread_gap_px = u32::from(
             resolved_cell_size_px(presenter.cell_px)
                 .0
@@ -149,12 +150,12 @@ impl RenderFrameDrawPlan {
             debug_status_visible: state.debug_status_visible,
             chrome: ui::ChromeViewState {
                 visible_pages,
-                page_layout_mode: state.page_layout_mode,
+                page_presentation,
                 zoom: state.zoom,
                 debug_status_visible: state.debug_status_visible,
                 notice: state.notice.clone(),
             },
-            page_layout_mode: state.page_layout_mode,
+            page_presentation,
             enable_crop: state.zoom > 1.0,
             file_name,
             presenter_backend_name: presenter.backend_name,
@@ -205,8 +206,9 @@ impl App {
         let slots = self
             .state
             .visible_page_slots_for_page(page, pdf.page_count());
+        let page_presentation = self.state.page_presentation_for_slots(slots);
         let (page_width_pt, page_height_pt) =
-            resolve_layout_dimensions(pdf, self.state.page_layout_mode, slots);
+            resolve_layout_dimensions(pdf, page_presentation, slots);
         let caps = self.render.presenter.capabilities();
         let max_scale = caps
             .preferred_max_render_scale
@@ -446,7 +448,7 @@ impl RenderSubsystem {
             let image_area = layout.viewer_inner;
             let spread_slot_areas = split_spread_slot_areas(image_area, SPREAD_GAP_CELLS);
 
-            let prepare_result = match draw_plan.page_layout_mode {
+            let prepare_result = match draw_plan.page_presentation {
                 PageLayoutMode::Single => self.prepare_single_page_or_preview_from_cache(
                     pdf,
                     viewport,
@@ -481,7 +483,7 @@ impl RenderSubsystem {
                         render_mode,
                         ..draw_plan.render_options
                     };
-                    let render_result = match draw_plan.page_layout_mode {
+                    let render_result = match draw_plan.page_presentation {
                         PageLayoutMode::Single => {
                             let render_slots: Vec<_> = spread_render_slots
                                 .into_iter()
@@ -506,7 +508,7 @@ impl RenderSubsystem {
                                 viewer_has_image = true;
                             }
                             let allow_viewer_loading =
-                                draw_plan.page_layout_mode == PageLayoutMode::Single;
+                                draw_plan.page_presentation == PageLayoutMode::Single;
                             draw_viewer_outcome(
                                 frame,
                                 image_area,
@@ -516,7 +518,7 @@ impl RenderSubsystem {
                                 viewer_has_image,
                                 allow_viewer_loading,
                             );
-                            if draw_plan.page_layout_mode == PageLayoutMode::Spread {
+                            if draw_plan.page_presentation == PageLayoutMode::Spread {
                                 draw_spread_loading_overlays(
                                     frame,
                                     &outcome,
@@ -542,7 +544,7 @@ impl RenderSubsystem {
                 }
                 Ok(None) => {
                     render_feedback = PresenterFeedback::Pending;
-                    let outcome = match draw_plan.page_layout_mode {
+                    let outcome = match draw_plan.page_presentation {
                         PageLayoutMode::Single => PresenterRenderOutcome {
                             slots: vec![PresenterSlotOutcome::active(
                                 image_area,
@@ -558,8 +560,9 @@ impl RenderSubsystem {
                             PresenterFeedback::Pending,
                         ),
                     };
-                    let allow_viewer_loading = draw_plan.page_layout_mode == PageLayoutMode::Single;
-                    if draw_plan.page_layout_mode == PageLayoutMode::Spread {
+                    let allow_viewer_loading =
+                        draw_plan.page_presentation == PageLayoutMode::Single;
+                    if draw_plan.page_presentation == PageLayoutMode::Spread {
                         clear_pending_spread_regions(frame, spread_slot_areas, &outcome);
                     }
                     draw_viewer_outcome(
@@ -571,7 +574,7 @@ impl RenderSubsystem {
                         viewer_has_image,
                         allow_viewer_loading,
                     );
-                    if draw_plan.page_layout_mode == PageLayoutMode::Spread {
+                    if draw_plan.page_presentation == PageLayoutMode::Spread {
                         draw_spread_loading_overlays(frame, &outcome, draw_plan.visible_pages);
                     }
                 }
@@ -777,14 +780,14 @@ fn presenter_render_options(
 
 fn resolve_layout_dimensions(
     pdf: &dyn PdfBackend,
-    mode: PageLayoutMode,
+    page_presentation: PageLayoutMode,
     slots: VisiblePageSlots,
 ) -> (f32, f32) {
     let (anchor_width, anchor_height) = pdf
         .page_dimensions(slots.anchor_page)
         .unwrap_or(DEFAULT_PAGE_SIZE_PT);
     match slots.trailing_page {
-        None => match mode {
+        None => match page_presentation {
             PageLayoutMode::Single => (anchor_width, anchor_height),
             // Tail spread still reserves a blank partner slot, so the scale
             // stays consistent with regular spread slot layout.
@@ -803,7 +806,7 @@ fn resolve_layout_dimensions(
 pub(super) fn compute_initial_preview_plan(
     doc_id: u64,
     visible_pages: VisiblePageSlots,
-    page_layout_mode: PageLayoutMode,
+    page_presentation: PageLayoutMode,
     current_scale: f32,
 ) -> Option<InitialPreviewPlan> {
     let preview_scale = quantize_scale(current_scale * INITIAL_PREVIEW_SCALE_RATIO);
@@ -811,7 +814,7 @@ pub(super) fn compute_initial_preview_plan(
         return None;
     }
 
-    let page_keys = match page_layout_mode {
+    let page_keys = match page_presentation {
         PageLayoutMode::Single => vec![RenderedPageKey::new(
             doc_id,
             visible_pages.anchor_page,

--- a/src/command/core.rs
+++ b/src/command/core.rs
@@ -1,8 +1,10 @@
 use crate::app::scale::{ZOOM_MAX, ZOOM_MIN};
-use crate::app::{AppState, Mode, NoticeAction, PageLayoutMode, SpreadDirection};
+use crate::app::{
+    AppState, Mode, NoticeAction, PageLayoutMode, SpreadCoverPolicy, SpreadDirection,
+};
 use crate::error::{AppError, AppResult};
 
-use super::types::{CommandOutcome, PageLayoutModeArg, SpreadDirectionArg};
+use super::types::{CommandOutcome, PageLayoutModeArg, SpreadCoverPolicyArg, SpreadDirectionArg};
 
 pub(crate) type CommandNoticeResult = (CommandOutcome, NoticeAction);
 
@@ -16,27 +18,23 @@ fn noop() -> CommandNoticeResult {
 
 pub(crate) fn next_page(app: &mut AppState, page_count: usize) -> AppResult<CommandNoticeResult> {
     let page_count = resolve_page_count(page_count)?;
-    let step = app.page_step();
-
-    if app.current_page.saturating_add(step) >= page_count {
+    let target = app.next_page_for_layout(app.current_page, page_count);
+    if app.current_page == target {
         return Ok(noop());
     }
 
-    let target = app.current_page.saturating_add(step);
-    app.current_page = app.normalize_page_for_layout(target, page_count);
+    app.current_page = target;
     Ok(applied())
 }
 
 pub(crate) fn prev_page(app: &mut AppState, page_count: usize) -> AppResult<CommandNoticeResult> {
     let page_count = resolve_page_count(page_count)?;
-    let step = app.page_step();
-
-    if app.current_page == 0 {
+    let target = app.prev_page_for_layout(app.current_page, page_count);
+    if app.current_page == target {
         return Ok(noop());
     }
 
-    let target = app.current_page.saturating_sub(step);
-    app.current_page = app.normalize_page_for_layout(target, page_count);
+    app.current_page = target;
     Ok(applied())
 }
 
@@ -91,6 +89,7 @@ pub(crate) fn set_page_layout(
     page_count: usize,
     mode: PageLayoutModeArg,
     direction: Option<SpreadDirectionArg>,
+    cover_policy: Option<SpreadCoverPolicyArg>,
 ) -> AppResult<CommandNoticeResult> {
     let page_count = resolve_page_count(page_count)?;
 
@@ -103,14 +102,20 @@ pub(crate) fn set_page_layout(
         Some(SpreadDirectionArg::Rtl) => SpreadDirection::Rtl,
         None => app.spread_direction,
     };
-    if next_mode == PageLayoutMode::Single && direction.is_some() {
+    let next_cover_policy = match cover_policy {
+        Some(SpreadCoverPolicyArg::Cover) => SpreadCoverPolicy::Cover,
+        Some(SpreadCoverPolicyArg::Paired) | None => SpreadCoverPolicy::Paired,
+    };
+    if next_mode == PageLayoutMode::Single && (direction.is_some() || cover_policy.is_some()) {
         return Err(AppError::invalid_argument(
-            "single layout does not accept a spread direction",
+            "single layout does not accept spread arguments",
         ));
     }
 
     let changed = app.page_layout_mode != next_mode
-        || (next_mode == PageLayoutMode::Spread && app.spread_direction != next_direction);
+        || (next_mode == PageLayoutMode::Spread
+            && (app.spread_direction != next_direction
+                || app.spread_cover_policy != next_cover_policy));
     if !changed {
         return Ok(noop());
     }
@@ -118,6 +123,7 @@ pub(crate) fn set_page_layout(
     app.page_layout_mode = next_mode;
     if next_mode == PageLayoutMode::Spread {
         app.spread_direction = next_direction;
+        app.spread_cover_policy = next_cover_policy;
     }
     app.normalize_current_page(page_count);
     app.pan_x = 0;

--- a/src/command/dispatch.rs
+++ b/src/command/dispatch.rs
@@ -101,9 +101,11 @@ pub fn dispatch(
             app.pan_y = app.pan_y.saturating_add(dy);
             Ok((CommandOutcome::Applied, NoticeAction::Clear))
         }
-        Command::SetPageLayout { mode, direction } => {
-            set_page_layout(app, page_count, mode, direction)
-        }
+        Command::SetPageLayout {
+            mode,
+            direction,
+            cover_policy,
+        } => set_page_layout(app, page_count, mode, direction, cover_policy),
         Command::DebugStatusShow => set_debug_status_visible(app, true),
         Command::DebugStatusHide => set_debug_status_visible(app, false),
         Command::DebugStatusToggle => {
@@ -262,11 +264,11 @@ mod tests {
     use std::sync::Arc;
 
     use crate::app::scale::zoom_eq;
-    use crate::app::{AppState, Notice, NoticeLevel, PaletteRequest};
+    use crate::app::{AppState, Notice, NoticeLevel, PaletteRequest, SpreadCoverPolicy};
     use crate::backend::{PdfBackend, RgbaFrame, SharedPdfBackend, TextPage};
     use crate::command::{
         ActionId, Command, CommandInvocationSource, CommandOutcome, PageLayoutModeArg, PanAmount,
-        PanDirection, SearchMatcherKind,
+        PanDirection, SearchMatcherKind, SpreadCoverPolicyArg,
     };
     use crate::event::{AppEvent, NavReason};
     use crate::extension::ExtensionHost;
@@ -868,6 +870,7 @@ mod tests {
             Command::SetPageLayout {
                 mode: PageLayoutModeArg::Spread,
                 direction: None,
+                cover_policy: None,
             },
             CommandInvocationSource::Keymap,
             pdf,
@@ -886,6 +889,63 @@ mod tests {
                 reason: NavReason::LayoutNormalize
             }
         ));
+    }
+
+    #[test]
+    fn dispatch_page_layout_spread_without_cover_policy_resets_to_paired() {
+        let mut app = AppState {
+            current_page: 1,
+            page_layout_mode: crate::app::PageLayoutMode::Spread,
+            spread_cover_policy: SpreadCoverPolicy::Cover,
+            ..AppState::default()
+        };
+        let pdf = Arc::new(StubPdf::new(8)) as SharedPdfBackend;
+        let mut host = ExtensionHost::default();
+        let mut palette_requests = VecDeque::new();
+
+        let result = dispatch(
+            &mut app,
+            Command::SetPageLayout {
+                mode: PageLayoutModeArg::Spread,
+                direction: None,
+                cover_policy: None,
+            },
+            CommandInvocationSource::Keymap,
+            pdf,
+            &mut host,
+            &mut palette_requests,
+        )
+        .expect("dispatch should succeed");
+
+        assert_eq!(result.outcome, CommandOutcome::Applied);
+        assert_eq!(app.spread_cover_policy, SpreadCoverPolicy::Paired);
+        assert_eq!(app.current_page, 0);
+    }
+
+    #[test]
+    fn dispatch_page_layout_spread_cover_keeps_cover_policy() {
+        let mut app = AppState::default();
+        let pdf = Arc::new(StubPdf::new(8)) as SharedPdfBackend;
+        let mut host = ExtensionHost::default();
+        let mut palette_requests = VecDeque::new();
+
+        let result = dispatch(
+            &mut app,
+            Command::SetPageLayout {
+                mode: PageLayoutModeArg::Spread,
+                direction: None,
+                cover_policy: Some(SpreadCoverPolicyArg::Cover),
+            },
+            CommandInvocationSource::Keymap,
+            pdf,
+            &mut host,
+            &mut palette_requests,
+        )
+        .expect("dispatch should succeed");
+
+        assert_eq!(result.outcome, CommandOutcome::Applied);
+        assert_eq!(app.spread_cover_policy, SpreadCoverPolicy::Cover);
+        assert_eq!(app.current_page, 0);
     }
 
     #[test]

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -15,5 +15,5 @@ pub use types::{
     ActionId, ArgHint, ArgKind, ArgSpec, Command, CommandAvailability, CommandCondition,
     CommandExposure, CommandInvocationPolicy, CommandInvocationSource, CommandOutcome,
     CommandRequest, CommandSpec, PageLayoutModeArg, PanAmount, PanDirection, SearchMatcherKind,
-    SpreadDirectionArg,
+    SpreadCoverPolicyArg, SpreadDirectionArg,
 };

--- a/src/command/parse.rs
+++ b/src/command/parse.rs
@@ -7,7 +7,7 @@ use crate::palette::{PaletteKind, PaletteOpenPayload};
 use super::spec::{CommandConditionContext, find_command_spec, validate_command_id_for_source};
 use super::types::{
     Command, CommandInvocationSource, PageLayoutModeArg, PanAmount, PanDirection,
-    SearchMatcherKind, SpreadDirectionArg,
+    SearchMatcherKind, SpreadCoverPolicyArg, SpreadDirectionArg,
 };
 
 pub fn parse_command_text(input: &str) -> AppResult<Command> {
@@ -266,6 +266,7 @@ fn parse_page_layout_single(args_text: &str) -> AppResult<Command> {
         Command::SetPageLayout {
             mode: PageLayoutModeArg::Single,
             direction: None,
+            cover_policy: None,
         },
     )
 }
@@ -276,6 +277,7 @@ fn parse_page_layout_spread(args_text: &str) -> AppResult<Command> {
         return Ok(Command::SetPageLayout {
             mode: PageLayoutModeArg::Spread,
             direction: None,
+            cover_policy: None,
         });
     }
 
@@ -285,15 +287,23 @@ fn parse_page_layout_spread(args_text: &str) -> AppResult<Command> {
     };
     let direction = SpreadDirectionArg::parse(direction_text)
         .ok_or(AppError::invalid_argument("unknown spread direction"))?;
+    let cover_policy = parts
+        .next()
+        .map(|policy_text| {
+            SpreadCoverPolicyArg::parse(policy_text)
+                .ok_or(AppError::invalid_argument("unknown spread cover policy"))
+        })
+        .transpose()?;
     if parts.next().is_some() {
         return Err(AppError::invalid_argument(
-            "page-layout-spread accepts at most 1 argument",
+            "page-layout-spread accepts at most 2 arguments",
         ));
     }
 
     Ok(Command::SetPageLayout {
         mode: PageLayoutModeArg::Spread,
         direction: Some(direction),
+        cover_policy,
     })
 }
 
@@ -424,7 +434,8 @@ mod tests {
     use super::{first_token, parse_command_text};
     use crate::command::{
         ArgHint, ArgKind, ArgSpec, Command, CommandExposure, PageLayoutModeArg, PanAmount,
-        PanDirection, SearchMatcherKind, SpreadDirectionArg, all_command_specs,
+        PanDirection, SearchMatcherKind, SpreadCoverPolicyArg, SpreadDirectionArg,
+        all_command_specs,
     };
     use crate::palette::{PaletteKind, PaletteOpenPayload};
 
@@ -550,6 +561,7 @@ mod tests {
             Command::SetPageLayout {
                 mode: PageLayoutModeArg::Single,
                 direction: None,
+                cover_policy: None,
             }
         );
         assert_eq!(
@@ -557,6 +569,7 @@ mod tests {
             Command::SetPageLayout {
                 mode: PageLayoutModeArg::Spread,
                 direction: None,
+                cover_policy: None,
             }
         );
         assert_eq!(
@@ -564,6 +577,15 @@ mod tests {
             Command::SetPageLayout {
                 mode: PageLayoutModeArg::Spread,
                 direction: Some(SpreadDirectionArg::Rtl),
+                cover_policy: None,
+            }
+        );
+        assert_eq!(
+            parse_command_text("page-layout-spread rtl cover").expect("parse should succeed"),
+            Command::SetPageLayout {
+                mode: PageLayoutModeArg::Spread,
+                direction: Some(SpreadDirectionArg::Rtl),
+                cover_policy: Some(SpreadCoverPolicyArg::Cover),
             }
         );
     }
@@ -746,6 +768,9 @@ mod tests {
                 if index == arg_index {
                     return Some(value);
                 }
+                if index < arg_index {
+                    return sample_arg(arg);
+                }
                 required_arg_sample(arg)
             })
             .collect::<Vec<_>>();
@@ -762,6 +787,10 @@ mod tests {
             return None;
         }
 
+        sample_arg(arg)
+    }
+
+    fn sample_arg(arg: &ArgSpec) -> Option<&'static str> {
         Some(match arg.kind {
             ArgKind::F32 => "1.25",
             ArgKind::I32 => "1",

--- a/src/command/spec.rs
+++ b/src/command/spec.rs
@@ -4,7 +4,7 @@ use crate::extension::ExtensionUiSnapshot;
 use super::types::{
     ArgHint, ArgKind, ArgSpec, Command, CommandAvailability, CommandCondition, CommandExposure,
     CommandInvocationPolicy, CommandInvocationSource, CommandSpec, PanDirection,
-    SpreadDirectionArg,
+    SpreadCoverPolicyArg, SpreadDirectionArg,
 };
 
 const NO_ARGS: [ArgSpec; 0] = [];
@@ -36,12 +36,20 @@ const ARGS_PAN: [ArgSpec; 2] = [
         hint: ArgHint::None,
     },
 ];
-const ARGS_PAGE_LAYOUT_SPREAD: [ArgSpec; 1] = [ArgSpec {
-    name: "direction",
-    kind: ArgKind::String,
-    required: false,
-    hint: ArgHint::Enum(SpreadDirectionArg::values),
-}];
+const ARGS_PAGE_LAYOUT_SPREAD: [ArgSpec; 2] = [
+    ArgSpec {
+        name: "direction",
+        kind: ArgKind::String,
+        required: false,
+        hint: ArgHint::Enum(SpreadDirectionArg::values),
+    },
+    ArgSpec {
+        name: "cover-policy",
+        kind: ArgKind::String,
+        required: false,
+        hint: ArgHint::Enum(SpreadCoverPolicyArg::values),
+    },
+];
 const ARGS_OPEN_PALETTE: [ArgSpec; 2] = [
     ArgSpec {
         name: "kind",

--- a/src/command/types.rs
+++ b/src/command/types.rs
@@ -126,6 +126,47 @@ impl SpreadDirectionArg {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpreadCoverPolicyArg {
+    Paired,
+    Cover,
+}
+
+impl SpreadCoverPolicyArg {
+    const VARIANTS: [Self; 2] = [Self::Paired, Self::Cover];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Paired => "paired",
+            Self::Cover => "cover",
+        }
+    }
+
+    pub fn id(self) -> &'static str {
+        self.as_str()
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Self::VARIANTS
+            .iter()
+            .copied()
+            .find(|candidate| candidate.as_str() == value)
+    }
+
+    pub fn values() -> &'static [&'static str] {
+        static VALUES: OnceLock<Box<[&'static str]>> = OnceLock::new();
+
+        VALUES
+            .get_or_init(|| {
+                SpreadCoverPolicyArg::VARIANTS
+                    .iter()
+                    .map(|candidate| candidate.as_str())
+                    .collect()
+            })
+            .as_ref()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PanDirection {
     Left,
     Right,
@@ -194,6 +235,7 @@ pub enum Command {
     SetPageLayout {
         mode: PageLayoutModeArg,
         direction: Option<SpreadDirectionArg>,
+        cover_policy: Option<SpreadCoverPolicyArg>,
     },
     DebugStatusShow,
     DebugStatusHide,
@@ -456,7 +498,7 @@ mod tests {
 
     use super::{
         ActionId, Command, PageLayoutModeArg, PanAmount, PanDirection, SearchMatcherKind,
-        SpreadDirectionArg,
+        SpreadCoverPolicyArg, SpreadDirectionArg,
     };
 
     #[test]
@@ -505,6 +547,13 @@ mod tests {
             &[
                 SpreadDirectionArg::Ltr.as_str(),
                 SpreadDirectionArg::Rtl.as_str(),
+            ]
+        );
+        assert_eq!(
+            SpreadCoverPolicyArg::values(),
+            &[
+                SpreadCoverPolicyArg::Paired.as_str(),
+                SpreadCoverPolicyArg::Cover.as_str(),
             ]
         );
         assert_eq!(
@@ -568,6 +617,7 @@ mod tests {
             Command::SetPageLayout {
                 mode: PageLayoutModeArg::Spread,
                 direction: Some(SpreadDirectionArg::Rtl),
+                cover_policy: None,
             }
             .action_id(),
             ActionId::SetPageLayout

--- a/src/command/types.rs
+++ b/src/command/types.rs
@@ -529,6 +529,10 @@ mod tests {
         for mode in [PageLayoutModeArg::Single, PageLayoutModeArg::Spread] {
             assert_eq!(PageLayoutModeArg::parse(mode.as_str()), Some(mode));
         }
+
+        for policy in [SpreadCoverPolicyArg::Paired, SpreadCoverPolicyArg::Cover] {
+            assert_eq!(SpreadCoverPolicyArg::parse(policy.as_str()), Some(policy));
+        }
     }
 
     #[test]

--- a/src/palette/providers/command.rs
+++ b/src/palette/providers/command.rs
@@ -752,6 +752,9 @@ mod tests {
     fn enum_argument_phase_lists_values() {
         let list = command_list_for_input("page-layout-spread ", false);
         assert_eq!(ids(&list), vec!["ltr".to_string(), "rtl".to_string()]);
+
+        let list = command_list_for_input("page-layout-spread ltr ", false);
+        assert_eq!(ids(&list), vec!["paired".to_string(), "cover".to_string()]);
     }
 
     #[test]
@@ -781,6 +784,9 @@ mod tests {
 
         let list = command_list_for_input("page-layout-spread rt", false);
         assert_eq!(ids(&list), vec!["rtl".to_string()]);
+
+        let list = command_list_for_input("page-layout-spread rtl p", false);
+        assert_eq!(ids(&list), vec!["paired".to_string()]);
     }
 
     #[test]
@@ -871,6 +877,7 @@ mod tests {
                 command: Command::SetPageLayout {
                     mode: crate::command::PageLayoutModeArg::Spread,
                     direction: None,
+                    cover_policy: None,
                 },
                 history_record: Some(InputHistoryRecord::Command(
                     "page-layout-spread".to_string(),
@@ -955,6 +962,7 @@ mod tests {
                 command: Command::SetPageLayout {
                     mode: crate::command::PageLayoutModeArg::Spread,
                     direction: None,
+                    cover_policy: None,
                 },
                 history_record: Some(InputHistoryRecord::Command(
                     "page-layout-spread".to_string(),
@@ -1009,6 +1017,7 @@ mod tests {
                 command: Command::SetPageLayout {
                     mode: crate::command::PageLayoutModeArg::Spread,
                     direction: Some(crate::command::SpreadDirectionArg::Rtl),
+                    cover_policy: None,
                 },
                 history_record: Some(InputHistoryRecord::Command(
                     "page-layout-spread rtl".to_string(),
@@ -1019,10 +1028,38 @@ mod tests {
     }
 
     #[test]
+    fn submit_dispatches_selected_spread_cover_policy_when_result_is_complete() {
+        let effect = command_submit_effect("page-layout-spread rtl ", "cover", false);
+        assert_eq!(
+            effect,
+            PaletteSubmitEffect::Dispatch {
+                command: Command::SetPageLayout {
+                    mode: crate::command::PageLayoutModeArg::Spread,
+                    direction: Some(crate::command::SpreadDirectionArg::Rtl),
+                    cover_policy: Some(crate::command::SpreadCoverPolicyArg::Cover),
+                },
+                history_record: Some(InputHistoryRecord::Command(
+                    "page-layout-spread rtl cover".to_string(),
+                )),
+                next: PalettePostAction::Close,
+            }
+        );
+    }
+
+    #[test]
     fn assistive_text_uses_enum_values_for_enum_arguments() {
         assert_eq!(
             assistive_text_for_input("page-layout-spread ", false),
-            Some("page-layout-spread [direction] | direction: ltr / rtl".to_string())
+            Some(
+                "page-layout-spread [direction] [cover-policy] | direction: ltr / rtl".to_string()
+            )
+        );
+        assert_eq!(
+            assistive_text_for_input("page-layout-spread rtl ", false),
+            Some(
+                "page-layout-spread [direction] [cover-policy] | cover-policy: paired / cover"
+                    .to_string()
+            )
         );
     }
 

--- a/src/palette/types.rs
+++ b/src/palette/types.rs
@@ -1,5 +1,5 @@
 use super::kind::PaletteKind;
-use crate::app::{AppState, PageLayoutMode};
+use crate::app::{AppState, PageLayoutMode, SpreadCoverPolicy};
 use crate::command::{Command, SearchMatcherKind};
 use crate::error::{AppError, AppResult};
 use crate::extension::ExtensionUiSnapshot;
@@ -165,6 +165,7 @@ pub enum PaletteTabEffect {
 pub struct PaletteAppSnapshot {
     pub current_page: usize,
     pub page_layout_mode: PageLayoutMode,
+    pub spread_cover_policy: SpreadCoverPolicy,
 }
 
 impl From<&AppState> for PaletteAppSnapshot {
@@ -172,6 +173,7 @@ impl From<&AppState> for PaletteAppSnapshot {
         Self {
             current_page: app.current_page,
             page_layout_mode: app.page_layout_mode,
+            spread_cover_policy: app.spread_cover_policy,
         }
     }
 }

--- a/src/search/palette.rs
+++ b/src/search/palette.rs
@@ -1,4 +1,4 @@
-use crate::app::PageLayoutMode;
+use crate::app::{PageLayoutMode, SpreadCoverPolicy};
 use crate::command::{Command, SearchMatcherKind};
 use crate::error::AppResult;
 use crate::input::InputHistoryRecord;
@@ -152,7 +152,10 @@ impl PaletteProvider for SearchResultsPaletteProvider {
         candidates: &[PaletteCandidate],
     ) -> Option<usize> {
         let primary_page = ctx.app.current_page + 1;
-        let trailing_page = if ctx.app.page_layout_mode == PageLayoutMode::Spread {
+        let cover_solo = ctx.app.page_layout_mode == PageLayoutMode::Spread
+            && ctx.app.spread_cover_policy == SpreadCoverPolicy::Cover
+            && ctx.app.current_page == 0;
+        let trailing_page = if ctx.app.page_layout_mode == PageLayoutMode::Spread && !cover_solo {
             Some(primary_page + 1)
         } else {
             None
@@ -321,7 +324,7 @@ fn result_candidate(entry: &SearchPaletteEntry) -> PaletteCandidate {
 #[cfg(test)]
 mod tests {
     use crate::{
-        app::PageLayoutMode,
+        app::{PageLayoutMode, SpreadCoverPolicy},
         command::SearchMatcherKind,
         extension::ExtensionUiSnapshot,
         palette::{
@@ -423,6 +426,7 @@ mod tests {
         let app = PaletteAppSnapshot {
             current_page: 4,
             page_layout_mode: PageLayoutMode::Spread,
+            spread_cover_policy: SpreadCoverPolicy::Paired,
         };
         let extensions = ExtensionUiSnapshot {
             search_results_entries: vec![
@@ -456,6 +460,49 @@ mod tests {
         assert_eq!(
             provider.initial_selected_candidate(&ctx, &candidates),
             Some(1)
+        );
+    }
+
+    #[test]
+    fn results_initial_selection_does_not_treat_cover_solo_as_spread() {
+        let provider = SearchResultsPaletteProvider;
+        let app = PaletteAppSnapshot {
+            current_page: 0,
+            page_layout_mode: PageLayoutMode::Spread,
+            spread_cover_policy: SpreadCoverPolicy::Cover,
+        };
+        let extensions = ExtensionUiSnapshot {
+            search_results_entries: vec![
+                SearchPaletteEntry {
+                    index: 1,
+                    page: 0,
+                    snippet: "cover".to_string(),
+                    snippet_match_start: None,
+                    snippet_match_end: None,
+                },
+                SearchPaletteEntry {
+                    index: 2,
+                    page: 1,
+                    snippet: "next".to_string(),
+                    snippet_match_start: None,
+                    snippet_match_end: None,
+                },
+            ]
+            .into(),
+            ..ExtensionUiSnapshot::default()
+        };
+        let ctx = PaletteContext {
+            app,
+            extensions: &extensions,
+            kind: PaletteKind::SearchResults,
+            input: "",
+            open_payload: None,
+        };
+        let candidates = provider.list(&ctx).expect("results list should build");
+
+        assert_eq!(
+            provider.initial_selected_candidate(&ctx, &candidates),
+            Some(0)
         );
     }
 

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -13,7 +13,7 @@ const MIN_FILENAME_ELISION_WIDTH: usize = 7;
 #[derive(Debug, Clone, PartialEq)]
 pub struct ChromeViewState {
     pub visible_pages: VisiblePageSlots,
-    pub page_layout_mode: PageLayoutMode,
+    pub page_presentation: PageLayoutMode,
     pub zoom: f32,
     pub debug_status_visible: bool,
     pub notice: Option<Notice>,
@@ -132,7 +132,7 @@ fn build_status_text(
 fn format_page_segment(chrome: &ChromeViewState, page_total: usize) -> String {
     let slots = chrome.visible_pages;
     let page_width = page_total.to_string().len();
-    match chrome.page_layout_mode {
+    match chrome.page_presentation {
         PageLayoutMode::Single => {
             let page_now = slots.anchor_page.saturating_add(1).min(page_total);
             format!("p.{:>page_width$}/{:>page_width$}", page_now, page_total)
@@ -278,7 +278,7 @@ fn elide_middle_by_width(input: &str, max_width: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::app::{AppState, Notice, NoticeLevel, PageLayoutMode};
+    use crate::app::{AppState, Notice, NoticeLevel, PageLayoutMode, SpreadCoverPolicy};
 
     use super::{
         ChromeViewState, build_presenter_path_text, build_status_text, display_width,
@@ -288,7 +288,7 @@ mod tests {
     fn chrome_from_app(app: &AppState, page_count: usize) -> ChromeViewState {
         ChromeViewState {
             visible_pages: app.visible_page_slots(page_count),
-            page_layout_mode: app.page_layout_mode,
+            page_presentation: app.page_presentation_for_slots(app.visible_page_slots(page_count)),
             zoom: app.zoom,
             debug_status_visible: app.debug_status_visible,
             notice: app.notice.clone(),
@@ -457,5 +457,18 @@ mod tests {
         };
         let text = build_status_text(&chrome_from_app(&app, 10), "sample.pdf", 10, &[], 120);
         assert_eq!(text, "pp. 3- 4/10 | zoom 1.00x | sample.pdf");
+    }
+
+    #[test]
+    fn build_status_text_uses_single_page_segment_for_cover_solo_page() {
+        let app = AppState {
+            current_page: 0,
+            page_layout_mode: PageLayoutMode::Spread,
+            spread_cover_policy: SpreadCoverPolicy::Cover,
+            ..AppState::default()
+        };
+
+        let text = build_status_text(&chrome_from_app(&app, 10), "sample.pdf", 10, &[], 120);
+        assert_eq!(text, "p. 1/10 | zoom 1.00x | sample.pdf");
     }
 }


### PR DESCRIPTION
## Summary

- add a paired/cover policy for spread layout, with paired as the default
- show the first page through the single-page path when spread cover mode is selected
- extend `page-layout-spread [ltr|rtl] [paired|cover]` parsing, palette completion, docs, and tests

## Verification

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

Closes #81


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "cover" option for spread page layout: page 1 can display solo, then pages pair thereafter (default remains paired).

* **UI / Behavior**
  * Page indicators, navigation, and selection now respect the cover policy (first-page solo presentation and navigation steps updated).
  * Command palette flow for spread layout now accepts an optional cover argument.

* **Documentation**
  * Updated command and rendering docs to describe the new cover policy and command usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shiguri-01/preview-pdf/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->