### PR TITLE
feat(config): add configurable keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,30 @@ cargo install preview-pdf
 | `<esc>` | Cancel current interactive state |
 | `q` | Quit |
 
+## Configuration
+
+`pvf` reads TOML configuration from `PVF_CONFIG_PATH`,
+`$XDG_CONFIG_HOME/pvf/config.toml`, `$HOME/.config/pvf/config.toml`, or
+`%APPDATA%/pvf/config.toml`.
+
+Normal-mode key bindings can be patched with `[keymap]`:
+
+```toml
+[keymap]
+preset = "default" # or "none"
+unbind = ["j"]
+
+[keymap.bindings]
+"<down>" = "next-page"
+"gg" = "first-page"
+"[count]G" = "goto-page"
+":" = "open-palette command"
+```
+
+Use the key labels shown in help, such as `G`, `<c-o>`, `<down>`, and
+`[count]G`. Palette-local keys are not part of the normal-mode keymap.
+`<esc>` and `<enter>` are reserved for now.
+
 ## Note
 
 Image quality and compatibility depend on terminal image protocol support such as Kitty, Sixel, or iTerm2.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -79,13 +79,13 @@ Contract:
 - `--config` and `--no-config` are mutually exclusive.
 - Partial config files leave unspecified options absent so later sources and
   defaults can still apply.
+- Top-level `[keymap]` config patches the normal-mode key sequence registry.
 - Validation and sanitization that users can observe, such as enum rejection,
-  safe duration minimums, and zoom bounds, are part of the config contract.
+  keymap preset and command validation, safe duration minimums, and zoom bounds,
+  are part of the config contract.
 
 Compatibility:
 - Supported config fields and enum values are compatibility-sensitive.
-- Unknown legacy sections may be tolerated intentionally, but new compatibility
-  behavior should be covered by tests.
 - Do not document the complete TOML inventory here; keep it in config types,
   parsing code, and tests.
 
@@ -152,13 +152,19 @@ Orientation:
 
 Contract:
 - Printable bindings are defined by resulting characters, not by physical keys.
+- Configured key bindings use the same key labels shown in help, such as
+  `gg`, `<c-o>`, `<down>`, and `[count]G`.
 - Multi-key sequences can remain pending until resolved or timed out.
 - Numeric prefixes are parsed by the input sequence layer and dispatch typed
   commands.
 - Built-in key bindings must reference known command ids and satisfy command
   invocation policy.
+- Configured key bindings must reference known commands that can be invoked
+  from the keymap; runtime availability remains a dispatch-time check.
 - Palette-local key handling is owned by palette behavior, not the normal-mode
   keymap.
