### PR TITLE
fix(app): preserve requested pan during cache prep

### DIFF
--- a/docs/rendering-pipeline.md
+++ b/docs/rendering-pipeline.md
@@ -80,6 +80,9 @@ Rules:
 - if zoomed content exceeds the viewport, only the visible region is forwarded
 - crop is cell-aligned
 - if the full frame already fits, the uncropped frame is forwarded
+- viewer state stores the requested pan from user commands; crop preparation
+  derives a separate effective pan clamped to the currently available image and
+  viewport bounds
 - zoomed spread-canvas crops still preserve left/right slot identity; a page
   outside the viewport is represented as an inactive slot rather than removing
   that slot from the presenter input
@@ -154,8 +157,9 @@ L2 cache rules:
   entry may temporarily coexist with the currently visible ready frame to avoid
   regressing to a blank viewer
 
-`viewport`, `pan`, and `overlay_stamp` are part of the L2 key because terminal
-output depends on all three.
+`viewport`, effective `pan`, and `overlay_stamp` are part of the L2 key because
+terminal output depends on all three. The requested pan stored in viewer state
+is not rewritten by cache preparation.
 
 ## Presenter draw contract
 

--- a/src/app/frame_ops.rs
+++ b/src/app/frame_ops.rs
@@ -75,6 +75,27 @@ pub(crate) fn prepare_presenter_frame(
     (frame, *pan)
 }
 
