### PR TITLE
fix(backend): make document identity content-sensitive

### DIFF
--- a/docs/rendering-pipeline.md
+++ b/docs/rendering-pipeline.md
@@ -50,6 +50,8 @@ Rules:
 - raster output uses RGBA pixel storage
 - cache identity includes document identity, page identity, scale, and an
   optional layout identity
+- document identity changes when the opened path's PDF bytes change, even if
+  the replacement file has the same byte length
 - render-worker page tasks use layout tag `0` for source-page identity
 - text extraction is a separate backend path used by search
 - raw render cache entries do not include highlight overlays

--- a/src/backend/hayro/document.rs
+++ b/src/backend/hayro/document.rs
@@ -58,7 +58,7 @@ impl PdfDoc {
                 "input is not a valid PDF header",
             ));
         }
-        let doc_id = calculate_doc_id(path, bytes.len());
+        let doc_id = calculate_doc_id(path, bytes.as_slice());
         let pdf = Pdf::new(bytes)
             .map_err(|_| AppError::invalid_argument("failed to parse PDF with hayro"))?;
 
@@ -174,10 +174,10 @@ impl PdfDoc {
         extract_outline_nodes(&self.pdf)
     }
 }
-fn calculate_doc_id(path: &Path, byte_len: usize) -> u64 {
+fn calculate_doc_id(path: &Path, bytes: &[u8]) -> u64 {
     let mut hasher = DefaultHasher::new();
     path.hash(&mut hasher);
-    byte_len.hash(&mut hasher);
+    bytes.hash(&mut hasher);
     hasher.finish()
 }
 

--- a/src/backend/hayro/mod.rs
+++ b/src/backend/hayro/mod.rs
@@ -122,6 +122,40 @@ mod tests {
     }
 
     #[test]
+    fn doc_id_changes_when_same_path_same_size_pdf_content_changes() {
+        let file = unique_temp_path("doc_id_same_size.pdf");
+        let first = build_pdf(&["alpha"]);
+        let second = build_pdf(&["bravo"]);
+        assert_eq!(
+            first.len(),
+            second.len(),
+            "fixture PDFs must be the same byte length"
+        );
+
+        fs::write(&file, first).expect("first test pdf should be created");
+        let first_doc = PdfDoc::open(&file).expect("first pdf should open");
+        let first_doc_id = first_doc.doc_id();
+
+        fs::write(&file, second).expect("second test pdf should replace first");
+        let second_doc = PdfDoc::open(&file).expect("second pdf should open");
+
+        assert_ne!(first_doc_id, second_doc.doc_id());
+        fs::remove_file(&file).expect("test file should be removed");
+    }
+
+    #[test]
+    fn doc_id_is_stable_for_same_path_and_content() {
+        let file = unique_temp_path("doc_id_stable.pdf");
+        fs::write(&file, build_pdf(&["stable"])).expect("test pdf should be created");
+
+        let first = PdfDoc::open(&file).expect("first pdf open should succeed");
+        let second = PdfDoc::open(&file).expect("second pdf open should succeed");
+
+        assert_eq!(first.doc_id(), second.doc_id());
+        fs::remove_file(&file).expect("test file should be removed");
+    }
+
+    #[test]
     fn render_page_rejects_out_of_range_page() {
         let file = unique_temp_path("render.pdf");
         fs::write(&file, build_pdf(&["hello"])).expect("test file should be created");


### PR DESCRIPTION
Rationale:
- Hardens the document identity used by render, search, and outline caches so same-path, same-size PDF replacements do not reuse stale cache entries.
- Addresses #76.

Changes:
- Hash PDF bytes as part of the Hayro document ID instead of only hashing byte length.
- Add regression coverage for same-path same-size content changes and stable IDs for unchanged content.
- Document the content-sensitive identity contract in the rendering pipeline spec.

Verification:
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified rendering pipeline specification for document identity determination.

* **Bug Fixes**
  * Improved document identification to detect PDF content changes even when file sizes remain identical.

* **Tests**
  * Added unit tests validating document identity behavior across file modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->