### PR TITLE
feat(input): treat enter as normal key

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -163,8 +163,8 @@ Contract:
   from the keymap; runtime availability remains a dispatch-time check.
 - Palette-local key handling is owned by palette behavior, not the normal-mode
   keymap.
-- `<esc>` and `<enter>` are not configurable normal-mode bindings while their
-  global cancellation and sequence-confirmation behavior is being settled.
+- `<esc>` is reserved for global cancellation and is not routed through the
+  normal-mode keymap.
 
 Compatibility:
 - Changing a default key binding affects user muscle memory and help output; do

--- a/src/app/input_ops.rs
+++ b/src/app/input_ops.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::backend::SharedPdfBackend;
 use crate::command::{
@@ -161,6 +161,10 @@ impl InteractionSubsystem {
     }
 
     fn help_command_for_key(key: KeyEvent) -> Option<Command> {
+        if key.modifiers != KeyModifiers::NONE {
+            return None;
+        }
+
         match key.code {
             KeyCode::Char('j') => Some(Command::HelpScrollDown),
             KeyCode::Char('k') => Some(Command::HelpScrollUp),
@@ -383,6 +387,13 @@ impl InteractionSubsystem {
                     )],
                 }
             }
+            SequenceResolution::DispatchWithRedraw(command) => KeyEventOutcome {
+                redraw: true,
+                commands: vec![CommandRequest::new(
+                    command,
+                    CommandInvocationSource::Keymap,
+                )],
+            },
         }
     }
 
@@ -556,6 +567,25 @@ mod tests {
         assert_eq!(state.help_scroll, 0);
         assert!(closed.commands.is_empty());
         assert!(closed.redraw);
+    }
+
+    #[test]
+    fn help_mode_ignores_modified_scroll_keys() {
+        let mut interaction = InteractionSubsystem::default();
+        let mut state = AppState {
+            mode: crate::app::Mode::Help,
+            ..AppState::default()
+        };
+
+        let outcome = interaction
+            .handle_key_event(
+                &mut state,
+                KeyEvent::new(KeyCode::Char('j'), KeyModifiers::CONTROL),
+            )
+            .expect("modified help key should be handled");
+
+        assert!(!outcome.redraw);
+        assert!(outcome.commands.is_empty());
     }
 
     #[test]