+pub(crate) fn effective_pan_for_viewport(
+    frame: &RgbaFrame,
+    viewport: Viewport,
+    pan: PanOffset,
+    cell_px: Option<(u16, u16)>,
+    enable_crop: bool,
+) -> PanOffset {
+    if !enable_crop {
+        return PanOffset::default();
+    }
+
+    let (cell_width_px, cell_height_px) = resolved_cell_size_px(cell_px);
+    let target_width = (viewport.width.max(1) as u32).saturating_mul(cell_width_px as u32);
+    let target_height = (viewport.height.max(1) as u32).saturating_mul(cell_height_px as u32);
+    let max_x = frame.width.saturating_sub(target_width);
+    let max_y = frame.height.saturating_sub(target_height);
+    let mut effective_pan = pan;
+    effective_pan.clamp_to_pixel_bounds(max_x, max_y, cell_width_px, cell_height_px);
+    effective_pan
+}
+
 pub(crate) fn crop_frame_for_viewport(
     frame: &RgbaFrame,
     viewport: Viewport,

--- a/src/app/runtime/mod.rs
+++ b/src/app/runtime/mod.rs
@@ -175,12 +175,16 @@ impl RenderRuntime {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use ratatui::layout::Rect;
 
     use super::*;
-    use crate::backend::OutlineNode;
+    use crate::backend::{OutlineNode, PdfRect};
     use crate::error::AppResult;
-    use crate::highlight::HighlightOverlaySnapshot;
+    use crate::highlight::{
+        HighlightOverlaySnapshot, HighlightSource, HighlightSpan, HighlightStyle,
+    };
     use crate::presenter::{
         ImagePresenter, PanOffset, PresenterCaps, PresenterFeedback, PresenterRenderOutcome,
         PresenterRenderSlot, PresenterSlot, Viewport,
@@ -194,6 +198,7 @@ mod tests {
         prepared_viewports: Vec<Viewport>,
         prepared_frame_sizes: Vec<(u32, u32)>,
         prepared_slot_pages: Vec<Option<usize>>,
+        last_prepare_pans: Vec<PanOffset>,
     }
 
     impl ImagePresenter for TestPresenter {
@@ -202,6 +207,7 @@ mod tests {
                 .iter()
                 .map(|slot| slot.cache_key.map(|key| key.page))
                 .collect();
+            self.last_prepare_pans = slots.iter().map(|slot| slot.pan).collect();
             for slot in slots {
                 let Some(frame) = slot.frame else {
                     continue;
@@ -271,6 +277,53 @@ mod tests {
         }
     }
 
+    struct CountingDimensionsPdf {
+        dimensions_calls: AtomicUsize,
+    }
+
+    impl CountingDimensionsPdf {
+        fn new() -> Self {
+            Self {
+                dimensions_calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl PdfBackend for CountingDimensionsPdf {
+        fn path(&self) -> &std::path::Path {
+            std::path::Path::new("counting-dimensions.pdf")
+        }
+
+        fn doc_id(&self) -> u64 {
+            12
+        }
+
+        fn page_count(&self) -> usize {
+            2
+        }
+
+        fn page_dimensions(&self, _page: usize) -> AppResult<(f32, f32)> {
+            self.dimensions_calls.fetch_add(1, Ordering::Relaxed);
+            Ok((100.0, 100.0))
+        }
+
+        fn render_page(&self, _page: usize, _scale: f32) -> AppResult<RgbaFrame> {
+            Err(AppError::unsupported("not needed in runtime test"))
+        }
+
+        fn extract_text(&self, _page: usize) -> AppResult<String> {
+            Err(AppError::unsupported("not needed in runtime test"))
+        }
+
+        fn extract_positioned_text(&self, _page: usize) -> AppResult<crate::backend::TextPage> {
+            Err(AppError::unsupported("not needed in runtime test"))
+        }
+
+        fn extract_outline(&self) -> AppResult<Vec<OutlineNode>> {
+            Err(AppError::unsupported("not needed in runtime test"))
+        }
+    }
+
     fn prepare_spread_canvas(
         runtime: &mut RenderRuntime,
         doc: &TwoPageRuntimePdf,
@@ -293,18 +346,12 @@ mod tests {
             },
         )? {
             CachePrepareResult::Prepared(prepared) => {
-                *pan = prepared.pan();
                 let areas = prepared.render_areas();
                 let slots = prepared.presenter_slots(1);
                 presenter.prepare_slots(&slots)?;
                 Ok(Some(areas))
             }
-            CachePrepareResult::Miss {
-                pan: normalized_pan,
-            } => {
-                *pan = normalized_pan;
-                Ok(None)
-            }
+            CachePrepareResult::Miss => Ok(None),
         }
     }
 
@@ -328,18 +375,30 @@ mod tests {
             },
         )? {
             CachePrepareResult::Prepared(prepared) => {
-                *pan = prepared.pan();
                 let slots = prepared.presenter_slots(1);
                 presenter.prepare_slots(&slots)?;
                 Ok(true)
             }
-            CachePrepareResult::Miss {
-                pan: normalized_pan,
-            } => {
-                *pan = normalized_pan;
-                Ok(false)
-            }
+            CachePrepareResult::Miss => Ok(false),
         }
+    }
+
+    fn two_page_highlight_overlay() -> HighlightOverlaySnapshot {
+        HighlightOverlaySnapshot::new(
+            (0..2)
+                .map(|page| HighlightSpan {
+                    source: HighlightSource::Search,
+                    page,
+                    rects: vec![PdfRect {
+                        x0: 0.0,
+                        y0: 0.0,
+                        x1: 10.0,
+                        y1: 10.0,
+                    }],
+                    style: HighlightStyle::SEARCH_HIT,
+                })
+                .collect(),
+        )
     }
 
     #[test]
@@ -550,7 +609,10 @@ mod tests {
         let doc = TwoPageRuntimePdf;
         let mut runtime = RenderRuntime::default();
         let mut presenter = TestPresenter::default();
-        let mut pan = PanOffset::default();
+        let mut pan = PanOffset {
+            cells_x: -3,
+            cells_y: -7,
+        };
 
         let areas = prepare_spread_canvas(
             &mut runtime,
@@ -574,11 +636,18 @@ mod tests {
         .expect("spread canvas prepare should pass");
 
         assert_eq!(areas, None);
+        assert_eq!(
+            pan,
+            PanOffset {
+                cells_x: -3,
+                cells_y: -7
+            }
+        );
         assert!(presenter.prepared_slot_pages.is_empty());
     }
 
     #[test]
-    fn page_slots_clamp_negative_pan_before_saving_state() {
+    fn page_slots_keep_requested_negative_pan_while_presenting_effective_pan() {
         let doc = TwoPageRuntimePdf;
         let mut runtime = RenderRuntime::default();
         let mut presenter = TestPresenter::default();
@@ -623,8 +692,77 @@ mod tests {
                 .expect("page slot prepare should pass");
 
         assert!(prepared);
-        assert_eq!(pan, PanOffset::default());
+        assert_eq!(
+            pan,
+            PanOffset {
+                cells_x: -3,
+                cells_y: -7
+            }
+        );
+        assert_eq!(
+            presenter.last_prepare_pans,
+            vec![PanOffset::default(), PanOffset::default()]
+        );
         assert_eq!(presenter.prepared_slot_pages, vec![Some(0), Some(1)]);
+    }
+
+    #[test]
+    fn page_slots_prepare_clamped_pan_once_per_cached_slot() {
+        let doc = CountingDimensionsPdf::new();
+        let mut runtime = RenderRuntime::default();
+        let overlay = two_page_highlight_overlay();
+        for page in 0..2 {
+            runtime.l1_cache.insert(
+                RenderedPageKey::new(doc.doc_id(), page, 1.0),
+                RgbaFrame {
+                    width: 100,
+                    height: 100,
+                    pixels: vec![page as u8; 100 * 100 * 4].into(),
+                },
+                false,
+            );
+        }
+        let page_slots = [
+            (
+                Some(RenderedPageKey::new(doc.doc_id(), 0, 1.0)),
+                Viewport {
+                    x: 0,
+                    y: 0,
+                    width: 5,
+                    height: 5,
+                },
+            ),
+            (
+                Some(RenderedPageKey::new(doc.doc_id(), 1, 1.0)),
+                Viewport {
+                    x: 5,
+                    y: 0,
+                    width: 5,
+                    height: 5,
+                },
+            ),
+        ];
+
+        let result = runtime
+            .prepare_page_slots_from_cache(
+                &doc,
+                PageSlotPrepareRequest {
+                    page_slots: &page_slots,
+                    pan: PanOffset {
+                        cells_x: -3,
+                        cells_y: -7,
+                    },
+                    options: FramePrepareOptions {
+                        cell_px: Some((10, 10)),
+                        crop: true,
+                        overlay: &overlay,
+                    },
+                },
+            )
+            .expect("page slot prepare should pass");
+
+        assert!(matches!(result, CachePrepareResult::Prepared(_)));
+        assert_eq!(doc.dimensions_calls.load(Ordering::Relaxed), 2);
     }
 
     #[test]
@@ -641,7 +779,10 @@ mod tests {
             },
             false,
         );
-        let mut pan = PanOffset::default();
+        let mut pan = PanOffset {
+            cells_x: -3,
+            cells_y: -7,
+        };
         let page_slots = [
             (
                 Some(RenderedPageKey::new(doc.doc_id(), 0, 1.0)),
@@ -668,6 +809,17 @@ mod tests {
                 .expect("page slot prepare should pass");
 
         assert!(prepared);
+        assert_eq!(
+            pan,
+            PanOffset {
+                cells_x: -3,
+                cells_y: -7
+            }
+        );
+        assert_eq!(
+            presenter.last_prepare_pans,
+            vec![PanOffset::default(), PanOffset::default()]
+        );
         assert_eq!(presenter.prepared_slot_pages, vec![None, Some(1)]);
     }
 
@@ -676,7 +828,10 @@ mod tests {
         let doc = TwoPageRuntimePdf;
         let mut runtime = RenderRuntime::default();
         let mut presenter = TestPresenter::default();
-        let mut pan = PanOffset::default();
+        let mut pan = PanOffset {
+            cells_x: -3,
+            cells_y: -7,
+        };
         let page_slots = [(
             Some(RenderedPageKey::new(doc.doc_id(), 0, 1.0)),
             Viewport {
@@ -692,6 +847,13 @@ mod tests {
                 .expect("page slot prepare should pass");
 
         assert!(!prepared);
+        assert_eq!(
+            pan,
+            PanOffset {
+                cells_x: -3,
+                cells_y: -7
+            }
+        );
         assert!(presenter.prepared_slot_pages.is_empty());
     }
 }

--- a/src/app/runtime/prepare.rs
+++ b/src/app/runtime/prepare.rs
@@ -11,7 +11,8 @@ use crate::render::cache::RenderedPageKey;
 use crate::work::WorkClass;
 
 use super::super::frame_ops::{
-    PageRenderSpace, apply_highlight_overlay, crop_frame_region, prepare_presenter_frame,
+    PageRenderSpace, apply_highlight_overlay, crop_frame_region, effective_pan_for_viewport,
+    prepare_presenter_frame,
 };
 use super::super::state::VisiblePageSlots;
 use super::RenderRuntime;
@@ -70,26 +71,35 @@ pub(crate) struct PrefetchEncodeRequest {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CachePrepareResult<T> {
     Prepared(T),
-    Miss { pan: PanOffset },
+    Miss,
 }
 
 pub(crate) struct PreparedPresenterSlots {
     slots: Vec<Option<PreparedPresenterSlot>>,
-    pan: PanOffset,
+    #[cfg(test)]
+    effective_pan: PanOffset,
 }
 
 impl PreparedPresenterSlots {
-    fn new(slots: Vec<Option<PreparedPresenterSlot>>, pan: PanOffset) -> Self {
-        Self { slots, pan }
+    fn new(
+        slots: Vec<Option<PreparedPresenterSlot>>,
+        #[cfg_attr(not(test), allow(unused_variables))] effective_pan: PanOffset,
+    ) -> Self {
+        Self {
+            slots,
+            #[cfg(test)]
+            effective_pan,
+        }
     }
 
     #[cfg(test)]
-    fn single(slot: PreparedPresenterSlot, pan: PanOffset) -> Self {
-        Self::new(vec![Some(slot)], pan)
+    fn single(slot: PreparedPresenterSlot, effective_pan: PanOffset) -> Self {
+        Self::new(vec![Some(slot)], effective_pan)
     }
 
-    pub(crate) fn pan(&self) -> PanOffset {
-        self.pan
+    #[cfg(test)]
+    pub(crate) fn effective_pan(&self) -> PanOffset {
+        self.effective_pan
     }
 
     pub(crate) fn presenter_slots(&self, generation: u64) -> Vec<PresenterSlot<'_>> {
@@ -103,7 +113,6 @@ impl PreparedPresenterSlots {
 pub(crate) struct PreparedSpreadCanvas {
     presenter_slots: [Option<PreparedPresenterSlot>; 2],
     render_slots: [PreparedRenderSlot; 2],
-    pan: PanOffset,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -126,10 +135,6 @@ impl PreparedRenderSlot {
 }
 
 impl PreparedSpreadCanvas {
-    pub(crate) fn pan(&self) -> PanOffset {
-        self.pan
-    }
-
     #[cfg(test)]
     pub(crate) fn render_areas(&self) -> [Option<Rect>; 2] {
         self.render_slots
@@ -171,6 +176,12 @@ struct PreparedPresenterSlot {
     viewport: Viewport,
     pan: PanOffset,
     overlay_stamp: u64,
+}
+
+struct CachedPageSlot {
+    key: RenderedPageKey,
+    frame: RgbaFrame,
+    viewport: Viewport,
 }
 
 struct CachedDecoratedPage {
@@ -229,20 +240,10 @@ impl RenderRuntime {
         doc: &dyn PdfBackend,
         request: PageSlotPrepareRequest<'_>,
     ) -> AppResult<CachePrepareResult<PreparedPresenterSlots>> {
-        let Some(mut prepared) = self.build_page_slots_from_cache(doc, request)? else {
+        let Some(prepared) = self.build_page_slots_from_cache(doc, request)? else {
             self.perf_stats.set_l1_hit_rate(self.l1_cache.hit_rate());
-            return Ok(CachePrepareResult::Miss { pan: request.pan });
+            return Ok(CachePrepareResult::Miss);
         };
-
-        if prepared.pan != request.pan {
-            let normalized_request = PageSlotPrepareRequest {
-                pan: prepared.pan,
-                ..request
-            };
-            if let Some(rebuilt) = self.build_page_slots_from_cache(doc, normalized_request)? {
-                prepared = rebuilt;
-            }
-        }
 
         Ok(CachePrepareResult::Prepared(prepared))
     }
@@ -306,12 +307,11 @@ impl RenderRuntime {
         }
 
         if presenter_slots.iter().all(Option::is_none) {
-            return Ok(CachePrepareResult::Miss { pan: layout.pan });
+            return Ok(CachePrepareResult::Miss);
         }
         Ok(CachePrepareResult::Prepared(PreparedSpreadCanvas {
             presenter_slots,
             render_slots,
-            pan: layout.pan,
         }))
     }
 
@@ -356,46 +356,76 @@ impl RenderRuntime {
         doc: &dyn PdfBackend,
         request: PageSlotPrepareRequest<'_>,
     ) -> AppResult<Option<PreparedPresenterSlots>> {
-        let mut prepared = Vec::new();
-        let mut normalized_pan = PanOffset {
-            cells_x: request.pan.cells_x.max(0),
-            cells_y: request.pan.cells_y.max(0),
-        };
-        let mut saw_cached_page = false;
+        let mut cached = Vec::with_capacity(request.page_slots.len());
+        let mut effective_pan: Option<PanOffset> = None;
 
         for (key, viewport) in request.page_slots {
             let Some(key) = *key else {
-                prepared.push(None);
+                cached.push(None);
                 continue;
             };
             let Some(frame) = self.l1_cache.get(&key) else {
+                cached.push(None);
+                continue;
+            };
+            let frame = frame.clone();
+            let slot_effective_pan = effective_pan_for_viewport(
+                &frame,
+                *viewport,
+                request.pan,
+                request.options.cell_px,
+                request.options.crop,
+            );
+            effective_pan = Some(match effective_pan {
+                Some(pan) => PanOffset {
+                    cells_x: pan.cells_x.min(slot_effective_pan.cells_x),
+                    cells_y: pan.cells_y.min(slot_effective_pan.cells_y),
+                },
+                None => slot_effective_pan,
+            });
+            cached.push(Some(CachedPageSlot {
+                key,
+                frame,
+                viewport: *viewport,
+            }));
+        }
+
+        let Some(effective_pan) = effective_pan else {
+            self.perf_stats.set_l1_hit_rate(self.l1_cache.hit_rate());
+            return Ok(None);
+        };
+
+        let mut prepared = Vec::with_capacity(cached.len());
+        for slot in cached {
+            let Some(slot) = slot else {
                 prepared.push(None);
                 continue;
             };
-            saw_cached_page = true;
-            let (frame, overlay_stamp) =
-                decorate_single_page_frame(doc, key.page, frame, request.options.overlay);
-            let mut slot_pan = request.pan;
+            let (frame, overlay_stamp) = decorate_single_page_frame(
+                doc,
+                slot.key.page,
+                &slot.frame,
+                request.options.overlay,
+            );
+            let mut slot_pan = effective_pan;
             let (frame, pan_for_presenter) = prepare_presenter_frame(
                 &frame,
-                *viewport,
+                slot.viewport,
                 &mut slot_pan,
                 request.options.cell_px,
                 request.options.crop,
             );
-            normalized_pan.cells_x = normalized_pan.cells_x.min(slot_pan.cells_x);
-            normalized_pan.cells_y = normalized_pan.cells_y.min(slot_pan.cells_y);
             prepared.push(Some(PreparedPresenterSlot {
-                cache_key: key,
+                cache_key: slot.key,
                 frame,
-                viewport: *viewport,
+                viewport: slot.viewport,
                 pan: pan_for_presenter,
                 overlay_stamp,
             }));
         }
 
         self.perf_stats.set_l1_hit_rate(self.l1_cache.hit_rate());
-        Ok(saw_cached_page.then(|| PreparedPresenterSlots::new(prepared, normalized_pan)))
+        Ok(Some(PreparedPresenterSlots::new(prepared, effective_pan)))
     }
 
     fn cached_decorated_page(

--- a/src/app/tests/runtime_worker.rs
+++ b/src/app/tests/runtime_worker.rs
@@ -208,7 +208,7 @@ fn prepare_current_page_updates_l1_and_presenter_metrics() {
             },
         )
         .and_then(|prepared| {
-            pan = prepared.pan();
+            pan = prepared.effective_pan();
             let slots = prepared.presenter_slots(0);
             presenter.prepare_slots(&slots)
         })
@@ -229,7 +229,7 @@ fn prepare_current_page_updates_l1_and_presenter_metrics() {
             },
         )
         .and_then(|prepared| {
-            pan = prepared.pan();
+            pan = prepared.effective_pan();
             let slots = prepared.presenter_slots(0);
             presenter.prepare_slots(&slots)
         })
@@ -301,7 +301,7 @@ fn prepare_current_page_uses_zero_overlay_stamp_when_decoration_falls_back() {
             },
         )
         .and_then(|prepared| {
-            pan = prepared.pan();
+            pan = prepared.effective_pan();
             let slots = prepared.presenter_slots(0);
             presenter.prepare_slots(&slots)
         })

--- a/src/app/view_ops/mod.rs
+++ b/src/app/view_ops/mod.rs
@@ -282,7 +282,7 @@ impl FrameCachePreparer<'_> {
         page: usize,
         full_scale: f32,
         initial_preview: Option<&InitialPreviewPlan>,
-        pan: &mut PanOffset,
+        requested_pan: PanOffset,
         enable_crop: bool,
     ) -> AppResult<Option<(PresenterRenderMode, Vec<PresenterRenderSlot>)>> {
         let attempts = initial_preview.map_or_else(
@@ -313,12 +313,11 @@ impl FrameCachePreparer<'_> {
                 self.pdf,
                 PageSlotPrepareRequest {
                     page_slots: &page_slots,
-                    pan: *pan,
+                    pan: requested_pan,
                     options,
                 },
             )?;
             if let CachePrepareResult::Prepared(prepared) = result {
-                *pan = prepared.pan();
                 let presenter_slots = prepared.presenter_slots(self.generation);
                 self.presenter.prepare_slots(&presenter_slots)?;
                 return Ok(Some((
@@ -341,7 +340,7 @@ impl FrameCachePreparer<'_> {
         viewport: Viewport,
         slot_areas: SpreadSlotAreas,
         draw_plan: &RenderFrameDrawPlan,
-        pan: &mut PanOffset,
+        requested_pan: PanOffset,
     ) -> AppResult<Option<(PresenterRenderMode, Vec<PresenterRenderSlot>)>> {
         let attempts = draw_plan.initial_preview.as_ref().map_or_else(
             || vec![(PresenterRenderMode::Full, draw_plan.current_scale)],
@@ -358,7 +357,7 @@ impl FrameCachePreparer<'_> {
                 slot_areas,
                 draw_plan,
                 scale,
-                pan,
+                requested_pan,
                 render_mode,
             )? {
                 return Ok(Some((render_mode, render_slots)));
@@ -374,7 +373,7 @@ impl FrameCachePreparer<'_> {
         slot_areas: SpreadSlotAreas,
         draw_plan: &RenderFrameDrawPlan,
         scale: f32,
-        pan: &mut PanOffset,
+        requested_pan: PanOffset,
         render_mode: PresenterRenderMode,
     ) -> AppResult<Option<Vec<PresenterRenderSlot>>> {
         if draw_plan.enable_crop {
@@ -384,7 +383,7 @@ impl FrameCachePreparer<'_> {
                     viewport,
                     visible_pages: draw_plan.visible_pages,
                     scale,
-                    pan: *pan,
+                    pan: requested_pan,
                     cell_px: self.cell_px,
                     overlay: self.highlight_overlay,
                     gap_px: draw_plan.spread_gap_px,
@@ -392,18 +391,12 @@ impl FrameCachePreparer<'_> {
             )?;
             return match result {
                 CachePrepareResult::Prepared(prepared) => {
-                    *pan = prepared.pan();
                     let render_slots = prepared.render_slots(render_mode);
                     let presenter_slots = prepared.presenter_slots(self.generation);
                     self.presenter.prepare_slots(&presenter_slots)?;
                     Ok(Some(render_slots))
                 }
-                CachePrepareResult::Miss {
-                    pan: normalized_pan,
-                } => {
-                    *pan = normalized_pan;
-                    Ok(None)
-                }
+                CachePrepareResult::Miss => Ok(None),
             };
         }
 
@@ -417,12 +410,11 @@ impl FrameCachePreparer<'_> {
             self.pdf,
             PageSlotPrepareRequest {
                 page_slots: &page_slots,
-                pan: *pan,
+                pan: requested_pan,
                 options,
             },
         )?;
         if let CachePrepareResult::Prepared(prepared) = result {
-            *pan = prepared.pan();
             let presenter_slots = prepared.presenter_slots(self.generation);
             self.presenter.prepare_slots(&presenter_slots)?;
             let options = PresenterRenderOptions::new(false, render_mode);
@@ -469,7 +461,7 @@ impl RenderSubsystem {
         pdf: &dyn PdfBackend,
         draw_plan: RenderFrameDrawPlan,
     ) -> AppResult<RenderFrameFeedback> {
-        let mut pan = draw_plan.pan;
+        let requested_pan = draw_plan.pan;
         let mut render_failed = false;
         let mut render_feedback = PresenterFeedback::None;
         let mut viewer_has_image = self.viewer_has_image;
@@ -510,14 +502,14 @@ impl RenderSubsystem {
                         draw_plan.visible_pages.anchor_page,
                         draw_plan.current_scale,
                         draw_plan.initial_preview.as_ref(),
-                        &mut pan,
+                        requested_pan,
                         draw_plan.enable_crop,
                     ),
                     PageLayoutMode::Spread => preparer.prepare_spread_or_preview_from_cache(
                         viewport,
                         spread_slot_areas,
                         &draw_plan,
-                        &mut pan,
+                        requested_pan,
                     ),
                 }
             };
@@ -653,7 +645,7 @@ impl RenderSubsystem {
         })?;
 
         Ok(RenderFrameFeedback {
-            pan,
+            pan: requested_pan,
             render_failed,
             render_feedback,
             viewer_has_image,


### PR DESCRIPTION
## Summary
- Keep requested pan in viewer state across cache hit/miss paths, including negative pan.
- Derive a separate effective pan for crop/presenter preparation.
- Avoid repeated rebuild-on-clamp work by computing effective page-slot pan before preparing slots.

## Rationale
Cache preparation should not rewrite user-requested pan based on cache warmth. The presenter still receives clamped effective pan when an image is available.

Closes #99

## Verification
- cargo fmt --check
- TMPDIR=/tmp CARGO_INCREMENTAL=0 cargo test
- TMPDIR=/tmp CARGO_INCREMENTAL=0 cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how viewport pan is managed during rendering pipeline operations and cache preparation.

* **Refactor**
  * Improved internal pan computation and clamping logic for viewport operations.
  * Enhanced test infrastructure to validate pan behavior across cache preparation and rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->