+- `<esc>` and `<enter>` are not configurable normal-mode bindings while their
+  global cancellation and sequence-confirmation behavior is being settled.
 
 Compatibility:
 - Changing a default key binding affects user muscle memory and help output; do

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -15,6 +15,7 @@ pub use parse::{parse_command_text, parse_invocable_command_text};
 pub use spec::{
     CommandConditionContext, all_command_specs, command_registry, find_command_spec,
     is_command_visible_in_palette, rejection_message_for_command, validate_command_for_source,
+    validate_command_id_invocation_for_source, validate_command_invocation_for_source,
 };
 pub use types::{
     ArgHint, ArgKind, ArgSpec, CommandAvailability, CommandCondition, CommandExposure,

--- a/src/command/spec.rs
+++ b/src/command/spec.rs
@@ -58,6 +58,28 @@ pub fn validate_command_for_source(
     validate_command_spec_for_source(spec, ctx)
 }
 
+pub fn validate_command_invocation_for_source(
+    command: &Command,
+    source: CommandInvocationSource,
+) -> AppResult<()> {
+    let Some(spec) = spec_for_command(command) else {
+        return Err(AppError::unsupported(
+            "command spec should exist for typed command",
+        ));
+    };
+    validate_command_spec_invocation_for_source(spec, source)
+}
+
+pub fn validate_command_id_invocation_for_source(
+    id: &str,
+    source: CommandInvocationSource,
+) -> AppResult<()> {
+    let Some(spec) = find_command_spec(id) else {
+        return Err(AppError::invalid_argument("unknown command id"));
+    };
+    validate_command_spec_invocation_for_source(spec, source)
+}
+
 pub fn rejection_message_for_command(
     command: &Command,
     ctx: &CommandConditionContext<'_>,
@@ -71,18 +93,27 @@ fn validate_command_spec_for_source(
     spec: CommandSpec,
     ctx: &CommandConditionContext<'_>,
 ) -> AppResult<()> {
-    if !is_invocation_source_allowed(spec, ctx.source) {
-        return Err(AppError::invalid_argument(format!(
-            "{} is an internal command and cannot be invoked directly",
-            spec.id
-        )));
-    }
+    validate_command_spec_invocation_for_source(spec, ctx.source)?;
 
     if !is_command_available(spec, ctx) {
         return Err(AppError::invalid_argument(unavailable_message(spec, ctx)));
     }
 
     Ok(())
+}
+
+fn validate_command_spec_invocation_for_source(
+    spec: CommandSpec,
+    source: CommandInvocationSource,
+) -> AppResult<()> {
+    if is_invocation_source_allowed(spec, source) {
+        return Ok(());
+    }
+
+    Err(AppError::invalid_argument(format!(
+        "{} is an internal command and cannot be invoked directly",
+        spec.id
+    )))
 }
 
 fn is_command_available(spec: CommandSpec, ctx: &CommandConditionContext<'_>) -> bool {
@@ -145,6 +176,7 @@ mod tests {
     use super::{
         CommandConditionContext, command_registry, find_command_spec,
         is_command_visible_in_palette, validate_command_for_source, validate_command_id_for_source,
+        validate_command_invocation_for_source,
     };
     use crate::command::{Command, CommandInvocationPolicy, CommandInvocationSource};
 
@@ -227,5 +259,14 @@ mod tests {
 
         let spec = find_command_spec("close-help").expect("spec should exist");
         assert!(!is_command_visible_in_palette(spec, &ctx));
+    }
+
+    #[test]
+    fn invocation_validation_ignores_runtime_availability() {
+        validate_command_invocation_for_source(
+            &Command::NextSearchHit,
+            CommandInvocationSource::Keymap,
+        )
+        .expect("keymap config may bind state-dependent commands");
     }
 }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -544,6 +544,34 @@ mod tests {
     }
 
     #[test]
+    fn keymap_config_allows_literal_less_than_binding() {
+        let path = unique_temp_path("keymap-less-than.toml");
+        fs::write(
+            &path,
+            r#"
+            [keymap]
+            preset = "none"
+
+            [keymap.bindings]
+            "<" = "prev-page"
+            "#,
+        )
+        .expect("config file should be written");
+
+        let options = load_options_from_explicit_path(&path).expect("config should parse");
+        let resolved = AppOptionsResolver::new().apply_options(options).resolve();
+        let mut resolver =
+            SequenceResolver::new(resolved.input.sequence_registry, DEFAULT_SEQUENCE_TIMEOUT);
+
+        assert_eq!(
+            resolver.handle_key(KeyEvent::new(KeyCode::Char('<'), KeyModifiers::NONE)),
+            SequenceResolution::Dispatch(Command::PrevPage)
+        );
+
+        fs::remove_file(&path).expect("config file should be removed");
+    }
+
+    #[test]
     fn keymap_config_rejects_unknown_preset() {
         let path = unique_temp_path("bad-keymap-preset.toml");
         fs::write(

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -8,7 +9,7 @@ use crate::app::{PageLayoutMode, SpreadCoverPolicy, SpreadDirection};
 use crate::error::{AppError, AppResult};
 
 use super::options::{
-    AppOptions, CacheOptions, InputOptions, RenderOptions, ViewOptions, WatchOptions,
+    AppOptions, CacheOptions, InputOptions, KeymapOptions, RenderOptions, ViewOptions, WatchOptions,
 };
 use super::policy::AppOptionsResolver;
 use super::types::Config;
@@ -65,6 +66,7 @@ struct RawConfig {
     cache: Option<RawCacheConfig>,
     view: Option<RawViewConfig>,
     input: Option<RawInputConfig>,
+    keymap: Option<RawKeymapConfig>,
     watch: Option<RawWatchConfig>,
 }
 
@@ -108,6 +110,14 @@ struct RawInputConfig {
 
 #[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
 #[serde(default)]
+struct RawKeymapConfig {
+    preset: Option<String>,
+    unbind: Vec<String>,
+    bindings: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+#[serde(default)]
 struct RawWatchConfig {
     enabled: Option<bool>,
     poll_interval_ms: Option<u64>,
@@ -125,6 +135,11 @@ impl RawConfig {
                 .transpose()?
                 .unwrap_or_default(),
             input: self.input.map(InputOptions::from).unwrap_or_default(),
+            keymap: self
+                .keymap
+                .map(KeymapOptions::try_from)
+                .transpose()?
+                .unwrap_or_default(),
             watch: self.watch.map(WatchOptions::from).unwrap_or_default(),
         })
     }
@@ -187,6 +202,34 @@ impl From<RawInputConfig> for InputOptions {
         Self {
             sequence_timeout_ms: raw.sequence_timeout_ms,
         }
+    }
+}
+
+impl TryFrom<RawKeymapConfig> for KeymapOptions {
+    type Error = AppError;
+
+    fn try_from(raw: RawKeymapConfig) -> Result<Self, Self::Error> {
+        let preset = raw
+            .preset
+            .as_deref()
+            .map(super::keymap::parse_keymap_preset)
+            .transpose()?;
+        let unbind = raw
+            .unbind
+            .iter()
+            .map(|key| super::keymap::parse_keymap_target(key))
+            .collect::<AppResult<Vec<_>>>()?;
+        let bindings = raw
+            .bindings
+            .iter()
+            .map(|(key, command)| super::keymap::parse_keymap_binding(key, command))
+            .collect::<AppResult<Vec<_>>>()?;
+
+        Ok(Self {
+            preset,
+            unbind,
+            bindings,
+        })
     }
 }
 
@@ -322,6 +365,11 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use crate::app::{PageLayoutMode, SpreadCoverPolicy, SpreadDirection};
+    use crate::command::Command;
+    use crate::config::{AppOptionsResolver, KeymapBinding, KeymapPreset, KeymapTarget};
+    use crate::input::sequence::{DEFAULT_SEQUENCE_TIMEOUT, SequenceResolution, SequenceResolver};
+    use crate::input::shortcut::ShortcutKey;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     use super::{
         Config, ConfigFileSelection, default_config_path_from_env, load_options_from_explicit_path,
@@ -408,22 +456,152 @@ mod tests {
     }
 
     #[test]
-    fn unknown_legacy_keymap_section_is_ignored() {
-        let path = unique_temp_path("legacy-keymap.toml");
+    fn explicit_config_reads_keymap_section() {
+        let path = unique_temp_path("keymap.toml");
+        fs::write(
+            &path,
+            r#"
+            [keymap]
+            preset = "none"
+            unbind = ["j", "[count]G"]
+
+            [keymap.bindings]
+            "<down>" = "next-page"
+            "[count]G" = "goto-page"
+            "#,
+        )
+        .expect("config file should be written");
+
+        let options = load_options_from_explicit_path(&path).expect("config should parse");
+        assert_eq!(options.keymap.preset, Some(KeymapPreset::None));
+        assert_eq!(
+            options.keymap.unbind,
+            vec![
+                KeymapTarget::Exact(vec![ShortcutKey::char('j')]),
+                KeymapTarget::NumericPrefix(ShortcutKey::char('G')),
+            ]
+        );
+        assert_eq!(
+            options.keymap.bindings,
+            vec![
+                KeymapBinding::Exact {
+                    keys: vec![ShortcutKey::key(KeyCode::Down)],
+                    command: Command::NextPage,
+                },
+                KeymapBinding::NumericPrefix {
+                    suffix: ShortcutKey::char('G'),
+                    command_id: "goto-page",
+                },
+            ]
+        );
+
+        fs::remove_file(&path).expect("config file should be removed");
+    }
+
+    #[test]
+    fn keymap_config_resolves_to_runtime_sequence_registry() {
+        let path = unique_temp_path("keymap-runtime.toml");
+        fs::write(
+            &path,
+            r#"
+            [keymap]
+            preset = "none"
+
+            [keymap.bindings]
+            "<down>" = "next-page"
+            "[count]G" = "goto-page"
+            "#,
+        )
+        .expect("config file should be written");
+
+        let options = load_options_from_explicit_path(&path).expect("config should parse");
+        let resolved = AppOptionsResolver::new().apply_options(options).resolve();
+        let mut resolver =
+            SequenceResolver::new(resolved.input.sequence_registry, DEFAULT_SEQUENCE_TIMEOUT);
+
+        assert_eq!(
+            resolver.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)),
+            SequenceResolution::Noop
+        );
+        assert_eq!(
+            resolver.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)),
+            SequenceResolution::Dispatch(Command::NextPage)
+        );
+        assert_eq!(
+            resolver.handle_key(KeyEvent::new(KeyCode::Char('4'), KeyModifiers::NONE)),
+            SequenceResolution::Pending
+        );
+        assert_eq!(
+            resolver.handle_key(KeyEvent::new(KeyCode::Char('2'), KeyModifiers::NONE)),
+            SequenceResolution::Pending
+        );
+        assert_eq!(
+            resolver.handle_key(KeyEvent::new(KeyCode::Char('G'), KeyModifiers::NONE)),
+            SequenceResolution::Dispatch(Command::GotoPage { page: 42 })
+        );
+
+        fs::remove_file(&path).expect("config file should be removed");
+    }
+
+    #[test]
+    fn keymap_config_rejects_unknown_preset() {
+        let path = unique_temp_path("bad-keymap-preset.toml");
         fs::write(
             &path,
             r#"
             [keymap]
             preset = "emacs"
-
-            [cache]
-            l1_max_entries = 42
             "#,
         )
         .expect("config file should be written");
 
-        let config = Config::load_from_path(&path).expect("config should parse");
-        assert_eq!(config.cache.l1_max_entries, 42);
+        let err = load_options_from_explicit_path(&path).expect_err("config should be rejected");
+        assert!(
+            err.to_string().contains("unknown keymap preset"),
+            "unexpected error: {err}"
+        );
+
+        fs::remove_file(&path).expect("config file should be removed");
+    }
+
+    #[test]
+    fn keymap_config_rejects_internal_only_commands() {
+        let path = unique_temp_path("bad-keymap-command.toml");
+        fs::write(
+            &path,
+            r#"
+            [keymap.bindings]
+            "x" = "submit-search needle"
+            "#,
+        )
+        .expect("config file should be written");
+
+        let err = load_options_from_explicit_path(&path).expect_err("config should be rejected");
+        assert!(
+            err.to_string().contains("internal command"),
+            "unexpected error: {err}"
+        );
+
+        fs::remove_file(&path).expect("config file should be removed");
+    }
+
+    #[test]
+    fn keymap_config_rejects_escape_and_enter_bindings() {
+        let path = unique_temp_path("bad-keymap-key.toml");
+        fs::write(
+            &path,
+            r#"
+            [keymap.bindings]
+            "<esc>" = "quit"
+            "#,
+        )
+        .expect("config file should be written");
+
+        let err = load_options_from_explicit_path(&path).expect_err("config should be rejected");
+        assert!(
+            err.to_string().contains("<esc> or <enter>"),
+            "unexpected error: {err}"
+        );
 
         fs::remove_file(&path).expect("config file should be removed");
     }
@@ -447,6 +625,9 @@ mod tests {
         assert_eq!(options.render.max_render_scale, None);
         assert_eq!(options.view.initial_page, None);
         assert_eq!(options.input.sequence_timeout_ms, None);
+        assert_eq!(options.keymap.preset, None);
+        assert!(options.keymap.unbind.is_empty());
+        assert!(options.keymap.bindings.is_empty());
         assert_eq!(options.watch.enabled, None);
 
         fs::remove_file(&path).expect("config file should be removed");

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -1,0 +1,218 @@
+use crate::command::{
+    Command, CommandInvocationSource, parse_command_text,
+    validate_command_id_invocation_for_source, validate_command_invocation_for_source,
+};
+use crate::error::{AppError, AppResult};
+use crate::input::keymap::build_builtin_sequence_registry;
+use crate::input::sequence::{SequenceRegistrationError, SequenceRegistry};
+use crate::input::shortcut::{ShortcutKey, parse_shortcut_sequence};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeymapPreset {
+    Default,
+    None,
+}
+
+impl KeymapPreset {
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        match value {
+            "default" => Some(Self::Default),
+            "none" => Some(Self::None),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeymapTarget {
+    Exact(Vec<ShortcutKey>),
+    NumericPrefix(ShortcutKey),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum KeymapBinding {
+    Exact {
+        keys: Vec<ShortcutKey>,
+        command: Command,
+    },
+    NumericPrefix {
+        suffix: ShortcutKey,
+        command_id: &'static str,
+    },
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct KeymapOptions {
+    pub preset: Option<KeymapPreset>,
+    pub unbind: Vec<KeymapTarget>,
+    pub bindings: Vec<KeymapBinding>,
+}
+
+impl KeymapOptions {
+    pub(crate) fn merge(mut self, next: Self) -> Self {
+        self.preset = next.preset.or(self.preset);
+        self.unbind.extend(next.unbind);
+        self.bindings.extend(next.bindings);
+        self
+    }
+}
+
+pub(crate) fn resolve_sequence_registry(options: &KeymapOptions) -> SequenceRegistry {
+    let mut registry = match options.preset.unwrap_or(KeymapPreset::Default) {
+        KeymapPreset::Default => build_builtin_sequence_registry(),
+        KeymapPreset::None => SequenceRegistry::new(),
+    };
+
+    for target in &options.unbind {
+        match target {
+            KeymapTarget::Exact(keys) => {
+                registry
+                    .unregister_static(keys)
+                    .expect("validated exact keymap target should unregister");
+            }
+            KeymapTarget::NumericPrefix(suffix) => {
+                registry
+                    .unregister_numeric_prefix(*suffix)
+                    .expect("validated numeric keymap target should unregister");
+            }
+        }
+    }
+
+    for binding in &options.bindings {
+        match binding {
+            KeymapBinding::Exact { keys, command } => {
+                registry
+                    .register_static(keys, command.clone())
+                    .expect("validated exact keymap binding should register");
+            }
+            KeymapBinding::NumericPrefix { suffix, command_id } => {
+                let factory = numeric_prefix_factory(command_id)
+                    .expect("validated numeric prefix command should have a factory");
+                registry
+                    .register_numeric_prefix(command_id, *suffix, factory)
+                    .expect("validated numeric keymap binding should register");
+            }
+        }
+    }
+
+    registry
+}
+
+pub(crate) fn parse_keymap_preset(value: &str) -> AppResult<KeymapPreset> {
+    KeymapPreset::parse(value).ok_or(AppError::invalid_argument("unknown keymap preset"))
+}
+
+pub(crate) fn parse_keymap_target(value: &str) -> AppResult<KeymapTarget> {
+    if let Some(suffix_text) = value.strip_prefix("[count]") {
+        let suffix = parse_numeric_suffix(suffix_text)?;
+        validate_configurable_key(&[suffix])?;
+        validate_numeric_suffix(suffix)?;
+        return Ok(KeymapTarget::NumericPrefix(suffix));
+    }
+
+    let keys = parse_exact_keys(value)?;
+    Ok(KeymapTarget::Exact(keys))
+}
+
+pub(crate) fn parse_keymap_binding(key: &str, command_text: &str) -> AppResult<KeymapBinding> {
+    match parse_keymap_target(key)? {
+        KeymapTarget::Exact(keys) => {
+            let command = parse_command_text(command_text)?;
+            validate_command_invocation_for_source(&command, CommandInvocationSource::Keymap)?;
+            validate_exact_keys(&keys)?;
+            Ok(KeymapBinding::Exact { keys, command })
+        }
+        KeymapTarget::NumericPrefix(suffix) => {
+            let command_id = parse_numeric_prefix_command(command_text)?;
+            validate_command_id_invocation_for_source(command_id, CommandInvocationSource::Keymap)?;
+            validate_numeric_suffix(suffix)?;
+            Ok(KeymapBinding::NumericPrefix { suffix, command_id })
+        }
+    }
+}
+
+fn parse_exact_keys(value: &str) -> AppResult<Vec<ShortcutKey>> {
+    let keys = parse_shortcut_sequence(value).map_err(|err| {
+        AppError::invalid_argument(format!("invalid key sequence {value:?}: {err}"))
+    })?;
+    validate_configurable_key(&keys)?;
+    validate_exact_keys(&keys)?;
+    Ok(keys)
+}
+
+fn parse_numeric_suffix(value: &str) -> AppResult<ShortcutKey> {
+    let keys = parse_shortcut_sequence(value).map_err(|err| {
+        AppError::invalid_argument(format!("invalid count key suffix {value:?}: {err}"))
+    })?;
+    let [suffix] = keys.as_slice() else {
+        return Err(AppError::invalid_argument(
+            "count key binding suffix must be exactly one key",
+        ));
+    };
+    Ok(*suffix)
+}
+
+fn parse_numeric_prefix_command(command_text: &str) -> AppResult<&'static str> {
+    let command_id = command_text.trim();
+    if command_id.is_empty() || command_id.split_whitespace().count() != 1 {
+        return Err(AppError::invalid_argument(
+            "count key binding command must be a command id",
+        ));
+    }
+    if numeric_prefix_factory(command_id).is_none() {
+        return Err(AppError::invalid_argument(
+            "count key binding currently supports only goto-page",
+        ));
+    }
+    Ok("goto-page")
+}
+
+fn validate_configurable_key(keys: &[ShortcutKey]) -> AppResult<()> {
+    if keys.iter().any(|key| {
+        matches!(
+            key.code(),
+            crossterm::event::KeyCode::Esc | crossterm::event::KeyCode::Enter
+        )
+    }) {
+        return Err(AppError::invalid_argument(
+            "keymap bindings cannot use <esc> or <enter>",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_exact_keys(keys: &[ShortcutKey]) -> AppResult<()> {
+    SequenceRegistry::new()
+        .register_static(keys, Command::Quit)
+        .map(|_| ())
+        .map_err(key_registration_error)
+}
+
+fn validate_numeric_suffix(suffix: ShortcutKey) -> AppResult<()> {
+    SequenceRegistry::new()
+        .register_numeric_prefix("goto-page", suffix, |page| Command::GotoPage { page })
+        .map(|_| ())
+        .map_err(key_registration_error)
+}
+
+fn key_registration_error(err: SequenceRegistrationError) -> AppError {
+    AppError::invalid_argument(match err {
+        SequenceRegistrationError::EmptySequence => "key sequence must not be empty",
+        SequenceRegistrationError::ReservedKeyInSequence => {
+            "<esc> and <enter> cannot be used inside multi-key bindings"
+        }
+        SequenceRegistrationError::InvalidNumericSuffix => {
+            "count key binding suffix must not be a digit"
+        }
+        SequenceRegistrationError::ShiftCharBindingUnsupported => {
+            "shifted character bindings must use the resulting character"
+        }
+    })
+}
+
+fn numeric_prefix_factory(command_id: &str) -> Option<fn(usize) -> Command> {
+    match command_id {
+        "goto-page" => Some(|page| Command::GotoPage { page }),
+        _ => None,
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,5 @@
 mod file;
+mod keymap;
 mod options;
 mod policy;
 mod types;
@@ -8,7 +9,8 @@ pub use file::{
     load_options_from_explicit_path,
 };
 pub use options::{
-    AppOptions, CacheOptions, InputOptions, RenderOptions, ViewOptions, WatchOptions,
+    AppOptions, CacheOptions, InputOptions, KeymapBinding, KeymapOptions, KeymapPreset,
+    KeymapTarget, RenderOptions, ViewOptions, WatchOptions,
 };
 pub use policy::{
     AppOptionsResolver, CachePolicy, EventLoopPolicy, InputPolicy, RenderPolicy,

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -1,5 +1,6 @@
 use crate::app::{PageLayoutMode, SpreadCoverPolicy, SpreadDirection};
 
+pub use super::keymap::{KeymapBinding, KeymapOptions, KeymapPreset, KeymapTarget};
 use super::types::Config;
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -8,6 +9,7 @@ pub struct AppOptions {
     pub cache: CacheOptions,
     pub view: ViewOptions,
     pub input: InputOptions,
+    pub keymap: KeymapOptions,
     pub watch: WatchOptions,
 }
 
@@ -17,6 +19,7 @@ impl AppOptions {
         self.cache = self.cache.merge(next.cache);
         self.view = self.view.merge(next.view);
         self.input = self.input.merge(next.input);
+        self.keymap = self.keymap.merge(next.keymap);
         self.watch = self.watch.merge(next.watch);
         self
     }
@@ -53,6 +56,7 @@ impl From<Config> for AppOptions {
             input: InputOptions {
                 sequence_timeout_ms: Some(config.input.sequence_timeout_ms),
             },
+            keymap: KeymapOptions::default(),
             watch: WatchOptions {
                 enabled: Some(config.watch.enabled),
                 poll_interval_ms: Some(config.watch.poll_interval_ms),

--- a/src/config/policy.rs
+++ b/src/config/policy.rs
@@ -345,7 +345,7 @@ fn resolve_options(options: AppOptions) -> ResolvedAppOptions {
         },
         input: InputPolicy {
             sequence_timeout: Duration::from_millis(sequence_timeout_ms),
-            sequence_registry: build_builtin_sequence_registry(),
+            sequence_registry: super::keymap::resolve_sequence_registry(&options.keymap),
         },
         watch: WatchPolicy {
             enabled: options.watch.enabled.unwrap_or(watch_defaults.enabled),

--- a/src/input/sequence.rs
+++ b/src/input/sequence.rs
@@ -107,6 +107,39 @@ impl SequenceRegistry {
         Ok(())
     }
 
+    pub fn unregister_static(
+        &mut self,
+        keys: &[ShortcutKey],
+    ) -> Result<bool, SequenceRegistrationError> {
+        if keys.is_empty() {
+            return Err(SequenceRegistrationError::EmptySequence);
+        }
+        let keys = keys
+            .iter()
+            .copied()
+            .map(canonicalize_binding_key)
+            .collect::<Result<Vec<_>, _>>()?;
+        let original_len = self.bindings.len();
+        self.bindings
+            .retain(|binding| !matches!(binding, SequenceBinding::Exact { keys: existing, .. } if existing == &keys));
+        Ok(self.bindings.len() != original_len)
+    }
+
+    pub fn unregister_numeric_prefix(
+        &mut self,
+        suffix: ShortcutKey,
+    ) -> Result<bool, SequenceRegistrationError> {
+        let suffix = canonicalize_binding_key(suffix)?;
+        if is_digit_key(suffix) {
+            return Err(SequenceRegistrationError::InvalidNumericSuffix);
+        }
+        let original_len = self.bindings.len();
+        self.bindings.retain(|binding| {
+            !matches!(binding, SequenceBinding::NumericPrefix { suffix: existing, .. } if *existing == suffix)
+        });
+        Ok(self.bindings.len() != original_len)
+    }
+
     pub fn snapshot(&self) -> SequenceRegistrySnapshot {
         let mut snapshot = SequenceRegistrySnapshot::default();
         for binding in &self.bindings {
@@ -629,6 +662,46 @@ mod tests {
         let reset = resolver.handle_key(KeyEvent::new(KeyCode::Char('='), KeyModifiers::NONE));
         assert_eq!(reset, SequenceResolution::Dispatch(Command::ZoomReset));
         assert_eq!(resolver.pending_display(), None);
+    }
+
+    #[test]
+    fn unregister_static_removes_exact_binding() {
+        let mut registry = SequenceRegistry::new();
+        registry
+            .register_static(&[ShortcutKey::char('j')], Command::NextPage)
+            .expect("binding should register");
+
+        assert!(
+            registry
+                .unregister_static(&[ShortcutKey::char('j')])
+                .expect("binding should unregister")
+        );
+        let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
+        assert_eq!(
+            resolver.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)),
+            SequenceResolution::Noop
+        );
+    }
+
+    #[test]
+    fn unregister_numeric_prefix_removes_count_binding() {
+        let mut registry = SequenceRegistry::new();
+        registry
+            .register_numeric_prefix("goto-page", ShortcutKey::char('G'), |page| {
+                Command::GotoPage { page }
+            })
+            .expect("binding should register");
+
+        assert!(
+            registry
+                .unregister_numeric_prefix(ShortcutKey::char('G'))
+                .expect("binding should unregister")
+        );
+        let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
+        assert_eq!(
+            resolver.handle_key(KeyEvent::new(KeyCode::Char('4'), KeyModifiers::NONE)),
+            SequenceResolution::Noop
+        );
     }
 
     #[test]

--- a/src/input/shortcut.rs
+++ b/src/input/shortcut.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crossterm::event::{KeyCode, KeyModifiers};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -9,6 +11,31 @@ pub struct ShortcutKey {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShortcutKeyError {
     UnsupportedModifiers,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShortcutParseError {
+    Empty,
+    UnterminatedAngle,
+    EmptyAngle,
+    UnknownModifier(String),
+    DuplicateModifier(String),
+    UnknownKey(String),
+    UnsupportedModifiers,
+}
+
+impl fmt::Display for ShortcutParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "key sequence must not be empty"),
+            Self::UnterminatedAngle => write!(f, "unterminated angle key"),
+            Self::EmptyAngle => write!(f, "angle key must not be empty"),
+            Self::UnknownModifier(value) => write!(f, "unknown key modifier: {value}"),
+            Self::DuplicateModifier(value) => write!(f, "duplicate key modifier: {value}"),
+            Self::UnknownKey(value) => write!(f, "unknown key name: {value}"),
+            Self::UnsupportedModifiers => write!(f, "unsupported key modifiers"),
+        }
+    }
 }
 
 impl ShortcutKey {
@@ -86,6 +113,111 @@ pub fn format_shortcut_key(key: ShortcutKey) -> String {
     format!("<{}-{key_text}>", modifiers.join("-"))
 }
 
+pub fn parse_shortcut_sequence(input: &str) -> Result<Vec<ShortcutKey>, ShortcutParseError> {
+    if input.is_empty() {
+        return Err(ShortcutParseError::Empty);
+    }
+
+    let mut keys = Vec::new();
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch != '<' {
+            keys.push(ShortcutKey::char(ch));
+            continue;
+        }
+
+        let mut token = String::new();
+        loop {
+            let Some(next) = chars.next() else {
+                return Err(ShortcutParseError::UnterminatedAngle);
+            };
+            if next == '>' {
+                break;
+            }
+            token.push(next);
+        }
+        keys.push(parse_angle_key(&token)?);
+    }
+
+    if keys.is_empty() {
+        return Err(ShortcutParseError::Empty);
+    }
+    Ok(keys)
+}
+
+fn parse_angle_key(token: &str) -> Result<ShortcutKey, ShortcutParseError> {
+    if token.is_empty() {
+        return Err(ShortcutParseError::EmptyAngle);
+    }
+
+    let parts = token.split('-').collect::<Vec<_>>();
+    if parts.iter().any(|part| part.is_empty()) {
+        return Err(ShortcutParseError::UnknownKey(token.to_string()));
+    }
+
+    let key_name = parts[parts.len() - 1].to_ascii_lowercase();
+    let mut modifiers = KeyModifiers::NONE;
+    for modifier in &parts[..parts.len() - 1] {
+        let modifier = modifier.to_ascii_lowercase();
+        let bit = match modifier.as_str() {
+            "c" | "ctrl" | "control" => KeyModifiers::CONTROL,
+            "m" | "alt" => KeyModifiers::ALT,
+            "s" | "shift" => KeyModifiers::SHIFT,
+            _ => return Err(ShortcutParseError::UnknownModifier(modifier)),
+        };
+        if modifiers.contains(bit) {
+            return Err(ShortcutParseError::DuplicateModifier(modifier));
+        }
+        modifiers.insert(bit);
+    }
+
+    let mut code = parse_base_key(&key_name)?;
+    if code == KeyCode::Tab && modifiers.contains(KeyModifiers::SHIFT) {
+        code = KeyCode::BackTab;
+        modifiers.remove(KeyModifiers::SHIFT);
+    }
+
+    ShortcutKey::try_new(code, modifiers).map_err(|_| ShortcutParseError::UnsupportedModifiers)
+}
+
+fn parse_base_key(key_name: &str) -> Result<KeyCode, ShortcutParseError> {
+    Ok(match key_name {
+        "backspace" => KeyCode::Backspace,
+        "enter" => KeyCode::Enter,
+        "left" => KeyCode::Left,
+        "right" => KeyCode::Right,
+        "up" => KeyCode::Up,
+        "down" => KeyCode::Down,
+        "home" => KeyCode::Home,
+        "end" => KeyCode::End,
+        "pgup" | "pageup" => KeyCode::PageUp,
+        "pgdn" | "pagedown" => KeyCode::PageDown,
+        "tab" => KeyCode::Tab,
+        "backtab" => KeyCode::BackTab,
+        "del" | "delete" => KeyCode::Delete,
+        "ins" | "insert" => KeyCode::Insert,
+        "esc" | "escape" => KeyCode::Esc,
+        "space" => KeyCode::Char(' '),
+        _ if key_name.len() == 1 => {
+            let ch = key_name
+                .chars()
+                .next()
+                .expect("single-character key name should have one char");
+            KeyCode::Char(ch)
+        }
+        _ if key_name.starts_with('f') => {
+            let number = key_name[1..]
+                .parse::<u8>()
+                .map_err(|_| ShortcutParseError::UnknownKey(key_name.to_string()))?;
+            if number == 0 {
+                return Err(ShortcutParseError::UnknownKey(key_name.to_string()));
+            }
+            KeyCode::F(number)
+        }
+        _ => return Err(ShortcutParseError::UnknownKey(key_name.to_string())),
+    })
+}
+
 fn validate_modifiers(modifiers: KeyModifiers) -> Result<(), ShortcutKeyError> {
     if modifiers.intersects(KeyModifiers::SUPER | KeyModifiers::HYPER | KeyModifiers::META) {
         return Err(ShortcutKeyError::UnsupportedModifiers);
@@ -140,8 +272,9 @@ mod tests {
     use crossterm::event::{KeyCode, KeyModifiers};
 
     use super::{
-        ShortcutKey, ShortcutKeyError, format_shortcut_alternatives,
+        ShortcutKey, ShortcutKeyError, ShortcutParseError, format_shortcut_alternatives,
         format_shortcut_alternatives_tight, format_shortcut_key, format_shortcut_sequence,
+        parse_shortcut_sequence,
     };
 
     #[test]
@@ -223,6 +356,43 @@ mod tests {
         assert_eq!(
             ShortcutKey::try_new(KeyCode::Char('k'), KeyModifiers::SUPER),
             Err(ShortcutKeyError::UnsupportedModifiers)
+        );
+    }
+
+    #[test]
+    fn parses_printable_and_angle_key_sequences() {
+        assert_eq!(
+            parse_shortcut_sequence("gg").expect("sequence should parse"),
+            vec![ShortcutKey::char('g'), ShortcutKey::char('g')]
+        );
+        assert_eq!(
+            parse_shortcut_sequence("<c-o>").expect("sequence should parse"),
+            vec![ShortcutKey::ctrl('o')]
+        );
+        assert_eq!(
+            parse_shortcut_sequence("<down>").expect("sequence should parse"),
+            vec![ShortcutKey::key(KeyCode::Down)]
+        );
+        assert_eq!(
+            parse_shortcut_sequence("<space>").expect("sequence should parse"),
+            vec![ShortcutKey::char(' ')]
+        );
+        assert_eq!(
+            parse_shortcut_sequence("<s-tab>").expect("sequence should parse"),
+            vec![ShortcutKey::key(KeyCode::BackTab)]
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_shortcut_sequence_text() {
+        assert_eq!(parse_shortcut_sequence(""), Err(ShortcutParseError::Empty));
+        assert_eq!(
+            parse_shortcut_sequence("<c-o"),
+            Err(ShortcutParseError::UnterminatedAngle)
+        );
+        assert_eq!(
+            parse_shortcut_sequence("<super-o>"),
+            Err(ShortcutParseError::UnknownModifier("super".to_string()))
         );
     }
 }

--- a/src/input/shortcut.rs
+++ b/src/input/shortcut.rs
@@ -125,6 +125,10 @@ pub fn parse_shortcut_sequence(input: &str) -> Result<Vec<ShortcutKey>, Shortcut
             keys.push(ShortcutKey::char(ch));
             continue;
         }
+        if chars.peek().is_none() {
+            keys.push(ShortcutKey::char('<'));
+            continue;
+        }
 
         let mut token = String::new();
         loop {
@@ -380,6 +384,10 @@ mod tests {
         assert_eq!(
             parse_shortcut_sequence("<s-tab>").expect("sequence should parse"),
             vec![ShortcutKey::key(KeyCode::BackTab)]
+        );
+        assert_eq!(
+            parse_shortcut_sequence("<").expect("literal less-than should parse"),
+            vec![ShortcutKey::char('<')]
         );
     }
 


### PR DESCRIPTION
## Summary

- Add top-level `[keymap]` config with `preset`, `unbind`, and `[keymap.bindings]`.
- Parse key labels such as `gg`, `<c-o>`, `<down>`, and `[count]G` into the normal-mode sequence registry.
- Validate keymap commands against keymap invocation policy while leaving runtime availability checks to dispatch.
- Document the user-facing config shape and key binding contract.

## Rationale

Users need to customize normal-mode key bindings without changing built-in command behavior. This keeps command parsing and dispatch as the source of truth while letting config patch the runtime sequence registry.

## Verification

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customizable key binding configuration: users can now configure key bindings via TOML configuration files with support for preset selection, unbinding existing key sequences, creating new custom command bindings, and automatic validation with reserved key protection

* **Documentation**
  * New Configuration section documents where TOML config files are loaded and provides a detailed key binding customization guide with practical examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->