@@ -891,6 +921,45 @@ mod tests {
             mismatch.commands,
             vec![CommandRequest::new(
                 Command::OpenHelp,
+                CommandInvocationSource::Keymap,
+            )]
+        );
+        assert_eq!(interaction.pending_sequence_status(), None);
+    }
+
+    #[test]
+    fn pending_sequence_redraws_when_reprocessed_followup_dispatches() {
+        let mut registry = SequenceRegistry::new();
+        registry
+            .register_static(
+                &[ShortcutKey::char('g'), ShortcutKey::char('g')],
+                Command::FirstPage,
+            )
+            .expect("multi-key binding should register");
+        registry
+            .register_static(&[ShortcutKey::char('j')], Command::NextPage)
+            .expect("single-key binding should register");
+        let mut interaction = InteractionSubsystem::with_sequence_registry(registry);
+        let mut state = AppState::default();
+
+        interaction
+            .handle_key_event(
+                &mut state,
+                KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+            )
+            .expect("first key should be captured");
+
+        let mismatch = interaction
+            .handle_key_event(
+                &mut state,
+                KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+            )
+            .expect("mismatched key should be reprocessed");
+        assert!(mismatch.redraw);
+        assert_eq!(
+            mismatch.commands,
+            vec![CommandRequest::new(
+                Command::NextPage,
                 CommandInvocationSource::Keymap,
             )]
         );

--- a/src/app/input_ops.rs
+++ b/src/app/input_ops.rs
@@ -809,6 +809,41 @@ mod tests {
     }
 
     #[test]
+    fn pending_sequence_requests_redraw_when_unbound_followup_clears_it() {
+        let mut registry = SequenceRegistry::new();
+        registry
+            .register_static(
+                &[ShortcutKey::char('g'), ShortcutKey::char('g')],
+                Command::FirstPage,
+            )
+            .expect("multi-key binding should register");
+        let mut interaction = InteractionSubsystem::with_sequence_registry(registry);
+        let mut state = AppState::default();
+
+        interaction
+            .handle_key_event(
+                &mut state,
+                KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+            )
+            .expect("first key should be captured");
+        assert_eq!(
+            interaction.pending_sequence_status().as_deref(),
+            Some("keys g")
+        );
+
+        let mismatch = interaction
+            .handle_key_event(
+                &mut state,
+                KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+            )
+            .expect("mismatched key should clear the sequence");
+
+        assert!(mismatch.redraw);
+        assert!(mismatch.commands.is_empty());
+        assert_eq!(interaction.pending_sequence_status(), None);
+    }
+
+    #[test]
     fn wake_flushes_timed_out_sequence() {
         let mut registry = SequenceRegistry::new();
         registry

--- a/src/app/input_ops.rs
+++ b/src/app/input_ops.rs
@@ -381,8 +381,8 @@ impl InteractionSubsystem {
                 commands: Vec::new(),
             },
             SequenceResolution::DispatchThen { first, next } => {
-                // `DispatchThen` represents "commit the timed-out sequence, then keep
-                // processing the key that arrived after it" without dropping input.
+                // `DispatchThen` represents "commit the pending sequence, then keep
+                // processing the latest key" without dropping input.
                 let (first_redraw, first_quit_requested) =
                     Self::command_effects(&first, redraw_on_dispatch);
                 let mut outcome = Self::sequence_outcome(*next, redraw_on_dispatch);
@@ -723,7 +723,7 @@ mod tests {
     }
 
     #[test]
-    fn pending_sequence_waits_for_confirmation() {
+    fn pending_sequence_reprocesses_enter_after_mismatch() {
         let mut registry = SequenceRegistry::new();
         registry
             .register_static(&[ShortcutKey::char('g')], Command::FirstPage)
@@ -734,6 +734,9 @@ mod tests {
                 Command::LastPage,
             )
             .expect("multi-key binding should register");
+        registry
+            .register_static(&[ShortcutKey::key(KeyCode::Enter)], Command::NextPage)
+            .expect("enter binding should register");
         let mut interaction = InteractionSubsystem::with_sequence_registry(registry);
         let mut state = AppState::default();
 
@@ -750,23 +753,24 @@ mod tests {
             Some("keys g")
         );
 
-        let confirm = interaction
+        let mismatch = interaction
             .handle_key_event(
                 &mut state,
                 KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
             )
-            .expect("Enter should confirm the pending sequence");
-        assert!(matches!(
-            confirm.commands.as_slice(),
-            [request]
-                if request.command == Command::FirstPage
-                    && request.source == CommandInvocationSource::Keymap
-        ));
+            .expect("Enter should be reprocessed after the pending sequence");
+        assert_eq!(
+            mismatch.commands,
+            vec![
+                CommandRequest::new(Command::FirstPage, CommandInvocationSource::Keymap),
+                CommandRequest::new(Command::NextPage, CommandInvocationSource::Keymap),
+            ]
+        );
         assert_eq!(interaction.pending_sequence_status(), None);
     }
 
     #[test]
-    fn pending_sequence_prevents_help_toggle_from_stealing_followup_key() {
+    fn pending_sequence_reprocesses_followup_key_after_mismatch() {
         let mut registry = SequenceRegistry::new();
         registry
             .register_static(
@@ -774,6 +778,9 @@ mod tests {
                 Command::FirstPage,
             )
             .expect("multi-key binding should register");
+        registry
+            .register_static(&[ShortcutKey::char('?')], Command::OpenHelp)
+            .expect("single-key binding should register");
         let mut interaction = InteractionSubsystem::with_sequence_registry(registry);
         let mut state = AppState::default();
 
@@ -789,9 +796,15 @@ mod tests {
                 &mut state,
                 KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE),
             )
-            .expect("mismatched key should clear the sequence");
+            .expect("mismatched key should be reprocessed");
         assert!(mismatch.redraw);
-        assert!(mismatch.commands.is_empty());
+        assert_eq!(
+            mismatch.commands,
+            vec![CommandRequest::new(
+                Command::OpenHelp,
+                CommandInvocationSource::Keymap,
+            )]
+        );
         assert_eq!(interaction.pending_sequence_status(), None);
     }
 

--- a/src/app/input_ops.rs
+++ b/src/app/input_ops.rs
@@ -380,13 +380,17 @@ impl InteractionSubsystem {
                 quit_requested: true,
                 commands: Vec::new(),
             },
-            SequenceResolution::DispatchThen { first, next } => {
+            SequenceResolution::DispatchThen {
+                first,
+                next,
+                redraw,
+            } => {
                 // `DispatchThen` represents "commit the pending sequence, then keep
                 // processing the latest key" without dropping input.
                 let (first_redraw, first_quit_requested) =
                     Self::command_effects(&first, redraw_on_dispatch);
                 let mut outcome = Self::sequence_outcome(*next, redraw_on_dispatch);
-                outcome.redraw |= first_redraw;
+                outcome.redraw |= redraw || first_redraw;
                 outcome.quit_requested |= first_quit_requested;
                 outcome.commands.insert(
                     0,
@@ -766,6 +770,50 @@ mod tests {
                 CommandRequest::new(Command::NextPage, CommandInvocationSource::Keymap),
             ]
         );
+        assert!(mismatch.redraw);
+        assert_eq!(interaction.pending_sequence_status(), None);
+    }
+
+    #[test]
+    fn pending_exact_mismatch_requests_redraw_even_when_commands_do_not() {
+        let mut registry = SequenceRegistry::new();
+        registry
+            .register_static(&[ShortcutKey::char('x')], Command::DebugStatusHide)
+            .expect("single-key binding should register");
+        registry
+            .register_static(
+                &[ShortcutKey::char('x'), ShortcutKey::char('x')],
+                Command::NextPage,
+            )
+            .expect("multi-key binding should register");
+        let mut interaction = InteractionSubsystem::with_sequence_registry(registry);
+        let mut state = AppState::default();
+
+        interaction
+            .handle_key_event(
+                &mut state,
+                KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+            )
+            .expect("first key should be captured");
+        assert_eq!(
+            interaction.pending_sequence_status().as_deref(),
+            Some("keys x")
+        );
+
+        let mismatch = interaction
+            .handle_key_event(
+                &mut state,
+                KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE),
+            )
+            .expect("mismatched key should commit the pending sequence");
+        assert_eq!(
+            mismatch.commands,
+            vec![CommandRequest::new(
+                Command::DebugStatusHide,
+                CommandInvocationSource::Keymap,
+            )]
+        );
+        assert!(mismatch.redraw);
         assert_eq!(interaction.pending_sequence_status(), None);
     }
 

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -614,7 +614,7 @@ mod tests {
     }
 
     #[test]
-    fn keymap_config_rejects_escape_and_enter_bindings() {
+    fn keymap_config_rejects_escape_bindings() {
         let path = unique_temp_path("bad-keymap-key.toml");
         fs::write(
             &path,
@@ -626,9 +626,30 @@ mod tests {
         .expect("config file should be written");
 
         let err = load_options_from_explicit_path(&path).expect_err("config should be rejected");
-        assert!(
-            err.to_string().contains("<esc> or <enter>"),
-            "unexpected error: {err}"
+        assert!(err.to_string().contains("<esc>"), "unexpected error: {err}");
+
+        fs::remove_file(&path).expect("config file should be removed");
+    }
+
+    #[test]
+    fn keymap_config_accepts_enter_bindings() {
+        let path = unique_temp_path("enter-keymap-key.toml");
+        fs::write(
+            &path,
+            r#"
+            [keymap.bindings]
+            "<enter>" = "next-page"
+            "#,
+        )
+        .expect("config file should be written");
+
+        let options = load_options_from_explicit_path(&path).expect("config should load");
+        assert_eq!(
+            options.keymap.bindings,
+            vec![KeymapBinding::Exact {
+                keys: vec![ShortcutKey::key(KeyCode::Enter)],
+                command: Command::NextPage,
+            }]
         );
 
         fs::remove_file(&path).expect("config file should be removed");

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -168,14 +168,12 @@ fn parse_numeric_prefix_command(command_text: &str) -> AppResult<&'static str> {
 }
 
 fn validate_configurable_key(keys: &[ShortcutKey]) -> AppResult<()> {
-    if keys.iter().any(|key| {
-        matches!(
-            key.code(),
-            crossterm::event::KeyCode::Esc | crossterm::event::KeyCode::Enter
-        )
-    }) {
+    if keys
+        .iter()
+        .any(|key| matches!(key.code(), crossterm::event::KeyCode::Esc))
+    {
         return Err(AppError::invalid_argument(
-            "keymap bindings cannot use <esc> or <enter>",
+            "keymap bindings cannot use <esc>",
         ));
     }
     Ok(())
@@ -199,7 +197,7 @@ fn key_registration_error(err: SequenceRegistrationError) -> AppError {
     AppError::invalid_argument(match err {
         SequenceRegistrationError::EmptySequence => "key sequence must not be empty",
         SequenceRegistrationError::ReservedKeyInSequence => {
-            "<esc> and <enter> cannot be used inside multi-key bindings"
+            "<esc> cannot be used inside multi-key bindings"
         }
         SequenceRegistrationError::InvalidNumericSuffix => {
             "count key binding suffix must not be a digit"

--- a/src/input/sequence.rs
+++ b/src/input/sequence.rs
@@ -375,14 +375,16 @@ impl SequenceResolver {
                     return SequenceResolution::Noop;
                 }
 
-                let next = Box::new(self.handle_normalized_key(latest_key));
                 if let Some(command) = pending_exact {
                     SequenceResolution::DispatchThen {
                         first: command,
-                        next,
+                        next: Box::new(self.handle_normalized_key(latest_key)),
                     }
                 } else {
-                    *next
+                    match self.handle_normalized_key(latest_key) {
+                        SequenceResolution::Noop => SequenceResolution::Cleared,
+                        next => next,
+                    }
                 }
             }
         }
@@ -709,6 +711,27 @@ mod tests {
 
         let mismatch = resolver.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
         assert_eq!(mismatch, SequenceResolution::Dispatch(Command::NextPage));
+        assert_eq!(resolver.pending_display(), None);
+    }
+
+    #[test]
+    fn mismatch_after_pending_prefix_reports_clear_when_latest_key_is_unbound() {
+        let mut registry = SequenceRegistry::new();
+        registry
+            .register_static(
+                &[ShortcutKey::char('g'), ShortcutKey::char('g')],
+                Command::FirstPage,
+            )
+            .expect("multi-key binding should register");
+        let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
+
+        assert_eq!(
+            resolver.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+            SequenceResolution::Pending
+        );
+
+        let mismatch = resolver.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+        assert_eq!(mismatch, SequenceResolution::Cleared);
         assert_eq!(resolver.pending_display(), None);
     }
 

--- a/src/input/sequence.rs
+++ b/src/input/sequence.rs
@@ -196,8 +196,8 @@ pub enum SequenceResolution {
     Pending,
     Cleared,
     Dispatch(Command),
-    // When a timed-out prefix is confirmed by the next key press, the old command
-    // must be emitted first and the new key must still be processed immediately.
+    // When a pending sequence is committed before processing the latest key, the
+    // old command must be emitted first and the new key must still be processed.
     DispatchThen {
         first: Command,
         next: Box<SequenceResolution>,
@@ -273,6 +273,9 @@ impl SequenceResolver {
     }
 
     fn handle_normalized_key(&mut self, key: ShortcutKey) -> SequenceResolution {
+        let pending_exact = (!self.state.is_empty())
+            .then(|| self.registry.match_buffer(self.state.as_slice()).exact)
+            .flatten();
         let had_pending = !self.state.is_empty();
 
         if had_pending {
@@ -297,13 +300,10 @@ impl SequenceResolver {
                 self.state.clear();
                 return SequenceResolution::Cleared;
             }
-            if key.code() == KeyCode::Enter {
-                return self.confirm_pending();
-            }
         }
 
         self.state.push(key);
-        self.resolve_pending_after_input(had_pending)
+        self.resolve_pending_after_input(key, pending_exact)
     }
 
     pub fn flush_timeout(&mut self) -> SequenceResolution {
@@ -356,7 +356,11 @@ impl SequenceResolver {
         }
     }
 
-    fn resolve_pending_after_input(&mut self, had_pending: bool) -> SequenceResolution {
+    fn resolve_pending_after_input(
+        &mut self,
+        latest_key: ShortcutKey,
+        pending_exact: Option<Command>,
+    ) -> SequenceResolution {
         let matched = self.registry.match_buffer(self.state.as_slice());
         match (matched.exact, matched.has_prefix) {
             (Some(command), false) => {
@@ -365,11 +369,20 @@ impl SequenceResolver {
             }
             (Some(_), true) | (None, true) => SequenceResolution::Pending,
             (None, false) => {
+                let had_pending = self.state.as_slice().len() > 1;
                 self.state.clear();
-                if had_pending {
-                    SequenceResolution::Cleared
+                if !had_pending {
+                    return SequenceResolution::Noop;
+                }
+
+                let next = Box::new(self.handle_normalized_key(latest_key));
+                if let Some(command) = pending_exact {
+                    SequenceResolution::DispatchThen {
+                        first: command,
+                        next,
+                    }
                 } else {
-                    SequenceResolution::Noop
+                    *next
                 }
             }
         }
@@ -469,7 +482,7 @@ fn normalize_shortcut_key(key: ShortcutKey) -> ShortcutKey {
 }
 
 fn is_reserved_sequence_key(key: ShortcutKey) -> bool {
-    matches!(key.code(), KeyCode::Enter | KeyCode::Esc)
+    matches!(key.code(), KeyCode::Esc)
 }
 
 fn is_digit_key(key: ShortcutKey) -> bool {
@@ -521,7 +534,7 @@ mod tests {
     }
 
     #[test]
-    fn ambiguous_exact_waits_for_timeout_or_confirmation() {
+    fn ambiguous_exact_waits_for_timeout() {
         let mut registry = SequenceRegistry::new();
         registry
             .register_static(&[ShortcutKey::char('g')], Command::FirstPage)
@@ -544,7 +557,21 @@ mod tests {
     }
 
     #[test]
-    fn enter_confirms_pending_exact_match() {
+    fn enter_dispatches_as_a_regular_exact_binding() {
+        let mut registry = SequenceRegistry::new();
+        registry
+            .register_static(&[ShortcutKey::key(KeyCode::Enter)], Command::NextPage)
+            .expect("enter binding should register");
+        let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
+
+        let resolution = resolver.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        assert_eq!(resolution, SequenceResolution::Dispatch(Command::NextPage));
+        assert_eq!(resolver.pending_display(), None);
+    }
+
+    #[test]
+    fn enter_after_pending_exact_match_reprocesses_as_next_key() {
         let mut registry = SequenceRegistry::new();
         registry
             .register_static(&[ShortcutKey::char('g')], Command::FirstPage)
@@ -555,6 +582,9 @@ mod tests {
                 Command::LastPage,
             )
             .expect("multi-key binding should register");
+        registry
+            .register_static(&[ShortcutKey::key(KeyCode::Enter)], Command::NextPage)
+            .expect("enter binding should register");
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
         assert_eq!(
@@ -562,8 +592,14 @@ mod tests {
             SequenceResolution::Pending
         );
 
-        let confirm = resolver.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
-        assert_eq!(confirm, SequenceResolution::Dispatch(Command::FirstPage));
+        let resolution = resolver.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(
+            resolution,
+            SequenceResolution::DispatchThen {
+                first: Command::FirstPage,
+                next: Box::new(SequenceResolution::Dispatch(Command::NextPage)),
+            }
+        );
     }
 
     #[test]
@@ -599,14 +635,41 @@ mod tests {
     }
 
     #[test]
-    fn mismatch_clears_pending_buffer_without_retrying_latest_key() {
+    fn enter_can_be_part_of_a_multi_key_binding() {
         let mut registry = SequenceRegistry::new();
         registry
             .register_static(
-                &[ShortcutKey::char('g'), ShortcutKey::char('g')],
+                &[ShortcutKey::char('g'), ShortcutKey::key(KeyCode::Enter)],
                 Command::FirstPage,
             )
+            .expect("enter should be usable in multi-key bindings");
+        let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
+
+        assert_eq!(
+            resolver.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+            SequenceResolution::Pending
+        );
+
+        let resolution = resolver.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(resolution, SequenceResolution::Dispatch(Command::FirstPage));
+        assert_eq!(resolver.pending_display(), None);
+    }
+
+    #[test]
+    fn mismatch_after_pending_exact_match_reprocesses_latest_key() {
+        let mut registry = SequenceRegistry::new();
+        registry
+            .register_static(&[ShortcutKey::char('g')], Command::FirstPage)
+            .expect("single-key binding should register");
+        registry
+            .register_static(
+                &[ShortcutKey::char('g'), ShortcutKey::char('g')],
+                Command::LastPage,
+            )
             .expect("multi-key binding should register");
+        registry
+            .register_static(&[ShortcutKey::char('x')], Command::NextPage)
+            .expect("single-key binding should register");
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
         assert_eq!(
@@ -615,7 +678,37 @@ mod tests {
         );
 
         let mismatch = resolver.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
-        assert_eq!(mismatch, SequenceResolution::Cleared);
+        assert_eq!(
+            mismatch,
+            SequenceResolution::DispatchThen {
+                first: Command::FirstPage,
+                next: Box::new(SequenceResolution::Dispatch(Command::NextPage)),
+            }
+        );
+        assert_eq!(resolver.pending_display(), None);
+    }
+
+    #[test]
+    fn mismatch_after_pending_prefix_reprocesses_latest_key() {
+        let mut registry = SequenceRegistry::new();
+        registry
+            .register_static(
+                &[ShortcutKey::char('g'), ShortcutKey::char('g')],
+                Command::FirstPage,
+            )
+            .expect("multi-key binding should register");
+        registry
+            .register_static(&[ShortcutKey::char('x')], Command::NextPage)
+            .expect("single-key binding should register");
+        let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
+
+        assert_eq!(
+            resolver.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+            SequenceResolution::Pending
+        );
+
+        let mismatch = resolver.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+        assert_eq!(mismatch, SequenceResolution::Dispatch(Command::NextPage));
         assert_eq!(resolver.pending_display(), None);
     }
 
@@ -705,15 +798,15 @@ mod tests {
     }
 
     #[test]
-    fn registry_rejects_reserved_keys_in_multikey_sequences() {
+    fn registry_rejects_escape_in_multikey_sequences() {
         let mut registry = SequenceRegistry::new();
 
         let error = registry
             .register_static(
-                &[ShortcutKey::char('g'), ShortcutKey::key(KeyCode::Enter)],
+                &[ShortcutKey::char('g'), ShortcutKey::key(KeyCode::Esc)],
                 Command::FirstPage,
             )
-            .expect_err("Enter should be reserved in multi-key bindings");
+            .expect_err("Esc should be reserved in multi-key bindings");
         assert_eq!(error, SequenceRegistrationError::ReservedKeyInSequence);
     }
 

--- a/src/input/sequence.rs
+++ b/src/input/sequence.rs
@@ -196,6 +196,7 @@ pub enum SequenceResolution {
     Pending,
     Cleared,
     Dispatch(Command),
+    DispatchWithRedraw(Command),
     // When a pending sequence is committed before processing the latest key, the
     // old command must be emitted first and the new key must still be processed.
     DispatchThen {
@@ -292,8 +293,12 @@ impl SequenceResolver {
                     SequenceResolution::Cleared | SequenceResolution::Noop => {
                         self.handle_normalized_key(key)
                     }
-                    SequenceResolution::Pending | SequenceResolution::DispatchThen { .. } => {
-                        unreachable!("confirming a timed out sequence cannot remain pending")
+                    SequenceResolution::Pending
+                    | SequenceResolution::DispatchWithRedraw(_)
+                    | SequenceResolution::DispatchThen { .. } => {
+                        unreachable!(
+                            "confirming a timed out sequence cannot return a derived resolution"
+                        )
                     }
                 };
             }
@@ -390,6 +395,9 @@ impl SequenceResolver {
                 } else {
                     match self.handle_normalized_key(latest_key) {
                         SequenceResolution::Noop => SequenceResolution::Cleared,
+                        SequenceResolution::Dispatch(command) => {
+                            SequenceResolution::DispatchWithRedraw(command)
+                        }
                         next => next,
                     }
                 }
@@ -734,7 +742,10 @@ mod tests {
         );
 
         let mismatch = resolver.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
-        assert_eq!(mismatch, SequenceResolution::Dispatch(Command::NextPage));
+        assert_eq!(
+            mismatch,
+            SequenceResolution::DispatchWithRedraw(Command::NextPage)
+        );
         assert_eq!(resolver.pending_display(), None);
     }
 

--- a/src/input/sequence.rs
+++ b/src/input/sequence.rs
@@ -201,6 +201,7 @@ pub enum SequenceResolution {
     DispatchThen {
         first: Command,
         next: Box<SequenceResolution>,
+        redraw: bool,
     },
 }
 
@@ -286,6 +287,7 @@ impl SequenceResolver {
                     SequenceResolution::Dispatch(command) => SequenceResolution::DispatchThen {
                         first: command,
                         next: Box::new(self.handle_normalized_key(key)),
+                        redraw: true,
                     },
                     SequenceResolution::Cleared | SequenceResolution::Noop => {
                         self.handle_normalized_key(key)
@@ -379,6 +381,7 @@ impl SequenceResolver {
                     SequenceResolution::DispatchThen {
                         first: command,
                         next: Box::new(self.handle_normalized_key(latest_key)),
+                        redraw: true,
                     }
                 } else {
                     match self.handle_normalized_key(latest_key) {
@@ -600,6 +603,7 @@ mod tests {
             SequenceResolution::DispatchThen {
                 first: Command::FirstPage,
                 next: Box::new(SequenceResolution::Dispatch(Command::NextPage)),
+                redraw: true,
             }
         );
     }
@@ -632,6 +636,7 @@ mod tests {
             SequenceResolution::DispatchThen {
                 first: Command::FirstPage,
                 next: Box::new(SequenceResolution::Dispatch(Command::NextPage)),
+                redraw: true,
             }
         );
     }
@@ -685,6 +690,7 @@ mod tests {
             SequenceResolution::DispatchThen {
                 first: Command::FirstPage,
                 next: Box::new(SequenceResolution::Dispatch(Command::NextPage)),
+                redraw: true,
             }
         );
         assert_eq!(resolver.pending_display(), None);


### PR DESCRIPTION
## Summary

- Treat `Enter` as a normal key in the normal-mode sequence resolver instead of a pending-sequence confirmation key.
- Reprocess mismatched follow-up keys so input is not dropped, while preserving redraw when a pending prefix is cleared by an unbound key.
- Keep `Esc` reserved for global cancellation and leave palette-local `Enter` handling unchanged.

## Rationale

Normal-mode `Enter` should follow the same routing rules as other non-reserved keys. This makes ambiguous sequences resolve through timeout or follow-up-key disambiguation instead of a dedicated confirmation path.

## Verification

- `cargo fmt --check`
- `cargo test`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated key binding documentation to state that `<esc>` is reserved for global cancellation and is not configurable.

* **Bug Fixes**
  * `<enter>` is now accepted as a normal-mode configurable key binding.
  * Improved multi-key sequence handling so follow-up keys are reprocessed correctly after mismatches, including ensuring redraws occur when pending sequence state is cleared.

* **Tests**
  * Updated and expanded key sequence coverage to match the revised pending/mismatch reprocessing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->