### PR TITLE
fix(app): avoid pan clamp overflow

### DIFF
--- a/src/app/frame_ops.rs
+++ b/src/app/frame_ops.rs
@@ -89,15 +89,8 @@ pub(crate) fn crop_frame_for_viewport(
     let src_height = frame.height;
     let max_x = src_width.saturating_sub(target_width);
     let max_y = src_height.saturating_sub(target_height);
-    let max_cells_x = (max_x / cell_width_px as u32) as i32;
-    let max_cells_y = (max_y / cell_height_px as u32) as i32;
-    pan.cells_x = pan.cells_x.clamp(0, max_cells_x);
-    pan.cells_y = pan.cells_y.clamp(0, max_cells_y);
-
-    let pan_px_x = pan.cells_x.saturating_mul(cell_width_px as i32);
-    let pan_px_y = pan.cells_y.saturating_mul(cell_height_px as i32);
-    let origin_x = pan_px_x.clamp(0, max_x as i32) as u32;
-    let origin_y = pan_px_y.clamp(0, max_y as i32) as u32;
+    pan.clamp_to_pixel_bounds(max_x, max_y, cell_width_px, cell_height_px);
+    let (origin_x, origin_y) = pan.pixel_origin(max_x, max_y, cell_width_px, cell_height_px);
 
     let copy_width = target_width.min(src_width.saturating_sub(origin_x));
     let copy_height = target_height.min(src_height.saturating_sub(origin_y));

--- a/src/app/runtime/spread_canvas.rs
+++ b/src/app/runtime/spread_canvas.rs
@@ -67,14 +67,12 @@ pub(super) fn layout(request: SpreadCanvasLayoutRequest) -> SpreadCanvasLayout {
     let mut pan = request.pan;
     let max_x = canvas_width.saturating_sub(viewport_width_px);
     let max_y = canvas_height.saturating_sub(viewport_height_px);
-    let max_cells_x = (max_x / u32::from(cell_width_px)) as i32;
-    let max_cells_y = (max_y / u32::from(cell_height_px)) as i32;
-    pan.cells_x = pan.cells_x.clamp(0, max_cells_x);
-    pan.cells_y = pan.cells_y.clamp(0, max_cells_y);
+    pan.clamp_to_pixel_bounds(max_x, max_y, cell_width_px, cell_height_px);
+    let (origin_x, origin_y) = pan.pixel_origin(max_x, max_y, cell_width_px, cell_height_px);
 
     let view = CanvasView {
-        x: pan.cells_x.saturating_mul(i32::from(cell_width_px)).max(0) as u32,
-        y: pan.cells_y.saturating_mul(i32::from(cell_height_px)).max(0) as u32,
+        x: origin_x,
+        y: origin_y,
         width: viewport_width_px,
         height: viewport_height_px,
         viewport: request.viewport,
@@ -300,5 +298,43 @@ mod tests {
             layout.clips.map(|clip| clip.map(|clip| clip.render_area)),
             [None, Some(Rect::new(4, 0, 6, 5))]
         );
+    }
+
+    #[test]
+    fn clamps_pan_for_oversized_canvas_without_signed_overflow() {
+        let layout = layout(SpreadCanvasLayoutRequest {
+            pages: [
+                Some(SpreadCanvasPage {
+                    width: u32::MAX,
+                    height: u32::MAX,
+                }),
+                None,
+            ],
+            viewport: Viewport {
+                x: 0,
+                y: 0,
+                width: 1,
+                height: 1,
+            },
+            pan: PanOffset {
+                cells_x: i32::MAX,
+                cells_y: i32::MAX,
+            },
+            cell_px: Some((1, 1)),
+            gap_px: 0,
+        });
+
+        assert_eq!(
+            layout.pan,
+            PanOffset {
+                cells_x: i32::MAX,
+                cells_y: i32::MAX
+            }
+        );
+        let clip = layout.clips[0].expect("oversized page should intersect the viewport");
+        assert_eq!(clip.crop_x, i32::MAX as u32);
+        assert_eq!(clip.crop_y, i32::MAX as u32);
+        assert_eq!(clip.crop_width, 1);
+        assert_eq!(clip.crop_height, 1);
     }
 }

--- a/src/presenter/traits.rs
+++ b/src/presenter/traits.rs
@@ -40,6 +40,47 @@ pub struct PanOffset {
     pub cells_y: i32,
 }
 
+impl PanOffset {
+    pub(crate) fn clamp_to_pixel_bounds(
+        &mut self,
+        max_x_px: u32,
+        max_y_px: u32,
+        cell_width_px: u16,
+        cell_height_px: u16,
+    ) {
+        self.cells_x = self
+            .cells_x
+            .clamp(0, max_pan_cells(max_x_px, cell_width_px));
+        self.cells_y = self
+            .cells_y
+            .clamp(0, max_pan_cells(max_y_px, cell_height_px));
+    }
+
+    pub(crate) fn pixel_origin(
+        self,
+        max_x_px: u32,
+        max_y_px: u32,
+        cell_width_px: u16,
+        cell_height_px: u16,
+    ) -> (u32, u32) {
+        (
+            pan_cell_origin_px(self.cells_x, cell_width_px, max_x_px),
+            pan_cell_origin_px(self.cells_y, cell_height_px, max_y_px),
+        )
+    }
+}
+
+fn max_pan_cells(max_px: u32, cell_px: u16) -> i32 {
+    (max_px / u32::from(cell_px.max(1))).min(i32::MAX as u32) as i32
+}
+
+fn pan_cell_origin_px(cells: i32, cell_px: u16, max_px: u32) -> u32 {
+    u32::try_from(cells)
+        .unwrap_or(0)
+        .saturating_mul(u32::from(cell_px.max(1)))
+        .min(max_px)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PresenterCaps {
     pub backend_name: &'static str,
@@ -334,5 +375,49 @@ pub fn combine_feedback(left: PresenterFeedback, right: PresenterFeedback) -> Pr
             PresenterFeedback::Pending
         }
         (PresenterFeedback::None, PresenterFeedback::None) => PresenterFeedback::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PanOffset;
+
+    #[test]
+    fn pan_pixel_bounds_cap_cells_before_signed_overflow() {
+        let mut pan = PanOffset {
+            cells_x: i32::MAX,
+            cells_y: i32::MAX,
+        };
+
+        pan.clamp_to_pixel_bounds(u32::MAX, u32::MAX, 1, 1);
+
+        assert_eq!(pan.cells_x, i32::MAX);
+        assert_eq!(pan.cells_y, i32::MAX);
+    }
+
+    #[test]
+    fn pan_pixel_origin_saturates_before_unsigned_overflow() {
+        let pan = PanOffset {
+            cells_x: i32::MAX,
+            cells_y: i32::MAX,
+        };
+
+        let origin = pan.pixel_origin(u32::MAX, u32::MAX, 3, 3);
+
+        assert_eq!(origin, (u32::MAX, u32::MAX));
+    }
+
+    #[test]
+    fn pan_pixel_bounds_clamp_negative_cells_to_zero() {
+        let mut pan = PanOffset {
+            cells_x: -1,
+            cells_y: -2,
+        };
+
+        pan.clamp_to_pixel_bounds(100, 200, 10, 20);
+        let origin = pan.pixel_origin(100, 200, 10, 20);
+
+        assert_eq!(pan, PanOffset::default());
+        assert_eq!(origin, (0, 0));
     }
 }


### PR DESCRIPTION
## Summary

- centralize pan clamping and pixel-origin conversion on PanOffset
- avoid lossy u32-to-i32 pan bound casts in spread canvas and frame cropping
- add oversized canvas and pan-boundary regression tests

Fixes #100.

## Verification

- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced pan offset clamping to correctly handle extreme viewport values and prevent integer overflow in edge cases

* **Refactor**
  * Refactored pan and viewport normalization logic to use a more robust pixel-based clamping approach

* **Tests**
  * Added unit tests for pan clamping edge cases, including maximum integer values and oversized canvas scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->