### PR TITLE
feat(reload): add live PDF reload

### DIFF
--- a/docs/runtime-spec.md
+++ b/docs/runtime-spec.md
@@ -18,12 +18,15 @@ Supported invocations:
 
 ```bash
 pvf <file.pdf>
+pvf --watch <file.pdf>
 ```
 
 Rules:
 
 - Exactly one PDF path argument is required.
 - The document is opened through the default backend factory.
+- `--watch` enables automatic reload of the displayed document when the input
+  file changes.
 - Performance diagnostics are developer tooling and are not part of the public
   viewer CLI. See `performance-diagnostics.md`.
 
@@ -110,6 +113,32 @@ Rules:
   - supported output protocols depend on terminal capability negotiation
   - cold start may temporarily show a lower-resolution preview before the
     current full-resolution view is ready
+
+- Reload
+  - `reload-document` reopens the current PDF path
+  - with `--watch`, the runtime polls the current PDF path and reloads after a
+    short debounce when file metadata settles
+  - reload success replaces the active document, clamps the current page to the
+    new page count, resets render work, clears presenter output cache, and
+    prewarms search text for the new document
+  - active search is submitted again against the new document using the same
+    query and matcher; cached outline data is cleared
+  - reload failure keeps the previous document visible
+  - manual reload failures show an error immediately
+  - `--watch` reload failures retry quietly with short backoff before showing a
+    warning, so a save that temporarily leaves a partial PDF on disk can recover
+    without user action
+  - acceptance cases for `--watch`:
+    - replacing a valid PDF with another valid PDF updates the displayed
+      document without restarting the viewer
+    - replacing a valid PDF with a temporarily invalid file keeps the previous
+      document visible while retrying
+    - replacing that temporarily invalid file with a valid PDF during the retry
+      window updates the viewer and clears retry state
+    - repeated reload failures eventually show a warning instead of retrying
+      forever
+    - a newer file-change request takes precedence over an older failed reload
+      result
 
 ## Default key bindings
 

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -92,6 +92,12 @@ pub struct App {
     pub render: RenderSubsystem,
     pub interaction: InteractionSubsystem,
     pub config: Config,
+    run_options: RunOptions,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RunOptions {
+    pub watch: bool,
 }
 
 impl App {
@@ -126,6 +132,15 @@ impl App {
             ),
             interaction: InteractionSubsystem::default(),
             config,
+            run_options: RunOptions::default(),
         })
+    }
+
+    pub fn set_watch(&mut self, watch: bool) {
+        self.run_options.watch = watch;
+    }
+
+    pub(crate) fn run_options(&self) -> RunOptions {
+        self.run_options
     }
 }

--- a/src/app/event_bus.rs
+++ b/src/app/event_bus.rs
@@ -38,21 +38,20 @@ impl EventBusRuntime {
     }
 
     pub(crate) fn start_input(&mut self, tx: UnboundedSender<DomainEvent>) {
-        self.tasks.push(spawn_input_task(tx));
+        self.push_task(spawn_input_task(tx));
     }
 
     pub(crate) fn start_file_watch(&mut self, path: PathBuf, tx: UnboundedSender<DomainEvent>) {
-        self.tasks.push(spawn_file_watch_task(path, tx));
+        self.push_task(spawn_file_watch_task(path, tx));
     }
 
     pub(crate) fn start_document_reload(
         &mut self,
         path: PathBuf,
-        reason: DocumentReloadReason,
+        request: DocumentReloadRequest,
         tx: UnboundedSender<DomainEvent>,
     ) {
-        self.tasks
-            .push(spawn_document_reload_task(path, reason, tx));
+        self.push_task(spawn_document_reload_task(path, request, tx));
     }
 
     pub(crate) fn start_delayed_document_reload(
@@ -61,14 +60,18 @@ impl EventBusRuntime {
         delay: Duration,
         tx: UnboundedSender<DomainEvent>,
     ) {
-        self.tasks
-            .push(spawn_delayed_document_reload_task(request, delay, tx));
+        self.push_task(spawn_delayed_document_reload_task(request, delay, tx));
     }
 
     pub(crate) fn shutdown(&mut self) {
         for task in self.tasks.drain(..) {
             task.abort();
         }
+    }
+
+    fn push_task(&mut self, task: JoinHandle<()>) {
+        self.tasks.retain(|task| !task.is_finished());
+        self.tasks.push(task);
     }
 }
 
@@ -149,13 +152,14 @@ fn spawn_file_watch_task(path: PathBuf, tx: UnboundedSender<DomainEvent>) -> Joi
 
 fn spawn_document_reload_task(
     path: PathBuf,
-    reason: DocumentReloadReason,
+    request: DocumentReloadRequest,
     tx: UnboundedSender<DomainEvent>,
 ) -> JoinHandle<()> {
     tokio::task::spawn_blocking(move || {
         let result = open_default_backend(&path).map_err(|err| err.to_string());
         let _ = tx.send(DomainEvent::DocumentReloaded(DocumentReloadResult {
-            reason,
+            reason: request.reason,
+            generation: request.generation,
             result,
         }));
     })
@@ -180,7 +184,7 @@ mod tests {
     use tokio::time;
 
     use crate::backend::test_support::{build_pdf, unique_temp_path};
-    use crate::event::{DocumentReloadReason, DomainEvent};
+    use crate::event::{DocumentReloadReason, DocumentReloadRequest, DomainEvent};
 
     use super::EventBusRuntime;
 
@@ -201,6 +205,32 @@ mod tests {
             let (tx, _rx, mut runtime) = EventBusRuntime::spawn_interactive();
             runtime.start_input(tx);
             runtime.shutdown();
+        });
+    }
+
+    #[test]
+    fn starting_task_prunes_finished_handles() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should initialize");
+        runtime.block_on(async {
+            let (tx, mut rx, mut event_runtime) = EventBusRuntime::spawn_headless();
+            event_runtime.start_delayed_document_reload(
+                DocumentReloadRequest::retry(DocumentReloadReason::FileChanged, 1),
+                Duration::ZERO,
+                tx.clone(),
+            );
+            let _ = rx.recv().await.expect("first delayed reload should emit");
+
+            event_runtime.start_delayed_document_reload(
+                DocumentReloadRequest::retry(DocumentReloadReason::FileChanged, 1),
+                Duration::from_secs(60),
+                tx,
+            );
+
+            assert_eq!(event_runtime.tasks.len(), 1);
+            event_runtime.shutdown();
         });
     }
 

--- a/src/app/event_bus.rs
+++ b/src/app/event_bus.rs
@@ -1,8 +1,16 @@
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
 use crossterm::event::EventStream;
 use futures_util::StreamExt;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio::task::JoinHandle;
+use tokio::time::{self, Duration, Instant};
 
+use crate::backend::open_default_backend;
+use crate::event::DocumentReloadReason;
+use crate::event::DocumentReloadRequest;
+use crate::event::DocumentReloadResult;
 use crate::event::DomainEvent;
 
 pub(crate) struct EventBusRuntime {
@@ -33,6 +41,30 @@ impl EventBusRuntime {
         self.tasks.push(spawn_input_task(tx));
     }
 
+    pub(crate) fn start_file_watch(&mut self, path: PathBuf, tx: UnboundedSender<DomainEvent>) {
+        self.tasks.push(spawn_file_watch_task(path, tx));
+    }
+
+    pub(crate) fn start_document_reload(
+        &mut self,
+        path: PathBuf,
+        reason: DocumentReloadReason,
+        tx: UnboundedSender<DomainEvent>,
+    ) {
+        self.tasks
+            .push(spawn_document_reload_task(path, reason, tx));
+    }
+
+    pub(crate) fn start_delayed_document_reload(
+        &mut self,
+        request: DocumentReloadRequest,
+        delay: Duration,
+        tx: UnboundedSender<DomainEvent>,
+    ) {
+        self.tasks
+            .push(spawn_delayed_document_reload_task(request, delay, tx));
+    }
+
     pub(crate) fn shutdown(&mut self) {
         for task in self.tasks.drain(..) {
             task.abort();
@@ -55,8 +87,101 @@ fn spawn_input_task(tx: UnboundedSender<DomainEvent>) -> JoinHandle<()> {
     })
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FileSignature {
+    exists: bool,
+    len: Option<u64>,
+    modified: Option<SystemTime>,
+}
+
+fn file_signature(path: &Path) -> FileSignature {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return FileSignature {
+            exists: false,
+            len: None,
+            modified: None,
+        };
+    };
+    FileSignature {
+        exists: true,
+        len: Some(metadata.len()),
+        modified: metadata.modified().ok(),
+    }
+}
+
+fn spawn_file_watch_task(path: PathBuf, tx: UnboundedSender<DomainEvent>) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        const POLL_INTERVAL: Duration = Duration::from_millis(250);
+        const DEBOUNCE: Duration = Duration::from_millis(500);
+
+        let mut last_seen = file_signature(&path);
+        let mut pending_since: Option<Instant> = None;
+        let mut interval = time::interval(POLL_INTERVAL);
+        interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+
+        loop {
+            interval.tick().await;
+            let current = file_signature(&path);
+            if current != last_seen {
+                last_seen = current;
+                pending_since = Some(Instant::now());
+                continue;
+            }
+
+            let Some(started_at) = pending_since else {
+                continue;
+            };
+            if started_at.elapsed() < DEBOUNCE {
+                continue;
+            }
+            pending_since = None;
+            if tx
+                .send(DomainEvent::ReloadDocument(DocumentReloadRequest::new(
+                    DocumentReloadReason::FileChanged,
+                )))
+                .is_err()
+            {
+                return;
+            }
+        }
+    })
+}
+
+fn spawn_document_reload_task(
+    path: PathBuf,
+    reason: DocumentReloadReason,
+    tx: UnboundedSender<DomainEvent>,
+) -> JoinHandle<()> {
+    tokio::task::spawn_blocking(move || {
+        let result = open_default_backend(&path).map_err(|err| err.to_string());
+        let _ = tx.send(DomainEvent::DocumentReloaded(DocumentReloadResult {
+            reason,
+            result,
+        }));
+    })
+}
+
+fn spawn_delayed_document_reload_task(
+    request: DocumentReloadRequest,
+    delay: Duration,
+    tx: UnboundedSender<DomainEvent>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        time::sleep(delay).await;
+        let _ = tx.send(DomainEvent::ReloadDocument(request));
+    })
+}
+
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::time::Duration;
+
+    use tokio::time;
+
+    use crate::backend::test_support::{build_pdf, unique_temp_path};
+    use crate::event::{DocumentReloadReason, DomainEvent};
+
     use super::EventBusRuntime;
 
     #[test]
