### PR TITLE
feat(command): add help scroll commands

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -121,6 +121,8 @@ Contract:
   command palette input.
 - Internal-only commands can be invoked only by provider-driven internal flows.
 - Availability checks are separate from invocation policy.
+- Availability may depend on runtime app state such as active mode, not only on
+  invocation source.
 - Command dispatch emits command execution events after validation and dispatch
   complete, including rejected commands.
 
@@ -163,6 +165,8 @@ Contract:
   from the keymap; runtime availability remains a dispatch-time check.
 - Palette-local key handling is owned by palette behavior, not the normal-mode
   keymap.
+- Help-mode-local keys are handled by the help input route when the help overlay
+  is active; they may dispatch commands without being normal-mode bindings.
 - `<esc>` and `<enter>` are not configurable normal-mode bindings while their
   global cancellation and sequence-confirmation behavior is being settled.
 

--- a/src/app/input_ops.rs
+++ b/src/app/input_ops.rs
@@ -31,12 +31,6 @@ enum KeyEventRoute {
     Normal,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum HelpKeyAction {
-    ScrollBy(isize),
-    Ignore,
-}
-
 impl InteractionSubsystem {
     pub(crate) fn handle_key_event(
         &mut self,
@@ -159,25 +153,26 @@ impl InteractionSubsystem {
         Self::sequence_outcome(resolution, false)
     }
 
-    fn handle_help_key_event(&mut self, state: &mut AppState, key: KeyEvent) -> KeyEventOutcome {
-        match Self::classify_help_key(key) {
-            HelpKeyAction::ScrollBy(delta) => {
-                state.scroll_help_by(delta);
-                KeyEventOutcome {
-                    redraw: true,
-                    quit_requested: false,
-                    commands: Vec::new(),
-                }
-            }
-            HelpKeyAction::Ignore => KeyEventOutcome::default(),
+    fn handle_help_key_event(&mut self, _state: &mut AppState, key: KeyEvent) -> KeyEventOutcome {
+        let Some(command) = Self::help_command_for_key(key) else {
+            return KeyEventOutcome::default();
+        };
+
+        KeyEventOutcome {
+            redraw: false,
+            quit_requested: false,
+            commands: vec![CommandRequest::new(
+                command,
+                CommandInvocationSource::Keymap,
+            )],
         }
     }
 
-    fn classify_help_key(key: KeyEvent) -> HelpKeyAction {
+    fn help_command_for_key(key: KeyEvent) -> Option<Command> {
         match key.code {
-            KeyCode::Char('j') => HelpKeyAction::ScrollBy(1),
-            KeyCode::Char('k') => HelpKeyAction::ScrollBy(-1),
-            _ => HelpKeyAction::Ignore,
+            KeyCode::Char('j') => Some(Command::HelpScrollDown),
+            KeyCode::Char('k') => Some(Command::HelpScrollUp),
+            _ => None,
         }
     }
 
@@ -529,7 +524,7 @@ mod tests {
     }
 
     #[test]
-    fn help_mode_scrolls_and_requests_close_help() {
+    fn help_mode_scroll_keys_request_help_scroll_commands() {
         let mut interaction = InteractionSubsystem::default();
         let mut state = AppState {
             mode: crate::app::Mode::Help,
@@ -542,9 +537,29 @@ mod tests {
                 KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
             )
             .expect("help scroll should be handled");
-        assert_eq!(state.help_scroll, 1);
-        assert!(down.redraw);
-        assert!(down.commands.is_empty());
+        assert_eq!(state.help_scroll, 0);
+        assert!(!down.redraw);
+        assert_eq!(
+            down.commands,
+            vec![CommandRequest::new(
+                Command::HelpScrollDown,
+                CommandInvocationSource::Keymap
+            )]
+        );
+
+        let up = interaction
+            .handle_key_event(
+                &mut state,
+                KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
+            )
+            .expect("help scroll should be handled");
+        assert_eq!(
+            up.commands,
+            vec![CommandRequest::new(
+                Command::HelpScrollUp,
+                CommandInvocationSource::Keymap
+            )]
+        );
 
         let closed = interaction
             .handle_key_event(&mut state, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))

--- a/src/command/catalog.rs
+++ b/src/command/catalog.rs
@@ -10,6 +10,7 @@ use super::types::{
 
 const NO_ARGS: [ArgSpec; 0] = [];
 const REQUIRES_SEARCH_ACTIVE: [CommandCondition; 1] = [CommandCondition::SearchActive];
+const REQUIRES_HELP_MODE: [CommandCondition; 1] = [CommandCondition::HelpMode];
 const ARGS_GOTO_PAGE: [ArgSpec; 1] = [ArgSpec {
     name: "page",
     kind: ArgKind::I32,
@@ -409,6 +410,26 @@ define_commands! {
         availability: CommandAvailability::Always,
         parse: no_args,
         exec: super::handlers::close_help,
+    }
+    HelpScrollDown {
+        id: "help-scroll-down",
+        title: "Scroll Help Down",
+        args: &NO_ARGS,
+        exposure: CommandExposure::Public,
+        invocation: CommandInvocationPolicy::User,
+        availability: CommandAvailability::AllOf(&REQUIRES_HELP_MODE),
+        parse: no_args,
+        exec: super::handlers::help_scroll_down,
+    }
+    HelpScrollUp {
+        id: "help-scroll-up",
+        title: "Scroll Help Up",
+        args: &NO_ARGS,
+        exposure: CommandExposure::Public,
+        invocation: CommandInvocationPolicy::User,
+        availability: CommandAvailability::AllOf(&REQUIRES_HELP_MODE),
+        parse: no_args,
+        exec: super::handlers::help_scroll_up,
     }
     OpenSearch {
         id: "search",

--- a/src/command/core.rs
+++ b/src/command/core.rs
@@ -207,6 +207,26 @@ pub(crate) fn close_help(app: &mut AppState) -> AppResult<CommandNoticeResult> {
     Ok(applied())
 }
 
+pub(crate) fn scroll_help_down(app: &mut AppState) -> AppResult<CommandNoticeResult> {
+    let previous = app.help_scroll;
+    app.scroll_help_by(1);
+    if app.help_scroll == previous {
+        return Ok(noop());
+    }
+
+    Ok(applied())
+}
+
+pub(crate) fn scroll_help_up(app: &mut AppState) -> AppResult<CommandNoticeResult> {
+    let previous = app.help_scroll;
+    app.scroll_help_by(-1);
+    if app.help_scroll == previous {
+        return Ok(noop());
+    }
+
+    Ok(applied())
+}
+
 fn resolve_page_count(page_count: usize) -> AppResult<usize> {
     if page_count > 0 {
         return Ok(page_count);

--- a/src/command/dispatch.rs
+++ b/src/command/dispatch.rs
@@ -800,7 +800,7 @@ mod tests {
             &mut app,
             Command::HelpScrollDown,
             CommandInvocationSource::Keymap,
-            pdf,
+            Arc::clone(&pdf),
             &mut host,
             &mut palette_requests,
         )
@@ -816,12 +816,11 @@ mod tests {
             }]
         ));
 
-        let pdf = Arc::new(StubPdf::new(3)) as SharedPdfBackend;
         let up = dispatch(
             &mut app,
             Command::HelpScrollUp,
             CommandInvocationSource::Keymap,
-            pdf,
+            Arc::clone(&pdf),
             &mut host,
             &mut palette_requests,
         )

--- a/src/command/dispatch.rs
+++ b/src/command/dispatch.rs
@@ -73,6 +73,7 @@ pub fn dispatch_with_view_policy(
     let extensions = extension_host.ui_snapshot();
     let ctx = CommandConditionContext {
         extensions: &extensions,
+        mode: app.mode,
         source,
     };
     if let Some(message) = rejection_message_for_command(&cmd, &ctx) {
@@ -191,6 +192,8 @@ fn derive_nav_reason(command: &Command, extension_host: &ExtensionHost) -> Optio
         | Command::ClosePalette
         | Command::OpenHelp
         | Command::CloseHelp
+        | Command::HelpScrollDown
+        | Command::HelpScrollUp
         | Command::OpenSearch
         | Command::OpenSearchResults
         | Command::SubmitSearch { .. }
@@ -751,6 +754,87 @@ mod tests {
                 id: CommandId::CloseHelp,
                 outcome: CommandOutcome::Applied
             }
+        ));
+    }
+
+    #[test]
+    fn dispatch_help_scroll_commands_require_help_mode() {
+        let mut app = AppState::default();
+        let pdf = Arc::new(StubPdf::new(3)) as SharedPdfBackend;
+        let mut host = ExtensionHost::default();
+        let mut palette_requests = VecDeque::new();
+
+        let result = dispatch(
+            &mut app,
+            Command::HelpScrollDown,
+            CommandInvocationSource::Keymap,
+            pdf,
+            &mut host,
+            &mut palette_requests,
+        )
+        .expect("dispatch should reject through noop result");
+
+        assert_eq!(app.mode, crate::app::Mode::Normal);
+        assert_eq!(app.help_scroll, 0);
+        assert_eq!(result.outcome, CommandOutcome::Noop);
+        assert_eq!(
+            app.notice,
+            Some(Notice {
+                level: NoticeLevel::Warning,
+                message: "help-scroll-down is unavailable outside help".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn dispatch_help_scroll_commands_update_help_scroll() {
+        let mut app = AppState {
+            mode: crate::app::Mode::Help,
+            ..AppState::default()
+        };
+        let pdf = Arc::new(StubPdf::new(3)) as SharedPdfBackend;
+        let mut host = ExtensionHost::default();
+        let mut palette_requests = VecDeque::new();
+
+        let down = dispatch(
+            &mut app,
+            Command::HelpScrollDown,
+            CommandInvocationSource::Keymap,
+            pdf,
+            &mut host,
+            &mut palette_requests,
+        )
+        .expect("dispatch should succeed");
+
+        assert_eq!(app.help_scroll, 1);
+        assert_eq!(down.outcome, CommandOutcome::Applied);
+        assert!(matches!(
+            down.emitted_events.as_slice(),
+            [AppEvent::CommandExecuted {
+                id: CommandId::HelpScrollDown,
+                outcome: CommandOutcome::Applied
+            }]
+        ));
+
+        let pdf = Arc::new(StubPdf::new(3)) as SharedPdfBackend;
+        let up = dispatch(
+            &mut app,
+            Command::HelpScrollUp,
+            CommandInvocationSource::Keymap,
+            pdf,
+            &mut host,
+            &mut palette_requests,
+        )
+        .expect("dispatch should succeed");
+
+        assert_eq!(app.help_scroll, 0);
+        assert_eq!(up.outcome, CommandOutcome::Applied);
+        assert!(matches!(
+            up.emitted_events.as_slice(),
+            [AppEvent::CommandExecuted {
+                id: CommandId::HelpScrollUp,
+                outcome: CommandOutcome::Applied
+            }]
         ));
     }
 

--- a/src/command/handlers/help.rs
+++ b/src/command/handlers/help.rs
@@ -1,6 +1,9 @@
 use crate::error::AppResult;
 
-use super::super::core::{close_help as close_help_core, open_help as open_help_core};
+use super::super::core::{
+    close_help as close_help_core, open_help as open_help_core,
+    scroll_help_down as scroll_help_down_core, scroll_help_up as scroll_help_up_core,
+};
 use super::super::dispatch::{CommandExecContext, CommandExecution};
 
 pub(in crate::command) fn open_help(
@@ -14,5 +17,19 @@ pub(in crate::command) fn close_help(
     ctx: &mut CommandExecContext<'_>,
 ) -> AppResult<CommandExecution> {
     let result = close_help_core(ctx.app)?;
+    Ok(CommandExecution::from_notice_result(result))
+}
+
+pub(in crate::command) fn help_scroll_down(
+    ctx: &mut CommandExecContext<'_>,
+) -> AppResult<CommandExecution> {
+    let result = scroll_help_down_core(ctx.app)?;
+    Ok(CommandExecution::from_notice_result(result))
+}
+
+pub(in crate::command) fn help_scroll_up(
+    ctx: &mut CommandExecContext<'_>,
+) -> AppResult<CommandExecution> {
+    let result = scroll_help_up_core(ctx.app)?;
     Ok(CommandExecution::from_notice_result(result))
 }

--- a/src/command/handlers/mod.rs
+++ b/src/command/handlers/mod.rs
@@ -11,7 +11,7 @@ mod viewport;
 
 pub(super) use control::{cancel_search, quit, reload_document};
 pub(super) use debug::{debug_status_hide, debug_status_show, debug_status_toggle};
-pub(super) use help::{close_help, open_help};
+pub(super) use help::{close_help, help_scroll_down, help_scroll_up, open_help};
 pub(super) use history::{history_back, history_forward, history_goto, open_history};
 pub(super) use layout::{page_layout_single, page_layout_spread};
 pub(super) use navigation::{first_page, goto_page, last_page, next_page, prev_page};

--- a/src/command/parse.rs
+++ b/src/command/parse.rs
@@ -1,5 +1,6 @@
 use std::num::IntErrorKind;
 
+use crate::app::Mode;
 use crate::error::{AppError, AppResult};
 use crate::extension::ExtensionUiSnapshot;
 use crate::palette::{PaletteKind, PaletteOpenPayload};
@@ -33,6 +34,7 @@ pub fn parse_invocable_command_text(
     input: &str,
     source: CommandInvocationSource,
     extensions: &ExtensionUiSnapshot,
+    mode: Mode,
 ) -> AppResult<Command> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
@@ -40,7 +42,11 @@ pub fn parse_invocable_command_text(
     }
 
     let id = first_token(trimmed);
-    let ctx = CommandConditionContext { extensions, source };
+    let ctx = CommandConditionContext {
+        extensions,
+        mode,
+        source,
+    };
     validate_command_id_for_source(id, &ctx)?;
     parse_command_text(trimmed)
 }
@@ -73,6 +79,8 @@ pub(super) fn parse_no_args(id: &str, args_text: &str, cmd: Command) -> AppResul
         "close-palette" => "close-palette does not accept arguments",
         "help" => "help does not accept arguments",
         "close-help" => "close-help does not accept arguments",
+        "help-scroll-down" => "help-scroll-down does not accept arguments",
+        "help-scroll-up" => "help-scroll-up does not accept arguments",
         "search" => "search does not accept arguments",
         "search-results" => "search-results does not accept arguments",
         "next-search-hit" => "next-search-hit does not accept arguments",

--- a/src/command/spec.rs
+++ b/src/command/spec.rs
@@ -1,3 +1,4 @@
+use crate::app::Mode;
 use crate::error::{AppError, AppResult};
 use crate::extension::ExtensionUiSnapshot;
 
@@ -19,6 +20,7 @@ pub fn all_command_specs() -> Vec<CommandSpec> {
 
 pub struct CommandConditionContext<'a> {
     pub extensions: &'a ExtensionUiSnapshot,
+    pub mode: Mode,
     pub source: CommandInvocationSource,
 }
 
@@ -137,6 +139,7 @@ fn is_invocation_source_allowed(spec: CommandSpec, source: CommandInvocationSour
 fn is_condition_met(condition: CommandCondition, ctx: &CommandConditionContext<'_>) -> bool {
     match condition {
         CommandCondition::SearchActive => ctx.extensions.search_active,
+        CommandCondition::HelpMode => ctx.mode == Mode::Help,
     }
 }
 
@@ -152,6 +155,10 @@ fn unavailable_message(spec: CommandSpec, ctx: &CommandConditionContext<'_>) -> 
                 return format!("{} is unavailable while search is inactive", spec.id);
             }
             CommandCondition::SearchActive => {}
+            CommandCondition::HelpMode if ctx.mode != Mode::Help => {
+                return format!("{} is unavailable outside help", spec.id);
+            }
+            CommandCondition::HelpMode => {}
         }
     }
 
@@ -171,6 +178,7 @@ fn app_error_message(err: AppError) -> String {
 mod tests {
     use std::collections::HashSet;
 
+    use crate::app::Mode;
     use crate::extension::ExtensionUiSnapshot;
 
     use super::{
@@ -200,6 +208,7 @@ mod tests {
         let extensions = ExtensionUiSnapshot::default();
         let ctx = CommandConditionContext {
             extensions: &extensions,
+            mode: Mode::Normal,
             source: CommandInvocationSource::CommandPaletteInput,
         };
 
@@ -212,6 +221,7 @@ mod tests {
         let extensions = ExtensionUiSnapshot::default();
         let ctx = CommandConditionContext {
             extensions: &extensions,
+            mode: Mode::Normal,
             source: CommandInvocationSource::Keymap,
         };
 
@@ -229,6 +239,7 @@ mod tests {
         let extensions = ExtensionUiSnapshot::default();
         let keymap_ctx = CommandConditionContext {
             extensions: &extensions,
+            mode: Mode::Normal,
             source: CommandInvocationSource::Keymap,
         };
         validate_command_for_source(
@@ -242,6 +253,7 @@ mod tests {
 
         let palette_input_ctx = CommandConditionContext {
             extensions: &extensions,
+            mode: Mode::Normal,
             source: CommandInvocationSource::CommandPaletteInput,
         };
         let err = validate_command_id_for_source("open-palette", &palette_input_ctx)
@@ -254,11 +266,35 @@ mod tests {
         let extensions = ExtensionUiSnapshot::default();
         let ctx = CommandConditionContext {
             extensions: &extensions,
+            mode: Mode::Normal,
             source: CommandInvocationSource::CommandPaletteInput,
         };
 
         let spec = find_command_spec("close-help").expect("spec should exist");
         assert!(!is_command_visible_in_palette(spec, &ctx));
+    }
+
+    #[test]
+    fn help_scroll_commands_are_only_available_in_help_mode() {
+        let extensions = ExtensionUiSnapshot::default();
+        let normal_ctx = CommandConditionContext {
+            extensions: &extensions,
+            mode: Mode::Normal,
+            source: CommandInvocationSource::Keymap,
+        };
+        let err = validate_command_id_for_source("help-scroll-down", &normal_ctx)
+            .expect_err("help scroll should be unavailable outside help");
+        assert!(err.to_string().contains("outside help"));
+
+        let help_ctx = CommandConditionContext {
+            extensions: &extensions,
+            mode: Mode::Help,
+            source: CommandInvocationSource::Keymap,
+        };
+        validate_command_id_for_source("help-scroll-down", &help_ctx)
+            .expect("help scroll down should be available in help");
+        validate_command_id_for_source("help-scroll-up", &help_ctx)
+            .expect("help scroll up should be available in help");
     }
 
     #[test]

--- a/src/command/tests/mod.rs
+++ b/src/command/tests/mod.rs
@@ -1,3 +1,4 @@
+use crate::app::Mode;
 use crate::command::{
     CommandConditionContext, CommandInvocationSource, command_registry, find_command_spec,
 };
@@ -13,6 +14,7 @@ fn builtin_keymap_references_registered_keymap_invocable_commands() {
     let extensions = ExtensionUiSnapshot::with_search_active(true);
     let ctx = CommandConditionContext {
         extensions: &extensions,
+        mode: Mode::Normal,
         source: CommandInvocationSource::Keymap,
     };
 

--- a/src/command/types.rs
+++ b/src/command/types.rs
@@ -227,6 +227,7 @@ pub enum CommandInvocationPolicy {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandCondition {
     SearchActive,
+    HelpMode,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/palette/providers/command.rs
+++ b/src/palette/providers/command.rs
@@ -54,6 +54,7 @@ impl PaletteProvider for CommandPaletteProvider {
                     .filter(|spec| {
                         let command_ctx = CommandConditionContext {
                             extensions: ctx.extensions,
+                            mode: ctx.app.mode,
                             source: CommandInvocationSource::CommandPaletteInput,
                         };
                         is_command_visible_in_palette(*spec, &command_ctx)
@@ -89,6 +90,7 @@ impl PaletteProvider for CommandPaletteProvider {
                 input,
                 CommandInvocationSource::CommandPaletteInput,
                 ctx.extensions,
+                ctx.app.mode,
             ) {
                 Ok(command) => {
                     return Ok(PaletteSubmitEffect::Dispatch {
@@ -409,6 +411,7 @@ fn submit_selected_enum_candidate(
         synthesized_trimmed,
         CommandInvocationSource::CommandPaletteInput,
         ctx.extensions,
+        ctx.app.mode,
     ) {
         Ok(command) => Ok(Some(PaletteSubmitEffect::Dispatch {
             command,

--- a/src/palette/types.rs
+++ b/src/palette/types.rs
@@ -1,5 +1,5 @@
 use super::kind::PaletteKind;
-use crate::app::{AppState, PageLayoutMode, SpreadCoverPolicy};
+use crate::app::{AppState, Mode, PageLayoutMode, SpreadCoverPolicy};
 use crate::command::{Command, SearchMatcherKind};
 use crate::error::{AppError, AppResult};
 use crate::extension::ExtensionUiSnapshot;
@@ -161,17 +161,30 @@ pub enum PaletteTabEffect {
     },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PaletteAppSnapshot {
     pub current_page: usize,
+    pub mode: Mode,
     pub page_layout_mode: PageLayoutMode,
     pub spread_cover_policy: SpreadCoverPolicy,
+}
+
+impl Default for PaletteAppSnapshot {
+    fn default() -> Self {
+        Self {
+            current_page: 0,
+            mode: Mode::Normal,
+            page_layout_mode: PageLayoutMode::default(),
+            spread_cover_policy: SpreadCoverPolicy::default(),
+        }
+    }
 }
 
 impl From<&AppState> for PaletteAppSnapshot {
     fn from(app: &AppState) -> Self {
         Self {
             current_page: app.current_page,
+            mode: app.mode,
             page_layout_mode: app.page_layout_mode,
             spread_cover_policy: app.spread_cover_policy,
         }

--- a/src/search/palette.rs
+++ b/src/search/palette.rs
@@ -427,6 +427,7 @@ mod tests {
             current_page: 4,
             page_layout_mode: PageLayoutMode::Spread,
             spread_cover_policy: SpreadCoverPolicy::Paired,
+            ..PaletteAppSnapshot::default()
         };
         let extensions = ExtensionUiSnapshot {
             search_results_entries: vec![
@@ -470,6 +471,7 @@ mod tests {
             current_page: 0,
             page_layout_mode: PageLayoutMode::Spread,
             spread_cover_policy: SpreadCoverPolicy::Cover,
+            ..PaletteAppSnapshot::default()
         };
         let extensions = ExtensionUiSnapshot {
             search_results_entries: vec![

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -360,7 +360,8 @@ mod tests {
         assert!(text.contains("x"));
         assert!(text.contains("y"));
         assert!(text.contains("A / S / W / D"));
-        assert!(!text.contains("j"));
+        assert!(!text.contains("j / k"));
+        assert!(!text.contains("Scroll help"));
         assert!(!text.contains("H / J / K / L"));
     }
 


### PR DESCRIPTION
## Summary

Adds `help-scroll-down` and `help-scroll-up` commands so Help-mode `j`/`k` scrolling goes through command dispatch instead of mutating help scroll state directly from input handling.

## Verification

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Help overlay can now be scrolled using `j` and `k` keys as explicit commands, available only when the help overlay is active.

* **Documentation**
  * Updated documentation to clarify that command availability may depend on runtime application state (e.g., active help mode) and how help key bindings are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->