### PR TITLE
fix(command): route quit through command dispatch

### DIFF
--- a/src/app/actors.rs
+++ b/src/app/actors.rs
@@ -55,8 +55,7 @@ impl InputActor {
         state: &mut AppState,
     ) -> AppResult<LoopEffects> {
         let timeout_outcome = interaction.flush_sequence_timeout(state.mode);
-        let mut effects =
-            LoopEffects::from_commands(timeout_outcome.commands, timeout_outcome.quit_requested);
+        let mut effects = LoopEffects::from_commands(timeout_outcome.commands);
         if timeout_outcome.redraw {
             effects.request_redraw(RedrawReason::Input);
         }
@@ -73,8 +72,7 @@ impl InputActor {
             Event::Key(key) if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) => {
                 self.last_input_at = Instant::now();
                 let outcome = interaction.handle_key_event(state, key)?;
-                let mut effects =
-                    LoopEffects::from_commands(outcome.commands, outcome.quit_requested);
+                let mut effects = LoopEffects::from_commands(outcome.commands);
                 if outcome.redraw {
                     effects.request_redraw(RedrawReason::Input);
                 }

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -822,7 +822,7 @@ mod tests {
     }
 
     #[test]
-    fn input_outcome_queues_commands_before_quit_event() {
+    fn input_outcome_queues_expired_command_before_quit_command() {
         let tokio_runtime = Builder::new_current_thread()
             .enable_all()
             .build()
@@ -889,7 +889,8 @@ mod tests {
         ));
         assert!(matches!(
             runtime.loop_event_rx.try_recv(),
-            Ok(DomainEvent::Quit)
+            Ok(DomainEvent::Command(request))
+                if request == CommandRequest::new(Command::Quit, CommandInvocationSource::Keymap)
         ));
     }
 

--- a/src/app/input_ops.rs
+++ b/src/app/input_ops.rs
@@ -19,7 +19,6 @@ use super::state::{AppState, Mode, PaletteRequest, notice_action_for_error};
 #[derive(Debug, Clone, Default)]
 pub(crate) struct KeyEventOutcome {
     pub redraw: bool,
-    pub quit_requested: bool,
     pub commands: Vec<CommandRequest>,
 }
 
@@ -76,7 +75,6 @@ impl InteractionSubsystem {
         let search_active = self.extensions.host.ui_snapshot().search_active;
         KeyEventOutcome {
             redraw: search_active,
-            quit_requested: false,
             commands: if search_active {
                 vec![CommandRequest::new(
                     Command::CancelSearch,
@@ -105,7 +103,6 @@ impl InteractionSubsystem {
         match result {
             PaletteKeyResult::Consumed { redraw } => Ok(KeyEventOutcome {
                 redraw,
-                quit_requested: false,
                 commands: Vec::new(),
             }),
             PaletteKeyResult::Submit(action) => {
@@ -113,7 +110,6 @@ impl InteractionSubsystem {
                     self.handle_palette_submit_effect(state, action.session_id, action.effect)?;
                 Ok(KeyEventOutcome {
                     redraw: changed_by_palette,
-                    quit_requested: false,
                     commands: command.into_iter().collect(),
                 })
             }
@@ -121,7 +117,6 @@ impl InteractionSubsystem {
                 state.apply_notice_action(notice_action_for_error(err));
                 Ok(KeyEventOutcome {
                     redraw: true,
-                    quit_requested: false,
                     commands: Vec::new(),
                 })
             }
@@ -138,14 +133,12 @@ impl InteractionSubsystem {
                 InputHookResult::Consumed => {
                     return KeyEventOutcome {
                         redraw: true,
-                        quit_requested: false,
                         commands: Vec::new(),
                     };
                 }
                 InputHookResult::EmitCommand(ext_command) => {
                     return KeyEventOutcome {
                         redraw: false,
-                        quit_requested: false,
                         commands: vec![CommandRequest::new(
                             ext_command,
                             CommandInvocationSource::Keymap,
@@ -165,7 +158,6 @@ impl InteractionSubsystem {
                 state.scroll_help_by(delta);
                 KeyEventOutcome {
                     redraw: true,
-                    quit_requested: false,
                     commands: Vec::new(),
                 }
             }
@@ -247,7 +239,6 @@ impl InteractionSubsystem {
         };
         Some(KeyEventOutcome {
             redraw: closed,
-            quit_requested: false,
             commands: Vec::new(),
         })
     }
@@ -357,11 +348,8 @@ impl InteractionSubsystem {
         }
     }
 
-    fn command_effects(command: &Command, redraw_on_dispatch: bool) -> (bool, bool) {
-        (
-            redraw_on_dispatch || matches!(command, Command::OpenHelp),
-            matches!(command, Command::Quit),
-        )
+    fn command_redraw(command: &Command, redraw_on_dispatch: bool) -> bool {
+        redraw_on_dispatch || matches!(command, Command::OpenHelp)
     }
 
     fn sequence_outcome(
@@ -372,22 +360,14 @@ impl InteractionSubsystem {
             SequenceResolution::Noop => KeyEventOutcome::default(),
             SequenceResolution::Pending | SequenceResolution::Cleared => KeyEventOutcome {
                 redraw: true,
-                quit_requested: false,
-                commands: Vec::new(),
-            },
-            SequenceResolution::Dispatch(Command::Quit) => KeyEventOutcome {
-                redraw: false,
-                quit_requested: true,
                 commands: Vec::new(),
             },
             SequenceResolution::DispatchThen { first, next } => {
                 // `DispatchThen` represents "commit the timed-out sequence, then keep
                 // processing the key that arrived after it" without dropping input.
-                let (first_redraw, first_quit_requested) =
-                    Self::command_effects(&first, redraw_on_dispatch);
+                let first_redraw = Self::command_redraw(&first, redraw_on_dispatch);
                 let mut outcome = Self::sequence_outcome(*next, redraw_on_dispatch);
                 outcome.redraw |= first_redraw;
-                outcome.quit_requested |= first_quit_requested;
                 outcome.commands.insert(
                     0,
                     CommandRequest::new(first, CommandInvocationSource::Keymap),
@@ -395,10 +375,9 @@ impl InteractionSubsystem {
                 outcome
             }
             SequenceResolution::Dispatch(command) => {
-                let (redraw, _) = Self::command_effects(&command, redraw_on_dispatch);
+                let redraw = Self::command_redraw(&command, redraw_on_dispatch);
                 KeyEventOutcome {
                     redraw,
-                    quit_requested: false,
                     commands: vec![CommandRequest::new(
                         command,
                         CommandInvocationSource::Keymap,
@@ -490,7 +469,7 @@ mod tests {
     }
 
     #[test]
-    fn quit_key_requests_immediate_quit_without_command_requeue() {
+    fn quit_key_dispatches_quit_command() {
         let mut interaction = InteractionSubsystem::default();
         let mut state = AppState::default();
 
@@ -501,8 +480,13 @@ mod tests {
             )
             .expect("quit key should be handled");
 
-        assert!(outcome.quit_requested);
-        assert!(outcome.commands.is_empty());
+        assert_eq!(
+            outcome.commands,
+            vec![CommandRequest::new(
+                Command::Quit,
+                CommandInvocationSource::Keymap,
+            )]
+        );
         assert!(!outcome.redraw);
     }
 
@@ -593,14 +577,13 @@ mod tests {
                 &mut state,
             )
             .expect("help close should be handled");
-        let (commands, events, redraws, quit_requested) = effects.into_parts();
+        let (commands, events, redraws) = effects.into_parts();
 
         assert_eq!(state.mode, Mode::Normal);
         assert_eq!(state.help_scroll, 0);
         assert!(!redraws.is_empty());
         assert!(commands.is_empty());
         assert!(events.is_empty());
-        assert!(!quit_requested);
     }
 
     #[test]
@@ -627,13 +610,12 @@ mod tests {
                 &mut state,
             )
             .expect("palette close should be handled");
-        let (commands, events, redraws, quit_requested) = effects.into_parts();
+        let (commands, events, redraws) = effects.into_parts();
 
         assert_eq!(state.mode, Mode::Normal);
         assert!(!redraws.is_empty());
         assert!(commands.is_empty());
         assert!(events.is_empty());
-        assert!(!quit_requested);
     }
 
     #[test]
@@ -660,7 +642,7 @@ mod tests {
                 &mut state,
             )
             .expect("palette submit should be handled");
-        let (commands, events, redraws, quit_requested) = effects.into_parts();
+        let (commands, events, redraws) = effects.into_parts();
 
         assert_eq!(state.mode, Mode::Normal);
         assert!(!redraws.is_empty());
@@ -671,7 +653,6 @@ mod tests {
                     && request.source == CommandInvocationSource::PaletteProvider
         ));
         assert!(events.is_empty());
-        assert!(!quit_requested);
     }
 
     #[test]
@@ -718,7 +699,6 @@ mod tests {
             Some(NoticeLevel::Warning)
         );
         assert!(outcome.redraw);
-        assert!(!outcome.quit_requested);
         assert!(outcome.commands.is_empty());
     }
 
@@ -856,7 +836,6 @@ mod tests {
         let flushed = interaction.flush_sequence_timeout(state.mode);
 
         assert!(!flushed.redraw);
-        assert!(!flushed.quit_requested);
         assert!(flushed.commands.is_empty());
         assert_eq!(interaction.pending_sequence_status(), None);
     }
@@ -979,7 +958,7 @@ mod tests {
     }
 
     #[test]
-    fn timed_out_sequence_followed_by_quit_sets_quit_requested() {
+    fn timed_out_sequence_followed_by_quit_dispatches_expired_command_then_quit() {
         let mut registry = SequenceRegistry::new();
         registry
             .register_static(&[ShortcutKey::char('g')], Command::FirstPage)
@@ -1009,15 +988,14 @@ mod tests {
                 &mut state,
                 KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE),
             )
-            .expect("next key should queue the expired command and request quit");
+            .expect("next key should queue the expired command and quit command");
 
-        assert!(next.quit_requested);
         assert_eq!(
             next.commands,
-            vec![CommandRequest::new(
-                Command::FirstPage,
-                CommandInvocationSource::Keymap,
-            )]
+            vec![
+                CommandRequest::new(Command::FirstPage, CommandInvocationSource::Keymap,),
+                CommandRequest::new(Command::Quit, CommandInvocationSource::Keymap,)
+            ]
         );
     }
 

--- a/src/app/loop_effects.rs
+++ b/src/app/loop_effects.rs
@@ -7,7 +7,6 @@ pub(super) struct LoopEffects {
     commands: Vec<CommandRequest>,
     events: Vec<DomainEvent>,
     redraws: Vec<RedrawReason>,
-    quit_requested: bool,
 }
 
 impl LoopEffects {
@@ -15,10 +14,9 @@ impl LoopEffects {
         Self::default()
     }
 
-    pub(super) fn from_commands(commands: Vec<CommandRequest>, quit_requested: bool) -> Self {
+    pub(super) fn from_commands(commands: Vec<CommandRequest>) -> Self {
         Self {
             commands,
-            quit_requested,
             ..Self::default()
         }
     }
@@ -31,19 +29,7 @@ impl LoopEffects {
         self.redraws.push(reason);
     }
 
-    pub(super) fn into_parts(
-        self,
-    ) -> (
-        Vec<CommandRequest>,
-        Vec<DomainEvent>,
-        Vec<RedrawReason>,
-        bool,
-    ) {
-        (
-            self.commands,
-            self.events,
-            self.redraws,
-            self.quit_requested,
-        )
+    pub(super) fn into_parts(self) -> (Vec<CommandRequest>, Vec<DomainEvent>, Vec<RedrawReason>) {
+        (self.commands, self.events, self.redraws)
     }
 }

--- a/src/app/loop_router.rs
+++ b/src/app/loop_router.rs
@@ -37,7 +37,7 @@ impl App {
     where
         S: TerminalSurface,
     {
-        let (commands, events, redraws, quit_requested) = effects.into_parts();
+        let (commands, events, redraws) = effects.into_parts();
         for reason in redraws {
             self.request_redraw(runtime, reason);
         }
@@ -54,9 +54,6 @@ impl App {
             if runtime.loop_event_tx.send(event).is_err() {
                 return LoopControl::Break;
             }
-        }
-        if quit_requested && runtime.loop_event_tx.send(DomainEvent::Quit).is_err() {
-            return LoopControl::Break;
         }
         LoopControl::Continue
     }
@@ -151,9 +148,6 @@ impl App {
             }
             WaitEvent::Event(DomainEvent::DocumentReloaded(result)) => {
                 self.handle_document_reload_result(runtime, document, result)?;
-            }
-            WaitEvent::Event(DomainEvent::Quit) => {
-                terminate_process_now(runtime);
             }
             WaitEvent::Event(DomainEvent::Wake) => {}
             WaitEvent::Closed => return Ok(LoopControl::Break),

--- a/src/command/dispatch.rs
+++ b/src/command/dispatch.rs
@@ -310,6 +310,33 @@ mod tests {
     }
 
     #[test]
+    fn dispatch_quit_requests_quit_and_emits_command_executed() {
+        let mut app = AppState::default();
+        let pdf = Arc::new(StubPdf::new(3)) as SharedPdfBackend;
+        let mut host = ExtensionHost::default();
+        let mut palette_requests = VecDeque::new();
+
+        let result = dispatch(
+            &mut app,
+            Command::Quit,
+            CommandInvocationSource::Keymap,
+            pdf,
+            &mut host,
+            &mut palette_requests,
+        )
+        .expect("dispatch should succeed");
+
+        assert_eq!(result.outcome, CommandOutcome::QuitRequested);
+        assert_eq!(
+            result.emitted_events,
+            vec![AppEvent::CommandExecuted {
+                id: CommandId::Quit,
+                outcome: CommandOutcome::QuitRequested,
+            }]
+        );
+    }
+
+    #[test]
     fn dispatch_next_page_emits_page_changed_and_command_executed() {
         let mut app = AppState::default();
         let pdf = Arc::new(StubPdf::new(3)) as SharedPdfBackend;

--- a/src/event.rs
+++ b/src/event.rs
@@ -118,7 +118,6 @@ pub(crate) enum DomainEvent {
     Input(Event),
     InputError(String),
     Command(CommandRequest),
-    Quit,
     App(AppEvent),
     ReloadDocument(DocumentReloadRequest),
     DocumentReloaded(DocumentReloadResult),


### PR DESCRIPTION
## Summary
- route keymap quit through Command::Quit instead of a separate quit flag/event path
- remove the unused KeyEventOutcome/LoopEffects quit plumbing and DomainEvent::Quit
- add coverage for quit dispatch and keymap sequencing

## Rationale
Keeping quit as a normal command makes keymap, configured keymap, and typed command behavior use the same command contract while preserving immediate termination through CommandOutcome::QuitRequested.

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal event handling and command dispatch workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->