@@ -77,5 +202,35 @@ mod tests {
             runtime.start_input(tx);
             runtime.shutdown();
         });
+    }
+
+    #[test]
+    fn file_watch_emits_reload_after_changed_file_settles() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should initialize");
+        let file = unique_temp_path("watch_reload.pdf");
+        fs::write(&file, build_pdf(&["before"])).expect("test pdf should be written");
+
+        runtime.block_on(async {
+            let (tx, mut rx, mut event_runtime) = EventBusRuntime::spawn_headless();
+            event_runtime.start_file_watch(file.clone(), tx);
+            time::sleep(Duration::from_millis(300)).await;
+            fs::write(&file, build_pdf(&["after"])).expect("test pdf should change");
+
+            let event = time::timeout(Duration::from_secs(2), rx.recv())
+                .await
+                .expect("watcher should emit before timeout")
+                .expect("watcher channel should stay open");
+            assert!(matches!(
+                event,
+                DomainEvent::ReloadDocument(request)
+                    if request.reason == DocumentReloadReason::FileChanged && !request.retry
+            ));
+            event_runtime.shutdown();
+        });
+
+        fs::remove_file(&file).expect("test file should be removed");
     }
 }

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -1039,6 +1039,107 @@ mod tests {
     }
 
     #[test]
+    fn document_reload_success_applies_even_when_doc_id_matches() {
+        let tokio_runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should build");
+        let _guard = tokio_runtime.enter();
+        let file = unique_temp_path("reload_same_doc_id.pdf");
+        fs::write(&file, build_pdf(&["same content"])).expect("test pdf should be created");
+        let first =
+            Arc::new(PdfDoc::open(&file).expect("first pdf should open")) as SharedPdfBackend;
+        let second =
+            Arc::new(PdfDoc::open(&file).expect("second pdf should open")) as SharedPdfBackend;
+        assert_eq!(first.doc_id(), second.doc_id());
+        assert!(!Arc::ptr_eq(&first, &second));
+
+        let mut document = ActiveDocument::new(Arc::clone(&first));
+        let mut app =
+            App::new_with_config(PresenterKind::RatatuiImage, Config::default()).expect("app init");
+        let (loop_event_tx, loop_event_rx, loop_event_runtime) =
+            crate::app::event_bus::EventBusRuntime::spawn_headless();
+        let session = StubSession::new(80, 24);
+        let mut runtime = app
+            .initialize_loop_runtime(
+                Arc::clone(&first),
+                first.page_count(),
+                session,
+                loop_event_tx,
+                loop_event_rx,
+                loop_event_runtime,
+            )
+            .expect("runtime should initialize");
+        runtime.ui_actor.clear_redraw();
+        runtime.reload_in_flight = true;
+        runtime.reload_retry_attempts = 2;
+
+        app.handle_waited_event(
+            WaitEvent::Event(DomainEvent::DocumentReloaded(DocumentReloadResult {
+                reason: DocumentReloadReason::Manual,
+                result: Ok(Arc::clone(&second)),
+            })),
+            &mut runtime,
+            &mut document,
+        )
+        .expect("reload result should be handled");
+
+        assert!(Arc::ptr_eq(&document.pdf, &second));
+        assert_eq!(runtime.reload_retry_attempts, 0);
+        assert!(runtime.ui_actor.needs_redraw());
+        fs::remove_file(&file).expect("test file should be removed");
+    }
+
+    #[test]
+    fn document_reload_success_clears_previous_reload_notice() {
+        let tokio_runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should build");
+        let _guard = tokio_runtime.enter();
+        let file = unique_temp_path("reload_clears_notice.pdf");
+        fs::write(&file, build_pdf(&["one"])).expect("first test pdf should be created");
+        let first =
+            Arc::new(PdfDoc::open(&file).expect("first pdf should open")) as SharedPdfBackend;
+        let mut document = ActiveDocument::new(Arc::clone(&first));
+        let mut app =
+            App::new_with_config(PresenterKind::RatatuiImage, Config::default()).expect("app init");
+        app.state
+            .set_warning_notice("Could not reload changed document: still invalid");
+        let (loop_event_tx, loop_event_rx, loop_event_runtime) =
+            crate::app::event_bus::EventBusRuntime::spawn_headless();
+        let session = StubSession::new(80, 24);
+        let mut runtime = app
+            .initialize_loop_runtime(
+                Arc::clone(&first),
+                first.page_count(),
+                session,
+                loop_event_tx,
+                loop_event_rx,
+                loop_event_runtime,
+            )
+            .expect("runtime should initialize");
+        runtime.reload_in_flight = true;
+
+        fs::write(&file, build_pdf(&["two"])).expect("second test pdf should replace first");
+        let second =
+            Arc::new(PdfDoc::open(&file).expect("second pdf should open")) as SharedPdfBackend;
+
+        app.handle_waited_event(
+            WaitEvent::Event(DomainEvent::DocumentReloaded(DocumentReloadResult {
+                reason: DocumentReloadReason::FileChanged,
+                result: Ok(second),
+            })),
+            &mut runtime,
+            &mut document,
+        )
+        .expect("reload result should be handled");
+
+        assert!(app.state.notice.is_none());
+        fs::remove_file(&file).expect("test file should be removed");
+    }
+
+    #[test]
     fn manual_document_reload_failure_keeps_previous_document() {
         let tokio_runtime = Builder::new_current_thread()
             .enable_all()
@@ -1297,6 +1398,69 @@ mod tests {
         assert_eq!(runtime.reload_retry_attempts, 0);
         assert!(app.state.notice.is_none());
         assert!(!runtime.ui_actor.needs_redraw());
+    }
+
+    #[test]
+    fn stale_file_reload_success_yields_to_pending_fresh_reload() {
+        let tokio_runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should build");
+        let _guard = tokio_runtime.enter();
+        let file = unique_temp_path("reload_stale_success.pdf");
+        fs::write(&file, build_pdf(&["one", "two", "three"]))
+            .expect("first test pdf should be created");
+        let first =
+            Arc::new(PdfDoc::open(&file).expect("first pdf should open")) as SharedPdfBackend;
+        let old_doc_id = first.doc_id();
+        let mut document = ActiveDocument::new(Arc::clone(&first));
+        let mut app =
+            App::new_with_config(PresenterKind::RatatuiImage, Config::default()).expect("app init");
+        let (loop_event_tx, loop_event_rx, loop_event_runtime) =
+            crate::app::event_bus::EventBusRuntime::spawn_headless();
+        let session = StubSession::new(80, 24);
+        let mut runtime = app
+            .initialize_loop_runtime(
+                Arc::clone(&first),
+                first.page_count(),
+                session,
+                loop_event_tx,
+                loop_event_rx,
+                loop_event_runtime,
+            )
+            .expect("runtime should initialize");
+        runtime.ui_actor.clear_redraw();
+        runtime.reload_in_flight = true;
+        runtime.reload_retry_attempts = 2;
+        runtime.pending_reload = Some(DocumentReloadRequest::new(
+            DocumentReloadReason::FileChanged,
+        ));
+
+        fs::write(&file, build_pdf(&["stale one", "stale two"]))
+            .expect("second test pdf should replace first");
+        let stale =
+            Arc::new(PdfDoc::open(&file).expect("stale pdf should open")) as SharedPdfBackend;
+        assert_ne!(old_doc_id, stale.doc_id());
+
+        app.handle_waited_event(
+            WaitEvent::Event(DomainEvent::DocumentReloaded(DocumentReloadResult {
+                reason: DocumentReloadReason::FileChanged,
+                result: Ok(stale),
+            })),
+            &mut runtime,
+            &mut document,
+        )
+        .expect("reload result should be handled");
+
+        assert_eq!(document.pdf.doc_id(), old_doc_id);
+        assert!(runtime.reload_in_flight);
+        assert!(runtime.pending_reload.is_none());
+        assert_eq!(runtime.reload_retry_attempts, 0);
+        assert!(app.state.notice.is_none());
+        assert!(!runtime.ui_actor.needs_redraw());
+
+        runtime.loop_event_runtime.shutdown();
+        fs::remove_file(&file).expect("test file should be removed");
     }
 
     #[test]

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -170,6 +170,7 @@ impl App {
             reload_in_flight: false,
             pending_reload: None,
             reload_retry_attempts: 0,
+            reload_generation: 0,
         })
     }
 
@@ -1024,6 +1025,7 @@ mod tests {
         app.handle_waited_event(
             WaitEvent::Event(DomainEvent::DocumentReloaded(DocumentReloadResult {
                 reason: DocumentReloadReason::Manual,
+                generation: 0,
                 result: Ok(second),
             })),
             &mut runtime,
@@ -1077,6 +1079,7 @@ mod tests {
         app.handle_waited_event(
             WaitEvent::Event(DomainEvent::DocumentReloaded(DocumentReloadResult {
                 reason: DocumentReloadReason::Manual,
+                generation: 0,
                 result: Ok(Arc::clone(&second)),
             })),
             &mut runtime,
@@ -1128,6 +1131,7 @@ mod tests {
         app.handle_waited_event(
             WaitEvent::Event(DomainEvent::DocumentReloaded(DocumentReloadResult {
                 reason: DocumentReloadReason::FileChanged,
+                generation: 0,
                 result: Ok(second),
             })),
             &mut runtime,
@@ -1170,6 +1174,7 @@ mod tests {
         app.handle_waited_event(
             WaitEvent::Event(DomainEvent::DocumentReloaded(DocumentReloadResult {
                 reason: DocumentReloadReason::Manual,
+                generation: 0,
                 result: Err("still being written".to_string()),
             })),
             &mut runtime,
@@ -1215,6 +1220,7 @@ mod tests {
         app.handle_waited_event(
             WaitEvent::Event(DomainEvent::DocumentReloaded(DocumentReloadResult {
                 reason: DocumentReloadReason::FileChanged,
+                generation: 0,
                 result: Err("still being written".to_string()),
             })),
             &mut runtime,
@@ -1238,6 +1244,7 @@ mod tests {
             DomainEvent::ReloadDocument(DocumentReloadRequest {
                 reason: DocumentReloadReason::FileChanged,
                 retry: true,
+                ..
             })
         ));
     }
@@ -1274,6 +1281,7 @@ mod tests {
         app.handle_waited_event(
             WaitEvent::Event(DomainEvent::DocumentReloaded(DocumentReloadResult {
                 reason: DocumentReloadReason::FileChanged,
+                generation: 0,
                 result: Err("still invalid after retries".to_string()),
             })),
             &mut runtime,
@@ -1334,6 +1342,7 @@ mod tests {
         app.handle_waited_event(
             WaitEvent::Event(DomainEvent::DocumentReloaded(DocumentReloadResult {
                 reason: DocumentReloadReason::FileChanged,
+                generation: 0,
                 result: Ok(second),
             })),
             &mut runtime,
@@ -1385,6 +1394,7 @@ mod tests {
         app.handle_waited_event(
             WaitEvent::Event(DomainEvent::DocumentReloaded(DocumentReloadResult {
                 reason: DocumentReloadReason::FileChanged,
+                generation: 0,
                 result: Err("stale failure".to_string()),
             })),
             &mut runtime,
@@ -1445,6 +1455,7 @@ mod tests {
         app.handle_waited_event(
             WaitEvent::Event(DomainEvent::DocumentReloaded(DocumentReloadResult {
                 reason: DocumentReloadReason::FileChanged,
+                generation: 0,
                 result: Ok(stale),
             })),
             &mut runtime,
@@ -1461,6 +1472,52 @@ mod tests {
 
         runtime.loop_event_runtime.shutdown();
         fs::remove_file(&file).expect("test file should be removed");
+    }
+
+    #[test]
+    fn old_delayed_retry_after_newer_reload_is_ignored() {
+        let tokio_runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should build");
+        let _guard = tokio_runtime.enter();
+        let pdf = test_pdf_backend();
+        let mut document = ActiveDocument::new(Arc::clone(&pdf));
+        let mut app =
+            App::new_with_config(PresenterKind::RatatuiImage, Config::default()).expect("app init");
+        let (loop_event_tx, loop_event_rx, loop_event_runtime) =
+            crate::app::event_bus::EventBusRuntime::spawn_headless();
+        let session = StubSession::new(80, 24);
+        let mut runtime = app
+            .initialize_loop_runtime(
+                Arc::clone(&pdf),
+                pdf.page_count(),
+                session,
+                loop_event_tx,
+                loop_event_rx,
+                loop_event_runtime,
+            )
+            .expect("runtime should initialize");
+        runtime.reload_generation = 2;
+        runtime.reload_retry_attempts = 3;
+        runtime.ui_actor.clear_redraw();
+
+        app.handle_waited_event(
+            WaitEvent::Event(DomainEvent::ReloadDocument(DocumentReloadRequest::retry(
+                DocumentReloadReason::FileChanged,
+                1,
+            ))),
+            &mut runtime,
+            &mut document,
+        )
+        .expect("stale retry should be handled");
+
+        assert!(!runtime.reload_in_flight);
+        assert!(runtime.pending_reload.is_none());
+        assert_eq!(runtime.reload_generation, 2);
+        assert_eq!(runtime.reload_retry_attempts, 3);
+        assert!(app.state.notice.is_none());
+        assert!(!runtime.ui_actor.needs_redraw());
     }
 
     #[test]

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -12,9 +12,11 @@ use crate::presenter::ImagePresenter;
 use crate::render::worker::RenderWorker;
 
 use super::actors::{InputActor, RenderActor, UiActor};
-use super::core::App;
+use super::core::{App, RunOptions};
 use super::event_bus::EventBusRuntime;
-use super::loop_runtime::{LoopControl, LoopRuntime, LoopStep, SessionRestore, WaitEvent};
+use super::loop_runtime::{
+    ActiveDocument, LoopControl, LoopRuntime, LoopStep, SessionRestore, WaitEvent,
+};
 use super::perf_runner::{
     HeadlessTerminalSession, PERF_HEADLESS_HEIGHT, PERF_HEADLESS_WIDTH, PerfLoopDriver,
 };
@@ -24,16 +26,25 @@ use super::terminal_session::{InteractiveTerminalSession, TerminalSurface};
 
 impl App {
     pub async fn run(&mut self, pdf: SharedPdfBackend) -> AppResult<()> {
+        self.run_with_options(pdf, self.run_options()).await
+    }
+
+    pub async fn run_with_options(
+        &mut self,
+        pdf: SharedPdfBackend,
+        options: RunOptions,
+    ) -> AppResult<()> {
         let page_count = pdf.page_count();
         if page_count == 0 {
             return Err(AppError::invalid_argument("pdf has no pages"));
         }
 
+        let mut document = ActiveDocument::new(pdf);
         let session = InteractiveTerminalSession::enter()?;
         let (loop_event_tx, loop_event_rx, loop_event_runtime) =
             EventBusRuntime::spawn_interactive();
         let mut runtime = self.initialize_loop_runtime(
-            Arc::clone(&pdf),
+            Arc::clone(&document.pdf),
             page_count,
             session,
             loop_event_tx,
@@ -43,7 +54,12 @@ impl App {
         runtime
             .loop_event_runtime
             .start_input(runtime.loop_event_tx.clone());
-        let result = self.run_interactive_loop(&mut runtime, pdf).await;
+        if options.watch {
+            runtime
+                .loop_event_runtime
+                .start_file_watch(document.path.clone(), runtime.loop_event_tx.clone());
+        }
+        let result = self.run_interactive_loop(&mut runtime, &mut document).await;
         runtime.loop_event_runtime.shutdown();
         let restore_result = runtime.session.restore();
         result?;
@@ -151,18 +167,21 @@ impl App {
             loop_event_tx,
             loop_event_rx,
             loop_event_runtime,
+            reload_in_flight: false,
+            pending_reload: None,
+            reload_retry_attempts: 0,
         })
     }
 
     async fn run_interactive_loop(
         &mut self,
         runtime: &mut LoopRuntime<InteractiveTerminalSession>,
-        pdf: SharedPdfBackend,
+        document: &mut ActiveDocument,
     ) -> AppResult<()> {
         loop {
-            let step = self.process_loop_iteration(runtime, pdf.as_ref())?;
+            let step = self.process_loop_iteration(runtime, document.pdf.as_ref())?;
             match self
-                .wait_and_handle_next_event(runtime, &step, Arc::clone(&pdf))
+                .wait_and_handle_next_event(runtime, &step, document)
                 .await?
             {
                 LoopControl::Continue => {}
@@ -180,9 +199,10 @@ impl App {
         cold_started_at: Instant,
     ) -> AppResult<PerfIterationSnapshot> {
         let mut perf_driver = PerfLoopDriver::new(scenario, parameters, cold_started_at);
+        let mut document = ActiveDocument::new(pdf);
 
         loop {
-            let step = self.process_loop_iteration(runtime, pdf.as_ref())?;
+            let step = self.process_loop_iteration(runtime, document.pdf.as_ref())?;
             let system_idle = step.current_cached
                 && runtime.render_worker.in_flight_len() == 0
                 && !self.render.presenter.has_pending_work()
@@ -204,7 +224,7 @@ impl App {
             }
 
             match self
-                .wait_and_handle_next_event(runtime, &step, Arc::clone(&pdf))
+                .wait_and_handle_next_event(runtime, &step, &mut document)
                 .await?
             {
                 LoopControl::Continue => {}
@@ -267,7 +287,7 @@ impl App {
         &mut self,
         runtime: &mut LoopRuntime<S>,
         step: &LoopStep,
-        pdf: SharedPdfBackend,
+        document: &mut ActiveDocument,
     ) -> AppResult<LoopControl>
     where
         S: TerminalSurface + SessionRestore,
@@ -297,7 +317,7 @@ impl App {
             wake_timeout,
         )
         .await;
-        self.handle_waited_event(waited, runtime, pdf)
+        self.handle_waited_event(waited, runtime, document)
     }
 
     fn build_loop_step(
@@ -468,6 +488,7 @@ mod tests {
     use super::{WaitEvent, wait_next_event};
     use crate::app::App;
     use crate::app::core::InteractionSubsystem;
+    use crate::app::loop_runtime::ActiveDocument;
     use crate::app::terminal_session::TerminalSurface;
     use crate::backend::test_support::{build_pdf, unique_temp_path};
     use crate::backend::{PdfDoc, SharedPdfBackend};
@@ -475,7 +496,9 @@ mod tests {
         Command, CommandInvocationSource, CommandRequest, PanAmount, PanDirection,
     };
     use crate::config::Config;
-    use crate::event::DomainEvent;
+    use crate::event::{
+        DocumentReloadReason, DocumentReloadRequest, DocumentReloadResult, DomainEvent,
+    };
     use crate::input::sequence::SequenceRegistry;
     use crate::input::shortcut::ShortcutKey;
     use crate::presenter::PresenterKind;
@@ -785,12 +808,13 @@ mod tests {
                 loop_event_runtime,
             )
             .expect("runtime should initialize");
+        let mut document = ActiveDocument::new(Arc::clone(&pdf));
 
         let control = app
             .handle_waited_event(
                 WaitEvent::Event(DomainEvent::Wake),
                 &mut runtime,
-                Arc::clone(&pdf),
+                &mut document,
             )
             .expect("wake should be handled");
 
@@ -850,6 +874,7 @@ mod tests {
                 loop_event_runtime,
             )
             .expect("runtime should initialize");
+        let mut document = ActiveDocument::new(Arc::clone(&pdf));
 
         let control = app
             .handle_waited_event(
@@ -858,7 +883,7 @@ mod tests {
                     KeyModifiers::NONE,
                 )))),
                 &mut runtime,
-                Arc::clone(&pdf),
+                &mut document,
             )
             .expect("input should be handled");
 
@@ -898,6 +923,7 @@ mod tests {
                 loop_event_runtime,
             )
             .expect("runtime should initialize");
+        let mut document = ActiveDocument::new(Arc::clone(&pdf));
 
         let control = app
             .handle_waited_event(
@@ -906,7 +932,7 @@ mod tests {
                     CommandInvocationSource::Keymap,
                 ))),
                 &mut runtime,
-                Arc::clone(&pdf),
+                &mut document,
             )
             .expect("command error should be handled as a notice");
 
@@ -915,6 +941,362 @@ mod tests {
         assert_eq!(notice.level, crate::app::NoticeLevel::Warning);
         assert_eq!(notice.message, "page 999 is out of range (1-1)");
         assert!(runtime.loop_event_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn reload_document_command_starts_reload_without_blocking_loop() {
+        let tokio_runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should build");
+        let _guard = tokio_runtime.enter();
+        let pdf = test_pdf_backend();
+        let mut document = ActiveDocument::new(Arc::clone(&pdf));
+        let mut app =
+            App::new_with_config(PresenterKind::RatatuiImage, Config::default()).expect("app init");
+        let (loop_event_tx, loop_event_rx, loop_event_runtime) =
+            crate::app::event_bus::EventBusRuntime::spawn_headless();
+        let session = StubSession::new(80, 24);
+        let mut runtime = app
+            .initialize_loop_runtime(
+                Arc::clone(&pdf),
+                pdf.page_count(),
+                session,
+                loop_event_tx,
+                loop_event_rx,
+                loop_event_runtime,
+            )
+            .expect("runtime should initialize");
+
+        let control = app
+            .handle_waited_event(
+                WaitEvent::Event(DomainEvent::Command(CommandRequest::new(
+                    Command::ReloadDocument,
+                    CommandInvocationSource::PaletteProvider,
+                ))),
+                &mut runtime,
+                &mut document,
+            )
+            .expect("reload command should be handled");
+
+        assert!(matches!(control, super::LoopControl::Continue));
+        assert!(runtime.reload_in_flight);
+    }
+
+    #[test]
+    fn document_reload_success_replaces_active_document_and_clamps_page() {
+        let tokio_runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should build");
+        let _guard = tokio_runtime.enter();
+        let file = unique_temp_path("reload_success.pdf");
+        fs::write(&file, build_pdf(&["one", "two", "three"]))
+            .expect("first test pdf should be created");
+        let first =
+            Arc::new(PdfDoc::open(&file).expect("first pdf should open")) as SharedPdfBackend;
+        let old_doc_id = first.doc_id();
+        let mut document = ActiveDocument::new(Arc::clone(&first));
+        let mut app =
+            App::new_with_config(PresenterKind::RatatuiImage, Config::default()).expect("app init");
+        app.state.current_page = 2;
+        let (loop_event_tx, loop_event_rx, loop_event_runtime) =
+            crate::app::event_bus::EventBusRuntime::spawn_headless();
+        let session = StubSession::new(80, 24);
+        let mut runtime = app
+            .initialize_loop_runtime(
+                Arc::clone(&first),
+                first.page_count(),
+                session,
+                loop_event_tx,
+                loop_event_rx,
+                loop_event_runtime,
+            )
+            .expect("runtime should initialize");
+        runtime.ui_actor.clear_redraw();
+
+        fs::write(&file, build_pdf(&["new one", "new two"]))
+            .expect("second test pdf should replace first");
+        let second =
+            Arc::new(PdfDoc::open(&file).expect("second pdf should open")) as SharedPdfBackend;
+        assert_ne!(old_doc_id, second.doc_id());
+
+        app.handle_waited_event(
+            WaitEvent::Event(DomainEvent::DocumentReloaded(DocumentReloadResult {
+                reason: DocumentReloadReason::Manual,
+                result: Ok(second),
+            })),
+            &mut runtime,
+            &mut document,
+        )
+        .expect("reload result should be handled");
+
+        assert_ne!(document.pdf.doc_id(), old_doc_id);
+        assert_eq!(runtime.page_count, 2);
+        assert_eq!(app.state.current_page, 1);
+        assert!(runtime.ui_actor.needs_redraw());
+        fs::remove_file(&file).expect("test file should be removed");
+    }
+
+    #[test]
+    fn manual_document_reload_failure_keeps_previous_document() {
+        let tokio_runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should build");
+        let _guard = tokio_runtime.enter();
+        let pdf = test_pdf_backend();
+        let old_doc_id = pdf.doc_id();
+        let mut document = ActiveDocument::new(Arc::clone(&pdf));
+        let mut app =
+            App::new_with_config(PresenterKind::RatatuiImage, Config::default()).expect("app init");
+        let (loop_event_tx, loop_event_rx, loop_event_runtime) =
+            crate::app::event_bus::EventBusRuntime::spawn_headless();
+        let session = StubSession::new(80, 24);
+        let mut runtime = app
+            .initialize_loop_runtime(
+                Arc::clone(&pdf),
+                pdf.page_count(),
+                session,
+                loop_event_tx,
+                loop_event_rx,
+                loop_event_runtime,
+            )
+            .expect("runtime should initialize");
+        runtime.ui_actor.clear_redraw();
+        runtime.reload_in_flight = true;
+
+        app.handle_waited_event(
+            WaitEvent::Event(DomainEvent::DocumentReloaded(DocumentReloadResult {
+                reason: DocumentReloadReason::Manual,
+                result: Err("still being written".to_string()),
+            })),
+            &mut runtime,
+            &mut document,
+        )
+        .expect("reload failure should be handled");
+
+        assert_eq!(document.pdf.doc_id(), old_doc_id);
+        assert!(!runtime.reload_in_flight);
+        let notice = app.state.notice.expect("reload failure should set notice");
+        assert_eq!(notice.level, crate::app::NoticeLevel::Error);
+        assert!(notice.message.contains("still being written"));
+    }
+
+    #[test]
+    fn file_reload_failure_keeps_previous_document_and_retries_quietly() {
+        let tokio_runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should build");
+        let _guard = tokio_runtime.enter();
+        let pdf = test_pdf_backend();
+        let old_doc_id = pdf.doc_id();
+        let mut document = ActiveDocument::new(Arc::clone(&pdf));
+        let mut app =
+            App::new_with_config(PresenterKind::RatatuiImage, Config::default()).expect("app init");
+        let (loop_event_tx, loop_event_rx, loop_event_runtime) =
+            crate::app::event_bus::EventBusRuntime::spawn_headless();
+        let session = StubSession::new(80, 24);
+        let mut runtime = app
+            .initialize_loop_runtime(
+                Arc::clone(&pdf),
+                pdf.page_count(),
+                session,
+                loop_event_tx,
+                loop_event_rx,
+                loop_event_runtime,
+            )
+            .expect("runtime should initialize");
+        runtime.ui_actor.clear_redraw();
+        runtime.reload_in_flight = true;
+
+        app.handle_waited_event(
+            WaitEvent::Event(DomainEvent::DocumentReloaded(DocumentReloadResult {
+                reason: DocumentReloadReason::FileChanged,
+                result: Err("still being written".to_string()),
+            })),
+            &mut runtime,
+            &mut document,
+        )
+        .expect("reload failure should be handled");
+
+        assert_eq!(document.pdf.doc_id(), old_doc_id);
+        assert!(!runtime.reload_in_flight);
+        assert_eq!(runtime.reload_retry_attempts, 1);
+        assert!(app.state.notice.is_none());
+
+        let retry = tokio_runtime
+            .block_on(async {
+                tokio::time::timeout(Duration::from_secs(1), runtime.loop_event_rx.recv()).await
+            })
+            .expect("retry event should arrive")
+            .expect("loop event channel should stay open");
+        assert!(matches!(
+            retry,
+            DomainEvent::ReloadDocument(DocumentReloadRequest {
+                reason: DocumentReloadReason::FileChanged,
+                retry: true,
+            })
+        ));
+    }
+
+    #[test]
+    fn file_reload_failure_after_retry_budget_shows_warning() {
+        let tokio_runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should build");
+        let _guard = tokio_runtime.enter();
+        let pdf = test_pdf_backend();
+        let old_doc_id = pdf.doc_id();
+        let mut document = ActiveDocument::new(Arc::clone(&pdf));
+        let mut app =
+            App::new_with_config(PresenterKind::RatatuiImage, Config::default()).expect("app init");
+        let (loop_event_tx, loop_event_rx, loop_event_runtime) =
+            crate::app::event_bus::EventBusRuntime::spawn_headless();
+        let session = StubSession::new(80, 24);
+        let mut runtime = app
+            .initialize_loop_runtime(
+                Arc::clone(&pdf),
+                pdf.page_count(),
+                session,
+                loop_event_tx,
+                loop_event_rx,
+                loop_event_runtime,
+            )
+            .expect("runtime should initialize");
+        runtime.ui_actor.clear_redraw();
+        runtime.reload_in_flight = true;
+        runtime.reload_retry_attempts = 5;
+
+        app.handle_waited_event(
+            WaitEvent::Event(DomainEvent::DocumentReloaded(DocumentReloadResult {
+                reason: DocumentReloadReason::FileChanged,
+                result: Err("still invalid after retries".to_string()),
+            })),
+            &mut runtime,
+            &mut document,
+        )
+        .expect("reload failure should be handled");
+
+        assert_eq!(document.pdf.doc_id(), old_doc_id);
+        assert!(!runtime.reload_in_flight);
+        assert_eq!(runtime.reload_retry_attempts, 5);
+        assert!(runtime.ui_actor.needs_redraw());
+        let notice = app.state.notice.expect("reload failure should set notice");
+        assert_eq!(notice.level, crate::app::NoticeLevel::Warning);
+        assert!(notice.message.contains("still invalid after retries"));
+        assert!(runtime.loop_event_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn file_reload_success_after_retries_replaces_document_and_resets_retry_count() {
+        let tokio_runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should build");
+        let _guard = tokio_runtime.enter();
+        let file = unique_temp_path("reload_retry_success.pdf");
+        fs::write(&file, build_pdf(&["one", "two", "three"]))
+            .expect("first test pdf should be created");
+        let first =
+            Arc::new(PdfDoc::open(&file).expect("first pdf should open")) as SharedPdfBackend;
+        let old_doc_id = first.doc_id();
+        let mut document = ActiveDocument::new(Arc::clone(&first));
+        let mut app =
+            App::new_with_config(PresenterKind::RatatuiImage, Config::default()).expect("app init");
+        app.state.current_page = 2;
+        let (loop_event_tx, loop_event_rx, loop_event_runtime) =
+            crate::app::event_bus::EventBusRuntime::spawn_headless();
+        let session = StubSession::new(80, 24);
+        let mut runtime = app
+            .initialize_loop_runtime(
+                Arc::clone(&first),
+                first.page_count(),
+                session,
+                loop_event_tx,
+                loop_event_rx,
+                loop_event_runtime,
+            )
+            .expect("runtime should initialize");
+        runtime.ui_actor.clear_redraw();
+        runtime.reload_in_flight = true;
+        runtime.reload_retry_attempts = 3;
+
+        fs::write(&file, build_pdf(&["new one", "new two"]))
+            .expect("second test pdf should replace first");
+        let second =
+            Arc::new(PdfDoc::open(&file).expect("second pdf should open")) as SharedPdfBackend;
+        assert_ne!(old_doc_id, second.doc_id());
+
+        app.handle_waited_event(
+            WaitEvent::Event(DomainEvent::DocumentReloaded(DocumentReloadResult {
+                reason: DocumentReloadReason::FileChanged,
+                result: Ok(second),
+            })),
+            &mut runtime,
+            &mut document,
+        )
+        .expect("reload result should be handled");
+
+        assert_ne!(document.pdf.doc_id(), old_doc_id);
+        assert_eq!(runtime.page_count, 2);
+        assert_eq!(app.state.current_page, 1);
+        assert_eq!(runtime.reload_retry_attempts, 0);
+        assert!(app.state.notice.is_none());
+        assert!(runtime.ui_actor.needs_redraw());
+        fs::remove_file(&file).expect("test file should be removed");
+    }
+
+    #[test]
+    fn stale_file_reload_failure_yields_to_pending_fresh_reload() {
+        let tokio_runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should build");
+        let _guard = tokio_runtime.enter();
+        let pdf = test_pdf_backend();
+        let old_doc_id = pdf.doc_id();
+        let mut document = ActiveDocument::new(Arc::clone(&pdf));
+        let mut app =
+            App::new_with_config(PresenterKind::RatatuiImage, Config::default()).expect("app init");
+        let (loop_event_tx, loop_event_rx, loop_event_runtime) =
+            crate::app::event_bus::EventBusRuntime::spawn_headless();
+        let session = StubSession::new(80, 24);
+        let mut runtime = app
+            .initialize_loop_runtime(
+                Arc::clone(&pdf),
+                pdf.page_count(),
+                session,
+                loop_event_tx,
+                loop_event_rx,
+                loop_event_runtime,
+            )
+            .expect("runtime should initialize");
+        runtime.ui_actor.clear_redraw();
+        runtime.reload_in_flight = true;
+        runtime.reload_retry_attempts = 2;
+        runtime.pending_reload = Some(DocumentReloadRequest::new(
+            DocumentReloadReason::FileChanged,
+        ));
+
+        app.handle_waited_event(
+            WaitEvent::Event(DomainEvent::DocumentReloaded(DocumentReloadResult {
+                reason: DocumentReloadReason::FileChanged,
+                result: Err("stale failure".to_string()),
+            })),
+            &mut runtime,
+            &mut document,
+        )
+        .expect("reload failure should be handled");
+
+        assert_eq!(document.pdf.doc_id(), old_doc_id);
+        assert!(runtime.reload_in_flight);
+        assert!(runtime.pending_reload.is_none());
+        assert_eq!(runtime.reload_retry_attempts, 0);
+        assert!(app.state.notice.is_none());
+        assert!(!runtime.ui_actor.needs_redraw());
     }
 
     #[test]
@@ -941,6 +1323,7 @@ mod tests {
             )
             .expect("runtime should initialize");
         runtime.loop_event_rx.close();
+        let mut document = ActiveDocument::new(Arc::clone(&pdf));
 
         let control = app
             .handle_waited_event(
@@ -949,7 +1332,7 @@ mod tests {
                     CommandInvocationSource::Keymap,
                 ))),
                 &mut runtime,
-                Arc::clone(&pdf),
+                &mut document,
             )
             .expect("command should be handled");
 
@@ -980,6 +1363,7 @@ mod tests {
             )
             .expect("runtime should initialize");
         runtime.ui_actor.clear_redraw();
+        let mut document = ActiveDocument::new(Arc::clone(&pdf));
 
         app.handle_waited_event(
             WaitEvent::Event(DomainEvent::EncodeComplete(
@@ -988,7 +1372,7 @@ mod tests {
                 },
             )),
             &mut runtime,
-            Arc::clone(&pdf),
+            &mut document,
         )
         .expect("encode completion should be handled");
 
@@ -1018,6 +1402,7 @@ mod tests {
                 loop_event_runtime,
             )
             .expect("runtime should initialize");
+        let mut document = ActiveDocument::new(Arc::clone(&pdf));
         assert!(runtime.render_actor.take_prefetch_due());
         assert!(!runtime.render_actor.take_prefetch_due());
         runtime.ui_actor.clear_redraw();
@@ -1025,7 +1410,7 @@ mod tests {
         app.handle_waited_event(
             WaitEvent::Event(DomainEvent::PrefetchTick),
             &mut runtime,
-            Arc::clone(&pdf),
+            &mut document,
         )
         .expect("prefetch tick should be handled");
 
@@ -1057,6 +1442,7 @@ mod tests {
                 loop_event_runtime,
             )
             .expect("runtime should initialize");
+        let mut document = ActiveDocument::new(Arc::clone(&pdf));
         runtime.ui_actor.clear_redraw();
         let viewport = App::current_viewport(&runtime.session, app.state.debug_status_visible);
         let current_scale =
@@ -1070,7 +1456,7 @@ mod tests {
                 runtime.render_actor.generation(),
             ))),
             &mut runtime,
-            Arc::clone(&pdf),
+            &mut document,
         )
         .expect("render completion should be handled");
 
@@ -1101,6 +1487,7 @@ mod tests {
                 loop_event_runtime,
             )
             .expect("runtime should initialize");
+        let mut document = ActiveDocument::new(Arc::clone(&pdf));
         runtime.ui_actor.clear_redraw();
 
         app.handle_waited_event(
@@ -1109,7 +1496,7 @@ mod tests {
                 CommandInvocationSource::Keymap,
             ))),
             &mut runtime,
-            Arc::clone(&pdf),
+            &mut document,
         )
         .expect("command should be handled");
 
@@ -1121,7 +1508,7 @@ mod tests {
         app.handle_waited_event(
             WaitEvent::Event(DomainEvent::App(event)),
             &mut runtime,
-            Arc::clone(&pdf),
+            &mut document,
         )
         .expect("app event should be handled");
         assert!(!runtime.ui_actor.needs_redraw());
@@ -1150,6 +1537,7 @@ mod tests {
                 loop_event_runtime,
             )
             .expect("runtime should initialize");
+        let mut document = ActiveDocument::new(Arc::clone(&pdf));
         runtime.ui_actor.clear_redraw();
 
         app.handle_waited_event(
@@ -1158,7 +1546,7 @@ mod tests {
                 CommandInvocationSource::Keymap,
             ))),
             &mut runtime,
-            Arc::clone(&pdf),
+            &mut document,
         )
         .expect("command should be handled");
 
@@ -1189,6 +1577,7 @@ mod tests {
                 loop_event_runtime,
             )
             .expect("runtime should initialize");
+        let mut document = ActiveDocument::new(Arc::clone(&pdf));
         runtime.ui_actor.clear_redraw();
 
         app.handle_waited_event(
@@ -1197,7 +1586,7 @@ mod tests {
                 CommandInvocationSource::Keymap,
             ))),
             &mut runtime,
-            Arc::clone(&pdf),
+            &mut document,
         )
         .expect("command should be handled");
 

--- a/src/app/input_ops.rs
+++ b/src/app/input_ops.rs
@@ -196,6 +196,14 @@ impl InteractionSubsystem {
         self.extensions.host.prewarm_search_text(pdf);
     }
 
+    pub(crate) fn reset_extensions_for_document_reload(
+        &mut self,
+        state: &mut AppState,
+        pdf: SharedPdfBackend,
+    ) {
+        self.extensions.host.reset_for_document_reload(state, pdf);
+    }
+
     pub(crate) fn sync_search_after_page_change(
         &mut self,
         pdf: SharedPdfBackend,

--- a/src/app/loop_router.rs
+++ b/src/app/loop_router.rs
@@ -308,10 +308,13 @@ impl App {
         S: TerminalSurface,
     {
         runtime.reload_in_flight = false;
+        if self.start_pending_document_reload(runtime, document) {
+            return Ok(());
+        }
+
         match reload.result {
             Ok(pdf) => {
-                if let Err(err) = self.apply_document_reload(runtime, document, pdf, reload.reason)
-                {
+                if let Err(err) = self.apply_document_reload(runtime, document, pdf) {
                     self.state
                         .set_error_notice(format!("Could not reload document: {err}"));
                     self.request_redraw(runtime, RedrawReason::AppEvent);
@@ -322,9 +325,6 @@ impl App {
                     self.state
                         .set_error_notice(format!("Could not reload document: {message}"));
                     self.request_redraw(runtime, RedrawReason::AppEvent);
-                } else if runtime.pending_reload.is_some() {
-                    // A fresh change arrived while the failed reload was running; handle it below
-                    // instead of spending a retry attempt on the stale result.
                 } else if self.schedule_file_reload_retry(runtime) {
                     return Ok(());
                 } else {
@@ -336,10 +336,23 @@ impl App {
             }
         }
 
+        self.start_pending_document_reload(runtime, document);
+        Ok(())
+    }
+
+    fn start_pending_document_reload<S>(
+        &mut self,
+        runtime: &mut LoopRuntime<S>,
+        document: &ActiveDocument,
+    ) -> bool
+    where
+        S: TerminalSurface,
+    {
         if let Some(request) = runtime.pending_reload.take() {
             self.request_document_reload(runtime, document, request);
+            return true;
         }
-        Ok(())
+        false
     }
 
     fn schedule_file_reload_retry<S>(&mut self, runtime: &mut LoopRuntime<S>) -> bool
@@ -364,7 +377,6 @@ impl App {
         runtime: &mut LoopRuntime<S>,
         document: &mut ActiveDocument,
         pdf: SharedPdfBackend,
-        reason: DocumentReloadReason,
     ) -> AppResult<()>
     where
         S: TerminalSurface,
@@ -372,21 +384,13 @@ impl App {
         if pdf.page_count() == 0 {
             return Err(AppError::invalid_argument("reloaded pdf has no pages"));
         }
-        if pdf.doc_id() == document.pdf.doc_id() {
-            runtime.reload_retry_attempts = 0;
-            if matches!(reason, DocumentReloadReason::Manual) {
-                self.state.clear_notice();
-                self.request_redraw(runtime, RedrawReason::Command);
-            }
-            return Ok(());
-        }
-
         let old_doc_id = document.pdf.doc_id();
         runtime.reload_retry_attempts = 0;
         document.replace(Arc::clone(&pdf));
         runtime.page_count = pdf.page_count();
         self.state.current_page = self.state.current_page.min(runtime.page_count - 1);
         self.state.normalize_current_page(runtime.page_count);
+        self.state.clear_reload_notice();
         self.state.clear_render_notice();
 
         self.render.runtime.l1_cache.remove_doc(old_doc_id);

--- a/src/app/loop_router.rs
+++ b/src/app/loop_router.rs
@@ -149,8 +149,8 @@ impl App {
             WaitEvent::Event(DomainEvent::RedrawTick) => {
                 self.request_redraw(runtime, RedrawReason::Timer);
             }
-            WaitEvent::Event(DomainEvent::ReloadDocument(reason)) => {
-                self.request_document_reload(runtime, document, reason);
+            WaitEvent::Event(DomainEvent::ReloadDocument(request)) => {
+                self.request_document_reload(runtime, document, request);
             }
             WaitEvent::Event(DomainEvent::DocumentReloaded(result)) => {
                 self.handle_document_reload_result(runtime, document, result)?;
@@ -278,10 +278,17 @@ impl App {
         &mut self,
         runtime: &mut LoopRuntime<S>,
         document: &ActiveDocument,
-        request: DocumentReloadRequest,
+        mut request: DocumentReloadRequest,
     ) where
         S: TerminalSurface,
     {
+        if request.retry && request.generation < runtime.reload_generation {
+            return;
+        }
+        if request.generation == 0 {
+            runtime.reload_generation += 1;
+            request = request.with_generation(runtime.reload_generation);
+        }
         if !request.retry || matches!(request.reason, DocumentReloadReason::Manual) {
             runtime.reload_retry_attempts = 0;
         }
@@ -293,7 +300,7 @@ impl App {
         runtime.reload_in_flight = true;
         runtime.loop_event_runtime.start_document_reload(
             document.path.clone(),
-            request.reason,
+            request,
             runtime.loop_event_tx.clone(),
         );
     }
@@ -325,7 +332,7 @@ impl App {
                     self.state
                         .set_error_notice(format!("Could not reload document: {message}"));
                     self.request_redraw(runtime, RedrawReason::AppEvent);
-                } else if self.schedule_file_reload_retry(runtime) {
+                } else if self.schedule_file_reload_retry(runtime, reload.generation) {
                     return Ok(());
                 } else {
                     self.state.set_warning_notice(format!(
@@ -355,17 +362,24 @@ impl App {
         false
     }
 
-    fn schedule_file_reload_retry<S>(&mut self, runtime: &mut LoopRuntime<S>) -> bool
+    fn schedule_file_reload_retry<S>(
+        &mut self,
+        runtime: &mut LoopRuntime<S>,
+        generation: u64,
+    ) -> bool
     where
         S: TerminalSurface,
     {
+        if generation < runtime.reload_generation {
+            return true;
+        }
         let Some(delay) = FILE_RELOAD_RETRY_DELAYS.get(usize::from(runtime.reload_retry_attempts))
         else {
             return false;
         };
         runtime.reload_retry_attempts += 1;
         runtime.loop_event_runtime.start_delayed_document_reload(
-            DocumentReloadRequest::retry(DocumentReloadReason::FileChanged),
+            DocumentReloadRequest::retry(DocumentReloadReason::FileChanged, generation),
             *delay,
             runtime.loop_event_tx.clone(),
         );

--- a/src/app/loop_router.rs
+++ b/src/app/loop_router.rs
@@ -1,20 +1,32 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::backend::SharedPdfBackend;
 use crate::command::{Command, CommandOutcome, CommandRequest, PanAmount};
-use crate::error::AppResult;
-use crate::event::{AppEvent, DomainEvent};
+use crate::error::{AppError, AppResult};
+use crate::event::{
+    AppEvent, DocumentReloadReason, DocumentReloadRequest, DocumentReloadResult, DomainEvent,
+};
 use crate::perf::RedrawReason;
 use crate::presenter::PresenterBackgroundEvent;
+use crate::render::worker::RenderWorker;
 
 use super::actors::RenderCompleteContext;
 use super::core::App;
 use super::loop_effects::LoopEffects;
 use super::loop_runtime::{
-    LoopControl, LoopRuntime, SessionRestore, WaitEvent, terminate_process_now,
+    ActiveDocument, LoopControl, LoopRuntime, SessionRestore, WaitEvent, terminate_process_now,
 };
 use super::state::notice_action_for_error;
 use super::terminal_session::TerminalSurface;
+
+const FILE_RELOAD_RETRY_DELAYS: [Duration; 5] = [
+    Duration::from_millis(250),
+    Duration::from_millis(500),
+    Duration::from_millis(1_000),
+    Duration::from_millis(1_500),
+    Duration::from_millis(2_000),
+];
 
 impl App {
     pub(super) fn apply_loop_effects<S>(
@@ -53,7 +65,7 @@ impl App {
         &mut self,
         waited: WaitEvent,
         runtime: &mut LoopRuntime<S>,
-        pdf: SharedPdfBackend,
+        document: &mut ActiveDocument,
     ) -> AppResult<LoopControl>
     where
         S: TerminalSurface + SessionRestore,
@@ -94,7 +106,7 @@ impl App {
             }
             WaitEvent::Event(DomainEvent::Command(request)) => {
                 if matches!(
-                    self.handle_command_event(request, runtime, pdf)?,
+                    self.handle_command_event(request, runtime, document)?,
                     LoopControl::Break
                 ) {
                     return Ok(LoopControl::Break);
@@ -115,7 +127,7 @@ impl App {
                     RenderCompleteContext {
                         config: &self.config,
                         session: &runtime.session,
-                        pdf: pdf.as_ref(),
+                        pdf: document.pdf.as_ref(),
                         input_actor: &runtime.input_actor,
                         prefetch_pause_after_input: runtime.prefetch_pause_after_input,
                         in_flight_len: runtime.render_worker.in_flight_len(),
@@ -136,6 +148,12 @@ impl App {
             }
             WaitEvent::Event(DomainEvent::RedrawTick) => {
                 self.request_redraw(runtime, RedrawReason::Timer);
+            }
+            WaitEvent::Event(DomainEvent::ReloadDocument(reason)) => {
+                self.request_document_reload(runtime, document, reason);
+            }
+            WaitEvent::Event(DomainEvent::DocumentReloaded(result)) => {
+                self.handle_document_reload_result(runtime, document, result)?;
             }
             WaitEvent::Event(DomainEvent::Quit) => {
                 terminate_process_now(runtime);
@@ -186,26 +204,44 @@ impl App {
         &mut self,
         request: CommandRequest,
         runtime: &mut LoopRuntime<S>,
-        pdf: SharedPdfBackend,
+        document: &mut ActiveDocument,
     ) -> AppResult<LoopControl>
     where
         S: TerminalSurface + SessionRestore,
     {
         let request = self.resolve_command_request(&runtime.session, request);
+        if matches!(request.command, Command::ReloadDocument) {
+            self.request_document_reload(
+                runtime,
+                document,
+                DocumentReloadRequest::new(DocumentReloadReason::Manual),
+            );
+            if runtime
+                .loop_event_tx
+                .send(DomainEvent::App(AppEvent::CommandExecuted {
+                    id: request.command.command_id(),
+                    outcome: CommandOutcome::Applied,
+                }))
+                .is_err()
+            {
+                return Ok(LoopControl::Break);
+            }
+            return Ok(LoopControl::Continue);
+        }
         let state_before_command = self.state.clone();
         let previous_page = self.state.current_page;
-        let dispatch =
-            match self
-                .interaction
-                .dispatch_command(&mut self.state, request, Arc::clone(&pdf))
-            {
-                Ok(dispatch) => dispatch,
-                Err(err) => {
-                    self.state.apply_notice_action(notice_action_for_error(err));
-                    self.request_redraw(runtime, RedrawReason::Command);
-                    return Ok(LoopControl::Continue);
-                }
-            };
+        let dispatch = match self.interaction.dispatch_command(
+            &mut self.state,
+            request,
+            Arc::clone(&document.pdf),
+        ) {
+            Ok(dispatch) => dispatch,
+            Err(err) => {
+                self.state.apply_notice_action(notice_action_for_error(err));
+                self.request_redraw(runtime, RedrawReason::Command);
+                return Ok(LoopControl::Continue);
+            }
+        };
         let mut effects = LoopEffects::none();
         for event in dispatch.emitted_events {
             effects.push_event(DomainEvent::App(event));
@@ -222,7 +258,7 @@ impl App {
         }
         if self.state.current_page != previous_page {
             self.interaction
-                .sync_search_after_page_change(Arc::clone(&pdf), self.state.current_page);
+                .sync_search_after_page_change(Arc::clone(&document.pdf), self.state.current_page);
         }
         match dispatch.outcome {
             CommandOutcome::QuitRequested => {
@@ -236,6 +272,150 @@ impl App {
             }
         }
         Ok(LoopControl::Continue)
+    }
+
+    fn request_document_reload<S>(
+        &mut self,
+        runtime: &mut LoopRuntime<S>,
+        document: &ActiveDocument,
+        request: DocumentReloadRequest,
+    ) where
+        S: TerminalSurface,
+    {
+        if !request.retry || matches!(request.reason, DocumentReloadReason::Manual) {
+            runtime.reload_retry_attempts = 0;
+        }
+        if runtime.reload_in_flight {
+            runtime.pending_reload = Some(request);
+            return;
+        }
+
+        runtime.reload_in_flight = true;
+        runtime.loop_event_runtime.start_document_reload(
+            document.path.clone(),
+            request.reason,
+            runtime.loop_event_tx.clone(),
+        );
+    }
+
+    fn handle_document_reload_result<S>(
+        &mut self,
+        runtime: &mut LoopRuntime<S>,
+        document: &mut ActiveDocument,
+        reload: DocumentReloadResult,
+    ) -> AppResult<()>
+    where
+        S: TerminalSurface,
+    {
+        runtime.reload_in_flight = false;
+        match reload.result {
+            Ok(pdf) => {
+                if let Err(err) = self.apply_document_reload(runtime, document, pdf, reload.reason)
+                {
+                    self.state
+                        .set_error_notice(format!("Could not reload document: {err}"));
+                    self.request_redraw(runtime, RedrawReason::AppEvent);
+                }
+            }
+            Err(message) => {
+                if matches!(reload.reason, DocumentReloadReason::Manual) {
+                    self.state
+                        .set_error_notice(format!("Could not reload document: {message}"));
+                    self.request_redraw(runtime, RedrawReason::AppEvent);
+                } else if runtime.pending_reload.is_some() {
+                    // A fresh change arrived while the failed reload was running; handle it below
+                    // instead of spending a retry attempt on the stale result.
+                } else if self.schedule_file_reload_retry(runtime) {
+                    return Ok(());
+                } else {
+                    self.state.set_warning_notice(format!(
+                        "Could not reload changed document: {message}"
+                    ));
+                    self.request_redraw(runtime, RedrawReason::AppEvent);
+                }
+            }
+        }
+
+        if let Some(request) = runtime.pending_reload.take() {
+            self.request_document_reload(runtime, document, request);
+        }
+        Ok(())
+    }
+
+    fn schedule_file_reload_retry<S>(&mut self, runtime: &mut LoopRuntime<S>) -> bool
+    where
+        S: TerminalSurface,
+    {
+        let Some(delay) = FILE_RELOAD_RETRY_DELAYS.get(usize::from(runtime.reload_retry_attempts))
+        else {
+            return false;
+        };
+        runtime.reload_retry_attempts += 1;
+        runtime.loop_event_runtime.start_delayed_document_reload(
+            DocumentReloadRequest::retry(DocumentReloadReason::FileChanged),
+            *delay,
+            runtime.loop_event_tx.clone(),
+        );
+        true
+    }
+
+    fn apply_document_reload<S>(
+        &mut self,
+        runtime: &mut LoopRuntime<S>,
+        document: &mut ActiveDocument,
+        pdf: SharedPdfBackend,
+        reason: DocumentReloadReason,
+    ) -> AppResult<()>
+    where
+        S: TerminalSurface,
+    {
+        if pdf.page_count() == 0 {
+            return Err(AppError::invalid_argument("reloaded pdf has no pages"));
+        }
+        if pdf.doc_id() == document.pdf.doc_id() {
+            runtime.reload_retry_attempts = 0;
+            if matches!(reason, DocumentReloadReason::Manual) {
+                self.state.clear_notice();
+                self.request_redraw(runtime, RedrawReason::Command);
+            }
+            return Ok(());
+        }
+
+        let old_doc_id = document.pdf.doc_id();
+        runtime.reload_retry_attempts = 0;
+        document.replace(Arc::clone(&pdf));
+        runtime.page_count = pdf.page_count();
+        self.state.current_page = self.state.current_page.min(runtime.page_count - 1);
+        self.state.normalize_current_page(runtime.page_count);
+        self.state.clear_render_notice();
+
+        self.render.runtime.l1_cache.remove_doc(old_doc_id);
+        self.render.presenter.reset_terminal_state();
+        self.render.viewer_has_image = false;
+        self.render.image_occluded_last_frame = false;
+        runtime.render_worker =
+            RenderWorker::spawn(Arc::clone(&pdf), self.config.render.worker_threads);
+
+        let viewport = Self::current_viewport(&runtime.session, self.state.debug_status_visible);
+        let visible_pages = self.state.visible_page_slots(runtime.page_count);
+        let tracked_scale =
+            self.compute_current_scale(pdf.as_ref(), visible_pages.anchor_page, viewport);
+        let mut render_actor = super::actors::RenderActor::new(
+            visible_pages.anchor_page,
+            self.state.zoom,
+            tracked_scale,
+        );
+        self.render.runtime.reset_prefetch(
+            pdf.as_ref(),
+            visible_pages.anchor_page,
+            render_actor.nav_mut().intent(),
+            tracked_scale,
+        );
+        runtime.render_actor = render_actor;
+        self.interaction
+            .reset_extensions_for_document_reload(&mut self.state, Arc::clone(&pdf));
+        self.request_redraw(runtime, RedrawReason::StateChanged);
+        Ok(())
     }
 
     pub(super) fn request_redraw<S>(&mut self, runtime: &mut LoopRuntime<S>, reason: RedrawReason)

--- a/src/app/loop_runtime.rs
+++ b/src/app/loop_runtime.rs
@@ -1,8 +1,11 @@
+use std::path::PathBuf;
 use std::time::Duration;
 
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::time;
 
+use crate::backend::SharedPdfBackend;
+use crate::event::DocumentReloadRequest;
 use crate::event::DomainEvent;
 use crate::render::cache::RenderedPageKey;
 use crate::render::scheduler::RenderTask;
@@ -30,6 +33,26 @@ pub(super) struct LoopRuntime<S> {
     pub(super) loop_event_tx: UnboundedSender<DomainEvent>,
     pub(super) loop_event_rx: UnboundedReceiver<DomainEvent>,
     pub(super) loop_event_runtime: EventBusRuntime,
+    pub(super) reload_in_flight: bool,
+    pub(super) pending_reload: Option<DocumentReloadRequest>,
+    pub(super) reload_retry_attempts: u8,
+}
+
+pub(super) struct ActiveDocument {
+    pub(super) pdf: SharedPdfBackend,
+    pub(super) path: PathBuf,
+}
+
+impl ActiveDocument {
+    pub(super) fn new(pdf: SharedPdfBackend) -> Self {
+        let path = pdf.path().to_path_buf();
+        Self { pdf, path }
+    }
+
+    pub(super) fn replace(&mut self, pdf: SharedPdfBackend) {
+        self.path = pdf.path().to_path_buf();
+        self.pdf = pdf;
+    }
 }
 
 pub(super) struct LoopStep {

--- a/src/app/loop_runtime.rs
+++ b/src/app/loop_runtime.rs
@@ -36,6 +36,7 @@ pub(super) struct LoopRuntime<S> {
     pub(super) reload_in_flight: bool,
     pub(super) pending_reload: Option<DocumentReloadRequest>,
     pub(super) reload_retry_attempts: u8,
+    pub(super) reload_generation: u64,
 }
 
 pub(super) struct ActiveDocument {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -20,7 +20,7 @@ mod view_ops;
 #[cfg(test)]
 mod tests;
 
-pub use core::App;
+pub use core::{App, RunOptions};
 pub use runtime::RenderRuntime;
 pub use state::{
     AppState, CacheHandle, CacheRefs, Mode, Notice, NoticeAction, NoticeLevel, PageLayoutMode,

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -170,6 +170,10 @@ impl Default for AppState {
 
 impl AppState {
     const RENDER_NOTICE_PREFIX: &str = "Could not render";
+    const RELOAD_NOTICE_PREFIXES: [&str; 2] = [
+        "Could not reload document:",
+        "Could not reload changed document:",
+    ];
 
     pub fn apply_notice_action(&mut self, action: NoticeAction) {
         match action {
@@ -214,6 +218,16 @@ impl AppState {
         if self.notice.as_ref().is_some_and(|notice| {
             notice.level == NoticeLevel::Error
                 && notice.message.starts_with(Self::RENDER_NOTICE_PREFIX)
+        }) {
+            self.notice = None;
+        }
+    }
+
+    pub fn clear_reload_notice(&mut self) {
+        if self.notice.as_ref().is_some_and(|notice| {
+            Self::RELOAD_NOTICE_PREFIXES
+                .iter()
+                .any(|prefix| notice.message.starts_with(prefix))
         }) {
             self.notice = None;
         }

--- a/src/command/catalog.rs
+++ b/src/command/catalog.rs
@@ -540,6 +540,16 @@ define_commands! {
         parse: no_args,
         exec: super::handlers::cancel_search,
     }
+    ReloadDocument {
+        id: "reload-document",
+        title: "Reload Document",
+        args: &NO_ARGS,
+        exposure: CommandExposure::Public,
+        invocation: CommandInvocationPolicy::User,
+        availability: CommandAvailability::Always,
+        parse: no_args,
+        exec: super::handlers::reload_document,
+    }
     Quit {
         id: "quit",
         title: "Quit",

--- a/src/command/dispatch.rs
+++ b/src/command/dispatch.rs
@@ -193,6 +193,7 @@ fn derive_nav_reason(command: &Command, extension_host: &ExtensionHost) -> Optio
         | Command::OpenHistory
         | Command::OpenOutline
         | Command::CancelSearch
+        | Command::ReloadDocument
         | Command::Quit => None,
     }
 }

--- a/src/command/handlers/control.rs
+++ b/src/command/handlers/control.rs
@@ -13,6 +13,12 @@ pub(in crate::command) fn cancel_search(
     Ok(CommandExecution::applied())
 }
 
+pub(in crate::command) fn reload_document(
+    _ctx: &mut CommandExecContext<'_>,
+) -> AppResult<CommandExecution> {
+    Ok(CommandExecution::applied())
+}
+
 pub(in crate::command) fn quit(_ctx: &mut CommandExecContext<'_>) -> AppResult<CommandExecution> {
     Ok(CommandExecution {
         outcome: CommandOutcome::QuitRequested,

--- a/src/command/handlers/mod.rs
+++ b/src/command/handlers/mod.rs
@@ -9,7 +9,7 @@ mod palette;
 mod search;
 mod viewport;
 
-pub(super) use control::{cancel_search, quit};
+pub(super) use control::{cancel_search, quit, reload_document};
 pub(super) use debug::{debug_status_hide, debug_status_show, debug_status_toggle};
 pub(super) use help::{close_help, open_help};
 pub(super) use history::{history_back, history_forward, history_goto, open_history};

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,6 +1,8 @@
 use crossterm::event::Event;
+use std::fmt;
 
 use crate::app::Mode;
+use crate::backend::SharedPdfBackend;
 use crate::command::{CommandId, CommandOutcome, CommandRequest};
 use crate::presenter::PresenterBackgroundEvent;
 use crate::render::worker::RenderWorkerResult;
@@ -55,6 +57,52 @@ pub enum AppEvent {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DocumentReloadReason {
+    Manual,
+    FileChanged,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DocumentReloadRequest {
+    pub(crate) reason: DocumentReloadReason,
+    pub(crate) retry: bool,
+}
+
+impl DocumentReloadRequest {
+    pub(crate) fn new(reason: DocumentReloadReason) -> Self {
+        Self {
+            reason,
+            retry: false,
+        }
+    }
+
+    pub(crate) fn retry(reason: DocumentReloadReason) -> Self {
+        Self {
+            reason,
+            retry: true,
+        }
+    }
+}
+
+pub(crate) struct DocumentReloadResult {
+    pub(crate) reason: DocumentReloadReason,
+    pub(crate) result: Result<SharedPdfBackend, String>,
+}
+
+impl fmt::Debug for DocumentReloadResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let result = match &self.result {
+            Ok(pdf) => format!("Ok(doc_id: {}, pages: {})", pdf.doc_id(), pdf.page_count()),
+            Err(message) => format!("Err({message:?})"),
+        };
+        f.debug_struct("DocumentReloadResult")
+            .field("reason", &self.reason)
+            .field("result", &result)
+            .finish()
+    }
+}
+
 #[derive(Debug)]
 pub(crate) enum DomainEvent {
     Input(Event),
@@ -62,6 +110,8 @@ pub(crate) enum DomainEvent {
     Command(CommandRequest),
     Quit,
     App(AppEvent),
+    ReloadDocument(DocumentReloadRequest),
+    DocumentReloaded(DocumentReloadResult),
     RenderComplete(RenderWorkerResult),
     EncodeComplete(PresenterBackgroundEvent),
     PrefetchTick,

--- a/src/event.rs
+++ b/src/event.rs
@@ -67,6 +67,7 @@ pub(crate) enum DocumentReloadReason {
 pub(crate) struct DocumentReloadRequest {
     pub(crate) reason: DocumentReloadReason,
     pub(crate) retry: bool,
+    pub(crate) generation: u64,
 }
 
 impl DocumentReloadRequest {
@@ -74,19 +75,27 @@ impl DocumentReloadRequest {
         Self {
             reason,
             retry: false,
+            generation: 0,
         }
     }
 
-    pub(crate) fn retry(reason: DocumentReloadReason) -> Self {
+    pub(crate) fn retry(reason: DocumentReloadReason, generation: u64) -> Self {
         Self {
             reason,
             retry: true,
+            generation,
         }
+    }
+
+    pub(crate) fn with_generation(mut self, generation: u64) -> Self {
+        self.generation = generation;
+        self
     }
 }
 
 pub(crate) struct DocumentReloadResult {
     pub(crate) reason: DocumentReloadReason,
+    pub(crate) generation: u64,
     pub(crate) result: Result<SharedPdfBackend, String>,
 }
 
@@ -98,6 +107,7 @@ impl fmt::Debug for DocumentReloadResult {
         };
         f.debug_struct("DocumentReloadResult")
             .field("reason", &self.reason)
+            .field("generation", &self.generation)
             .field("result", &result)
             .finish()
     }

--- a/src/extension/host.rs
+++ b/src/extension/host.rs
@@ -94,6 +94,21 @@ impl ExtensionHost {
         self.search.prewarm(pdf);
     }
 
+    pub fn reset_for_document_reload(&mut self, app: &mut AppState, pdf: SharedPdfBackend) {
+        let active_search = self
+            .search
+            .is_active()
+            .then(|| (self.search.query().to_string(), self.search.matcher()));
+        self.search = SearchExtension::init_state();
+        self.outline = OutlineExtension::init_state();
+        self.search.prewarm(Arc::clone(&pdf));
+        if let Some((query, matcher)) = active_search
+            && let Err(err) = self.search.submit(app, pdf, query, matcher)
+        {
+            app.set_warning_notice(format!("Could not restore search after reload: {err}"));
+        }
+    }
+
     pub fn resolve_search_priority_geometry(
         &mut self,
         pdf: SharedPdfBackend,
@@ -338,5 +353,28 @@ mod tests {
         let canceled = host.cancel_search(pdf).expect("cancel should succeed");
         assert!(canceled);
         assert!(!host.ui_snapshot().search_active);
+    }
+
+    #[test]
+    fn document_reload_preserves_active_search() {
+        let mut host = ExtensionHost::default();
+        let mut app = crate::app::AppState::default();
+        let first = Arc::new(StubPdf::new(4)) as SharedPdfBackend;
+        let second = Arc::new(StubPdf::new(2)) as SharedPdfBackend;
+
+        host.submit_search(
+            &mut app,
+            first,
+            "needle".to_string(),
+            SearchMatcherKind::ContainsSensitive,
+        )
+        .expect("submit-search should succeed");
+
+        host.reset_for_document_reload(&mut app, second);
+
+        assert!(host.ui_snapshot().search_active);
+        assert_eq!(host.search_query(), "needle");
+        assert_eq!(host.search_matcher(), SearchMatcherKind::ContainsSensitive);
+        assert_eq!(host.status_bar_segments(&app), vec!["SEARCH 0 hits"]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,16 @@
 use std::path::PathBuf;
 
 use clap::Parser;
+#[cfg(not(test))]
 use pvf::app::App;
+#[cfg(not(test))]
 use pvf::backend::open_default_backend;
+#[cfg(not(test))]
 use pvf::error::AppResult;
+#[cfg(not(test))]
 use pvf::presenter::PresenterKind;
 
+#[cfg(not(test))]
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
     if let Err(err) = run().await {
@@ -14,29 +19,38 @@ async fn main() {
     }
 }
 
+#[cfg(test)]
+fn main() {}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CliOptions {
     pdf_path: PathBuf,
+    watch: bool,
 }
 
 #[derive(Debug, Parser)]
 #[command(version, about = "PDF viewer for the terminal")]
 struct Cli {
+    #[arg(long, help = "Reload the displayed PDF when the file changes")]
+    watch: bool,
     #[arg(value_name = "FILE")]
     pdf_path: PathBuf,
 }
 
+#[cfg(not(test))]
 async fn run() -> AppResult<()> {
     let options = parse_cli(Cli::parse());
 
     let pdf = open_default_backend(&options.pdf_path)?;
     let mut app = App::new(PresenterKind::RatatuiImage)?;
+    app.set_watch(options.watch);
     app.run(pdf).await
 }
 
 fn parse_cli(cli: Cli) -> CliOptions {
     CliOptions {
         pdf_path: cli.pdf_path,
+        watch: cli.watch,
     }
 }
 
@@ -53,6 +67,16 @@ mod tests {
         let cli = Cli::try_parse_from(["pvf", "sample.pdf"]).expect("single arg should parse");
         let options = parse_cli(cli);
         assert_eq!(options.pdf_path, PathBuf::from("sample.pdf"));
+        assert!(!options.watch);
+    }
+
+    #[test]
+    fn parse_cli_accepts_watch_flag() {
+        let cli =
+            Cli::try_parse_from(["pvf", "--watch", "sample.pdf"]).expect("watch flag should parse");
+        let options = parse_cli(cli);
+        assert_eq!(options.pdf_path, PathBuf::from("sample.pdf"));
+        assert!(options.watch);
     }
 
     #[test]

--- a/src/presenter/ratatui/mod.rs
+++ b/src/presenter/ratatui/mod.rs
@@ -569,6 +569,10 @@ impl ImagePresenter for RatatuiImagePresenter {
         self.drain_encode_results()
     }
 
+    fn reset_terminal_state(&mut self) {
+        RatatuiImagePresenter::reset_terminal_state(self);
+    }
+
     fn recv_background_event<'a>(
         &'a mut self,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<PresenterBackgroundEvent>> + 'a>>

--- a/src/presenter/traits.rs
+++ b/src/presenter/traits.rs
@@ -349,6 +349,8 @@ pub trait ImagePresenter {
         false
     }
 
+    fn reset_terminal_state(&mut self) {}
+
     fn recv_background_event<'a>(
         &'a mut self,
     ) -> Pin<Box<dyn Future<Output = Option<PresenterBackgroundEvent>> + 'a>> {


### PR DESCRIPTION
Adds live PDF reload for development workflows. Users can run `pvf --watch <file.pdf>` or invoke `reload-document` to reopen the active file without restarting the viewer.

Implementation:
- polls the target PDF path with debounce and reloads asynchronously
- keeps the previous document visible while a changed file is temporarily invalid
- retries watch reload failures with short backoff, then shows a warning after the retry budget
- replaces render/search state on success while preserving active search query and matcher
- documents watch acceptance cases in `docs/runtime-spec.md`

Behavior covered:
- valid PDF replacement updates the active document
- temporarily invalid PDF writes keep the previous document visible while retrying
- retry success replaces the document and resets retry state
- repeated reload failures eventually show a warning
- newer file-change requests take precedence over older failed reload results
- active search query and matcher are preserved after reload

Related:
- #76 remains open. This PR introduces reload/reopen behavior, but it does not claim to settle the broader document identity/cache contract tracked there.

Verification:
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- --help`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--watch` CLI flag for automatic document reloads on file changes
  * Added `reload-document` command for manual reload
  * Watch mode: debounced change detection, quiet retries with limits, and swap semantics that preserve active search and clamp current page on replacement

* **Documentation**
  * Expanded runtime spec describing reload, watch, retry, success/failure, and acceptance behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->