### PR TITLE
refactor(input): clarify conditional binding registry

### DIFF
--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -8,7 +8,7 @@ use crate::config::{
 use crate::error::AppResult;
 use crate::extension::ExtensionHost;
 use crate::input::InputHistoryService;
-use crate::input::keymap::build_builtin_sequence_registry;
+use crate::input::keymap::build_default_sequence_registry;
 use crate::input::sequence::{DEFAULT_SEQUENCE_TIMEOUT, SequenceRegistry, SequenceResolver};
 use crate::palette::{PaletteManager, PaletteRegistry};
 use crate::presenter::{ImagePresenter, PresenterKind, create_presenter_with_cache_limits};
@@ -59,7 +59,7 @@ pub struct InteractionSubsystem {
 
 impl Default for InteractionSubsystem {
     fn default() -> Self {
-        Self::with_sequence_registry(build_builtin_sequence_registry())
+        Self::with_sequence_registry(build_default_sequence_registry())
     }
 }
 

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -772,10 +772,15 @@ mod tests {
             App::new_with_config(PresenterKind::RatatuiImage, Config::default()).expect("app init");
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('g')], Command::OpenHelp)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('g')],
+                Command::OpenHelp,
+            )
             .expect("single-key binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::FirstPage,
             )
@@ -833,16 +838,25 @@ mod tests {
             App::new_with_config(PresenterKind::RatatuiImage, Config::default()).expect("app init");
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('g')], Command::DebugStatusShow)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('g')],
+                Command::DebugStatusShow,
+            )
             .expect("single-key binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::LastPage,
             )
             .expect("multi-key binding should register");
         registry
-            .register_static(&[ShortcutKey::char('x')], Command::DebugStatusHide)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('x')],
+                Command::DebugStatusHide,
+            )
             .expect("single-key binding should register");
         app.interaction =
             InteractionSubsystem::with_sequence_registry_and_timeout(registry, Duration::ZERO);
@@ -903,16 +917,21 @@ mod tests {
             App::new_with_config(PresenterKind::RatatuiImage, Config::default()).expect("app init");
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('x')], Command::OpenHelp)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('x')],
+                Command::OpenHelp,
+            )
             .expect("single-key binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('x'), ShortcutKey::char('x')],
                 Command::LastPage,
             )
             .expect("multi-key binding should register");
         registry
-            .register_static_with_condition(
+            .register_exact(
                 ConditionExpr::Always,
                 &[ShortcutKey::char('j')],
                 Command::HelpScrollDown,

--- a/src/app/input_ops.rs
+++ b/src/app/input_ops.rs
@@ -258,6 +258,7 @@ mod tests {
     use crate::backend::test_support::{build_pdf, unique_temp_path};
     use crate::backend::{PdfDoc, SharedPdfBackend};
     use crate::command::{Command, CommandInvocationSource, CommandRequest};
+    use crate::condition::ConditionExpr;
     use crate::config::ViewPolicy;
     use crate::input::sequence::SequenceRegistry;
     use crate::input::shortcut::ShortcutKey;
@@ -573,16 +574,25 @@ mod tests {
     fn pending_sequence_reprocesses_enter_after_mismatch() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('g')], Command::FirstPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('g')],
+                Command::FirstPage,
+            )
             .expect("single-key binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::LastPage,
             )
             .expect("multi-key binding should register");
         registry
-            .register_static(&[ShortcutKey::key(KeyCode::Enter)], Command::NextPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::key(KeyCode::Enter)],
+                Command::NextPage,
+            )
             .expect("enter binding should register");
         let mut interaction = InteractionSubsystem::with_sequence_registry(registry);
         let mut state = AppState::default();
@@ -621,10 +631,15 @@ mod tests {
     fn pending_exact_mismatch_requests_redraw_even_when_commands_do_not() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('x')], Command::DebugStatusHide)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('x')],
+                Command::DebugStatusHide,
+            )
             .expect("single-key binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('x'), ShortcutKey::char('x')],
                 Command::NextPage,
             )
@@ -664,16 +679,25 @@ mod tests {
     fn pending_exact_mismatch_does_not_reprocess_after_mode_change() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('x')], Command::OpenHelp)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('x')],
+                Command::OpenHelp,
+            )
             .expect("single-key binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('x'), ShortcutKey::char('x')],
                 Command::LastPage,
             )
             .expect("multi-key binding should register");
         registry
-            .register_static(&[ShortcutKey::char('j')], Command::NextPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('j')],
+                Command::NextPage,
+            )
             .expect("single-key binding should register");
         let mut interaction = InteractionSubsystem::with_sequence_registry(registry);
         let mut state = AppState::default();
@@ -710,13 +734,18 @@ mod tests {
     fn pending_sequence_reprocesses_followup_key_after_mismatch() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::FirstPage,
             )
             .expect("multi-key binding should register");
         registry
-            .register_static(&[ShortcutKey::char('?')], Command::OpenHelp)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('?')],
+                Command::OpenHelp,
+            )
             .expect("single-key binding should register");
         let mut interaction = InteractionSubsystem::with_sequence_registry(registry);
         let mut state = AppState::default();
@@ -749,13 +778,18 @@ mod tests {
     fn pending_sequence_redraws_when_reprocessed_followup_dispatches() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::FirstPage,
             )
             .expect("multi-key binding should register");
         registry
-            .register_static(&[ShortcutKey::char('j')], Command::NextPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('j')],
+                Command::NextPage,
+            )
             .expect("single-key binding should register");
         let mut interaction = InteractionSubsystem::with_sequence_registry(registry);
         let mut state = AppState::default();
@@ -788,7 +822,8 @@ mod tests {
     fn pending_sequence_requests_redraw_when_unbound_followup_clears_it() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::FirstPage,
             )
@@ -823,10 +858,15 @@ mod tests {
     fn wake_flushes_timed_out_sequence() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('g')], Command::FirstPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('g')],
+                Command::FirstPage,
+            )
             .expect("single-key binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::LastPage,
             )
@@ -857,10 +897,15 @@ mod tests {
     fn timeout_flush_uses_current_conditions_outside_normal_mode() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('g')], Command::FirstPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('g')],
+                Command::FirstPage,
+            )
             .expect("single-key binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::LastPage,
             )
@@ -894,10 +939,15 @@ mod tests {
     fn opening_palette_preserves_pending_sequences_that_remain_enabled() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('g')], Command::FirstPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('g')],
+                Command::FirstPage,
+            )
             .expect("single-key binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::LastPage,
             )
@@ -932,10 +982,15 @@ mod tests {
     fn batched_palette_open_and_close_preserves_enabled_pending_sequences() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('g')], Command::FirstPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('g')],
+                Command::FirstPage,
+            )
             .expect("single-key binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::LastPage,
             )
@@ -975,16 +1030,25 @@ mod tests {
     fn timed_out_sequence_returns_expired_command_before_processing_new_key() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('g')], Command::FirstPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('g')],
+                Command::FirstPage,
+            )
             .expect("single-key binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::LastPage,
             )
             .expect("multi-key binding should register");
         registry
-            .register_static(&[ShortcutKey::char('j')], Command::NextPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('j')],
+                Command::NextPage,
+            )
             .expect("single-key binding should register");
         let mut interaction =
             InteractionSubsystem::with_sequence_registry_and_timeout(registry, Duration::ZERO);
@@ -1017,16 +1081,25 @@ mod tests {
     fn timed_out_sequence_followed_by_quit_dispatches_expired_command_then_quit() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('g')], Command::FirstPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('g')],
+                Command::FirstPage,
+            )
             .expect("single-key binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::LastPage,
             )
             .expect("multi-key binding should register");
         registry
-            .register_static(&[ShortcutKey::char('q')], Command::Quit)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('q')],
+                Command::Quit,
+            )
             .expect("single-key binding should register");
         let mut interaction =
             InteractionSubsystem::with_sequence_registry_and_timeout(registry, Duration::ZERO);
@@ -1060,10 +1133,15 @@ mod tests {
         let pdf = test_pdf_backend();
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('g')], Command::FirstPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('g')],
+                Command::FirstPage,
+            )
             .expect("single-key binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::LastPage,
             )

--- a/src/command/tests/mod.rs
+++ b/src/command/tests/mod.rs
@@ -13,7 +13,6 @@ use super::spec::validate_command_id_for_policy;
 fn default_registry_bindings_reference_commands_invocable_when_enabled() {
     let registry = build_default_sequence_registry();
     let snapshot = registry.snapshot();
-    let extensions = ExtensionUiSnapshot::with_search_active(true);
 
     assert!(
         !snapshot.exact_bindings.is_empty(),
@@ -34,7 +33,6 @@ fn default_registry_bindings_reference_commands_invocable_when_enabled() {
         assert_binding_is_invocable(
             binding.command_id,
             binding.enabled_when,
-            &extensions,
             format!("key binding {:?}", binding.keys),
         );
     }
@@ -49,7 +47,6 @@ fn default_registry_bindings_reference_commands_invocable_when_enabled() {
         assert_binding_is_invocable(
             binding.command_id,
             binding.enabled_when,
-            &extensions,
             format!("numeric key binding {:?}", binding.suffix),
         );
     }
@@ -64,35 +61,46 @@ fn default_registry_bindings_reference_commands_invocable_when_enabled() {
         assert_binding_is_invocable(
             binding.command_id,
             binding.enabled_when,
-            &extensions,
             format!("generated key binding {:?}", binding.matcher),
         );
     }
 }
 
-fn assert_binding_is_invocable(
-    command_id: &str,
-    enabled_when: ConditionExpr,
-    extensions: &ExtensionUiSnapshot,
-    label: String,
-) {
-    let contexts = [
-        RuntimeConditionContext::new(Mode::Normal, None, extensions),
-        RuntimeConditionContext::new(Mode::Palette, Some(PaletteKind::Command), extensions),
-        RuntimeConditionContext::new(Mode::Palette, Some(PaletteKind::Outline), extensions),
-        RuntimeConditionContext::new(Mode::Help, None, extensions),
+fn assert_binding_is_invocable(command_id: &str, enabled_when: ConditionExpr, label: String) {
+    let extension_states = [
+        ExtensionUiSnapshot::with_search_active(false),
+        ExtensionUiSnapshot::with_search_active(true),
     ];
-    let runtime = contexts
-        .into_iter()
-        .find(|ctx| evaluate_condition(enabled_when, ctx))
-        .unwrap_or_else(|| panic!("{label} has an unsatisfiable enabled_when condition"));
-    let ctx = CommandPolicyContext {
-        source: CommandInvocationSource::Binding,
-        runtime,
-    };
-    validate_command_id_for_policy(command_id, &ctx).unwrap_or_else(|err| {
-        panic!("{label} references command {command_id} that bindings cannot invoke: {err}")
+    let contexts = extension_states.iter().flat_map(|extensions| {
+        [
+            RuntimeConditionContext::new(Mode::Normal, None, extensions),
+            RuntimeConditionContext::new(Mode::Palette, Some(PaletteKind::Command), extensions),
+            RuntimeConditionContext::new(Mode::Palette, Some(PaletteKind::Outline), extensions),
+            RuntimeConditionContext::new(Mode::Help, None, extensions),
+        ]
     });
+    let mut enabled_context_found = false;
+
+    for runtime in contexts {
+        if !evaluate_condition(enabled_when, &runtime) {
+            continue;
+        }
+        enabled_context_found = true;
+
+        let ctx = CommandPolicyContext {
+            source: CommandInvocationSource::Binding,
+            runtime,
+        };
+        if validate_command_id_for_policy(command_id, &ctx).is_ok() {
+            return;
+        }
+    }
+
+    assert!(
+        enabled_context_found,
+        "{label} has an unsatisfiable enabled_when condition"
+    );
+    panic!("{label} references command {command_id} that bindings cannot invoke when enabled");
 }
 
 #[test]

--- a/src/command/tests/mod.rs
+++ b/src/command/tests/mod.rs
@@ -4,24 +4,24 @@ use crate::command::{
 };
 use crate::condition::{ConditionExpr, RuntimeConditionContext, evaluate_condition};
 use crate::extension::ExtensionUiSnapshot;
-use crate::input::keymap::build_builtin_sequence_registry;
+use crate::input::keymap::build_default_sequence_registry;
 use crate::palette::PaletteKind;
 
 use super::spec::validate_command_id_for_policy;
 
 #[test]
-fn builtin_bindings_reference_commands_invocable_when_enabled() {
-    let registry = build_builtin_sequence_registry();
+fn default_registry_bindings_reference_commands_invocable_when_enabled() {
+    let registry = build_default_sequence_registry();
     let snapshot = registry.snapshot();
     let extensions = ExtensionUiSnapshot::with_search_active(true);
 
     assert!(
         !snapshot.exact_bindings.is_empty(),
-        "builtin keymap must define at least one exact binding"
+        "default registry must define at least one exact binding"
     );
     assert!(
         !snapshot.numeric_prefix_bindings.is_empty(),
-        "builtin keymap must define at least one numeric prefix binding"
+        "default registry must define at least one numeric prefix binding"
     );
 
     for binding in snapshot.exact_bindings {

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -367,13 +367,21 @@ mod tests {
     use crate::app::{PageLayoutMode, SpreadCoverPolicy, SpreadDirection};
     use crate::command::Command;
     use crate::config::{AppOptionsResolver, KeymapBinding, KeymapPreset, KeymapTarget};
-    use crate::input::sequence::{DEFAULT_SEQUENCE_TIMEOUT, SequenceResolution, SequenceResolver};
+    use crate::extension::ExtensionUiSnapshot;
+    use crate::input::sequence::{
+        DEFAULT_SEQUENCE_TIMEOUT, KeyBindingContext, SequenceResolution, SequenceResolver,
+    };
     use crate::input::shortcut::ShortcutKey;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     use super::{
         Config, ConfigFileSelection, default_config_path_from_env, load_options_from_explicit_path,
     };
+
+    fn handle_normal_key(resolver: &mut SequenceResolver, key: KeyEvent) -> SequenceResolution {
+        let extensions = ExtensionUiSnapshot::default();
+        resolver.handle_key_in_context(KeyBindingContext::normal(&extensions), key)
+    }
 
     fn unique_temp_path(suffix: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -520,23 +528,38 @@ mod tests {
             SequenceResolver::new(resolved.input.sequence_registry, DEFAULT_SEQUENCE_TIMEOUT);
 
         assert_eq!(
-            resolver.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)),
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)
+            ),
             SequenceResolution::Noop
         );
         assert_eq!(
-            resolver.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)),
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)
+            ),
             SequenceResolution::Dispatch(Command::NextPage)
         );
         assert_eq!(
-            resolver.handle_key(KeyEvent::new(KeyCode::Char('4'), KeyModifiers::NONE)),
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Char('4'), KeyModifiers::NONE)
+            ),
             SequenceResolution::Pending
         );
         assert_eq!(
-            resolver.handle_key(KeyEvent::new(KeyCode::Char('2'), KeyModifiers::NONE)),
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Char('2'), KeyModifiers::NONE)
+            ),
             SequenceResolution::Pending
         );
         assert_eq!(
-            resolver.handle_key(KeyEvent::new(KeyCode::Char('G'), KeyModifiers::NONE)),
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Char('G'), KeyModifiers::NONE)
+            ),
             SequenceResolution::Dispatch(Command::GotoPage { page: 42 })
         );
 
@@ -564,7 +587,10 @@ mod tests {
             SequenceResolver::new(resolved.input.sequence_registry, DEFAULT_SEQUENCE_TIMEOUT);
 
         assert_eq!(
-            resolver.handle_key(KeyEvent::new(KeyCode::Char('<'), KeyModifiers::NONE)),
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Char('<'), KeyModifiers::NONE)
+            ),
             SequenceResolution::Dispatch(Command::PrevPage)
         );
 

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -2,10 +2,10 @@ use crate::command::{
     Command, parse_command_text, validate_command_for_normal_keymap,
     validate_command_id_for_normal_keymap,
 };
+use crate::condition::ConditionExpr;
 use crate::error::{AppError, AppResult};
 use crate::input::keymap::{
-    WHEN_NORMAL, build_builtin_sequence_registry, register_builtin_normal_reserved_bindings,
-    register_builtin_surface_bindings,
+    WHEN_NORMAL, build_default_sequence_registry, build_none_sequence_registry,
 };
 use crate::input::sequence::{SequenceRegistrationError, SequenceRegistry};
 use crate::input::shortcut::{ShortcutKey, parse_shortcut_sequence};
@@ -62,34 +62,20 @@ impl KeymapOptions {
 
 pub(crate) fn resolve_sequence_registry(options: &KeymapOptions) -> SequenceRegistry {
     let mut registry = match options.preset.unwrap_or(KeymapPreset::Default) {
-        KeymapPreset::Default => build_builtin_sequence_registry(),
-        KeymapPreset::None => {
-            let mut registry = SequenceRegistry::new();
-            // `preset = "none"` currently disables only configurable normal-mode
-            // bindings; reserved cancellation and binding-only surface controls remain
-            // available.
-            register_builtin_normal_reserved_bindings(&mut registry);
-            register_builtin_surface_bindings(&mut registry);
-            registry
-        }
+        KeymapPreset::Default => build_default_sequence_registry(),
+        KeymapPreset::None => build_none_sequence_registry(),
     };
 
     for target in &options.unbind {
         match target {
             KeymapTarget::Exact(keys) => {
                 registry
-                    .unregister_static_with_condition(
-                        Some(crate::condition::ConditionExpr::All(&WHEN_NORMAL)),
-                        keys,
-                    )
+                    .unregister_exact(ConditionExpr::All(&WHEN_NORMAL), keys)
                     .expect("validated exact keymap target should unregister");
             }
             KeymapTarget::NumericPrefix(suffix) => {
                 registry
-                    .unregister_numeric_prefix_with_condition(
-                        Some(crate::condition::ConditionExpr::All(&WHEN_NORMAL)),
-                        *suffix,
-                    )
+                    .unregister_numeric_prefix(ConditionExpr::All(&WHEN_NORMAL), *suffix)
                     .expect("validated numeric keymap target should unregister");
             }
         }
@@ -99,19 +85,15 @@ pub(crate) fn resolve_sequence_registry(options: &KeymapOptions) -> SequenceRegi
         match binding {
             KeymapBinding::Exact { keys, command } => {
                 registry
-                    .register_static_with_condition(
-                        crate::condition::ConditionExpr::All(&WHEN_NORMAL),
-                        keys,
-                        command.clone(),
-                    )
+                    .register_exact(ConditionExpr::All(&WHEN_NORMAL), keys, command.clone())
                     .expect("validated exact keymap binding should register");
             }
             KeymapBinding::NumericPrefix { suffix, command_id } => {
                 let factory = numeric_prefix_factory(command_id)
                     .expect("validated numeric prefix command should have a factory");
                 registry
-                    .register_numeric_prefix_with_condition(
-                        crate::condition::ConditionExpr::All(&WHEN_NORMAL),
+                    .register_numeric_prefix(
+                        ConditionExpr::All(&WHEN_NORMAL),
                         command_id,
                         *suffix,
                         factory,
@@ -207,14 +189,16 @@ fn validate_configurable_key(keys: &[ShortcutKey]) -> AppResult<()> {
 
 fn validate_exact_keys(keys: &[ShortcutKey]) -> AppResult<()> {
     SequenceRegistry::new()
-        .register_static(keys, Command::Quit)
+        .register_exact(ConditionExpr::Always, keys, Command::Quit)
         .map(|_| ())
         .map_err(key_registration_error)
 }
 
 fn validate_numeric_suffix(suffix: ShortcutKey) -> AppResult<()> {
     SequenceRegistry::new()
-        .register_numeric_prefix("goto-page", suffix, |page| Command::GotoPage { page })
+        .register_numeric_prefix(ConditionExpr::Always, "goto-page", suffix, |page| {
+            Command::GotoPage { page }
+        })
         .map(|_| ())
         .map_err(key_registration_error)
 }
@@ -245,17 +229,19 @@ fn numeric_prefix_factory(command_id: &str) -> Option<fn(usize) -> Command> {
 mod tests {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
+    use crate::app::Mode;
     use crate::command::Command;
     use crate::condition::RuntimeConditionContext;
     use crate::extension::ExtensionUiSnapshot;
     use crate::input::sequence::{
         DEFAULT_SEQUENCE_TIMEOUT, KeyBindingContext, SequenceResolution, SequenceResolver,
     };
+    use crate::palette::PaletteKind;
 
     use super::{KeymapOptions, KeymapPreset, resolve_sequence_registry};
 
     #[test]
-    fn none_preset_preserves_reserved_search_cancellation() {
+    fn none_preset_preserves_current_compatibility_bindings_and_omits_defaults() {
         let registry = resolve_sequence_registry(&KeymapOptions {
             preset: Some(KeymapPreset::None),
             ..KeymapOptions::default()
@@ -271,6 +257,37 @@ mod tests {
                 KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
             ),
             SequenceResolution::Dispatch(Command::CancelSearch)
+        );
+        assert_eq!(
+            resolver.handle_key_in_context(
+                KeyBindingContext {
+                    runtime: RuntimeConditionContext::normal(&extensions),
+                },
+                KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+            ),
+            SequenceResolution::Noop
+        );
+        assert_eq!(
+            resolver.handle_key_in_context(
+                KeyBindingContext {
+                    runtime: RuntimeConditionContext::new(
+                        Mode::Palette,
+                        Some(PaletteKind::Command),
+                        &extensions,
+                    ),
+                },
+                KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            ),
+            SequenceResolution::Dispatch(Command::PaletteSubmit)
+        );
+        assert_eq!(
+            resolver.handle_key_in_context(
+                KeyBindingContext {
+                    runtime: RuntimeConditionContext::new(Mode::Help, None, &extensions),
+                },
+                KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            ),
+            SequenceResolution::Dispatch(Command::CloseHelp)
         );
     }
 }

--- a/src/config/policy.rs
+++ b/src/config/policy.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use crate::app::scale::{ZOOM_MAX, ZOOM_MIN};
 use crate::app::{PageLayoutMode, SpreadCoverPolicy, SpreadDirection};
-use crate::input::keymap::build_builtin_sequence_registry;
+use crate::input::keymap::build_default_sequence_registry;
 use crate::input::sequence::{DEFAULT_SEQUENCE_TIMEOUT, SequenceRegistry};
 
 use super::options::AppOptions;
@@ -126,7 +126,7 @@ impl Default for InputPolicy {
     fn default() -> Self {
         Self {
             sequence_timeout: DEFAULT_SEQUENCE_TIMEOUT,
-            sequence_registry: build_builtin_sequence_registry(),
+            sequence_registry: build_default_sequence_registry(),
         }
     }
 }

--- a/src/input/keymap.rs
+++ b/src/input/keymap.rs
@@ -22,130 +22,161 @@ const WHEN_PALETTE_INPUT_HISTORY_UNAVAILABLE: [RuntimeCondition; 2] = [
 ];
 const WHEN_HELP: [RuntimeCondition; 1] = [RuntimeCondition::ModeIs(crate::app::Mode::Help)];
 
-pub fn build_builtin_sequence_registry() -> SequenceRegistry {
+pub fn build_default_sequence_registry() -> SequenceRegistry {
     let mut registry = SequenceRegistry::new();
+    register_surface_open_bindings(&mut registry);
+    register_page_navigation_bindings(&mut registry);
+    register_view_bindings(&mut registry);
+    register_history_bindings(&mut registry);
+    register_search_navigation_bindings(&mut registry);
+    register_quit_binding(&mut registry);
+    register_search_cancellation_binding(&mut registry);
+    register_palette_bindings(&mut registry);
+    register_help_bindings(&mut registry);
+    registry
+}
 
-    register_static(
-        &mut registry,
+pub(crate) fn build_none_sequence_registry() -> SequenceRegistry {
+    let mut registry = SequenceRegistry::new();
+    register_search_cancellation_binding(&mut registry);
+    register_palette_bindings(&mut registry);
+    register_help_bindings(&mut registry);
+    registry
+}
+
+fn register_surface_open_bindings(registry: &mut SequenceRegistry) {
+    let when = ConditionExpr::All(&WHEN_NORMAL);
+    register_exact_binding(
+        registry,
+        when,
         &[ShortcutKey::char(':')],
         Command::OpenPalette {
             kind: PaletteKind::Command,
             payload: None,
         },
     );
-    register_static(
-        &mut registry,
+    register_exact_binding(
+        registry,
+        when,
         &[ShortcutKey::char('/')],
         Command::OpenSearch,
     );
-    register_static(&mut registry, &[ShortcutKey::char('?')], Command::OpenHelp);
-    register_static(
-        &mut registry,
+    register_exact_binding(registry, when, &[ShortcutKey::char('?')], Command::OpenHelp);
+}
+
+fn register_page_navigation_bindings(registry: &mut SequenceRegistry) {
+    let when = ConditionExpr::All(&WHEN_NORMAL);
+    register_exact_binding(registry, when, &[ShortcutKey::char('j')], Command::NextPage);
+    register_exact_binding(registry, when, &[ShortcutKey::char('k')], Command::PrevPage);
+    register_exact_binding(
+        registry,
+        when,
+        &[ShortcutKey::char('g'), ShortcutKey::char('g')],
+        Command::FirstPage,
+    );
+    register_exact_binding(registry, when, &[ShortcutKey::char('G')], Command::LastPage);
+    register_numeric_prefix_binding(
+        registry,
+        when,
+        "goto-page",
+        ShortcutKey::char('G'),
+        |page| Command::GotoPage { page },
+    );
+}
+
+fn register_view_bindings(registry: &mut SequenceRegistry) {
+    let when = ConditionExpr::All(&WHEN_NORMAL);
+    register_exact_binding(
+        registry,
+        when,
         &[ShortcutKey::char('H')],
         Command::Pan {
             direction: PanDirection::Left,
             amount: PanAmount::DefaultStep,
         },
     );
-    register_static(
-        &mut registry,
+    register_exact_binding(
+        registry,
+        when,
         &[ShortcutKey::char('J')],
         Command::Pan {
             direction: PanDirection::Down,
             amount: PanAmount::DefaultStep,
         },
     );
-    register_static(
-        &mut registry,
+    register_exact_binding(
+        registry,
+        when,
         &[ShortcutKey::char('K')],
         Command::Pan {
             direction: PanDirection::Up,
             amount: PanAmount::DefaultStep,
         },
     );
-    register_static(
-        &mut registry,
+    register_exact_binding(
+        registry,
+        when,
         &[ShortcutKey::char('L')],
         Command::Pan {
             direction: PanDirection::Right,
             amount: PanAmount::DefaultStep,
         },
     );
-    register_static(&mut registry, &[ShortcutKey::char('j')], Command::NextPage);
-    register_static(&mut registry, &[ShortcutKey::char('k')], Command::PrevPage);
-    register_static(
-        &mut registry,
-        &[ShortcutKey::char('g'), ShortcutKey::char('g')],
-        Command::FirstPage,
+    register_exact_binding(registry, when, &[ShortcutKey::char('+')], Command::ZoomIn);
+    register_exact_binding(registry, when, &[ShortcutKey::char('-')], Command::ZoomOut);
+    register_exact_binding(
+        registry,
+        when,
+        &[ShortcutKey::char('=')],
+        Command::ZoomReset,
     );
-    register_static(&mut registry, &[ShortcutKey::char('G')], Command::LastPage);
-    register_numeric_prefix(&mut registry, "goto-page", ShortcutKey::char('G'), |page| {
-        Command::GotoPage { page }
-    });
-    register_static(&mut registry, &[ShortcutKey::char('+')], Command::ZoomIn);
-    register_static(&mut registry, &[ShortcutKey::char('-')], Command::ZoomOut);
-    register_static(&mut registry, &[ShortcutKey::char('=')], Command::ZoomReset);
-    register_static(
-        &mut registry,
+}
+
+fn register_history_bindings(registry: &mut SequenceRegistry) {
+    let when = ConditionExpr::All(&WHEN_NORMAL);
+    register_exact_binding(
+        registry,
+        when,
         &[ShortcutKey::ctrl('o')],
         Command::HistoryBack,
     );
-    register_static(
-        &mut registry,
+    register_exact_binding(
+        registry,
+        when,
         &[ShortcutKey::ctrl('i')],
         Command::HistoryForward,
     );
-    register_static(
-        &mut registry,
+}
+
+fn register_search_navigation_bindings(registry: &mut SequenceRegistry) {
+    let when = ConditionExpr::All(&WHEN_NORMAL);
+    register_exact_binding(
+        registry,
+        when,
         &[ShortcutKey::char('n')],
         Command::NextSearchHit,
     );
-    register_static(
-        &mut registry,
+    register_exact_binding(
+        registry,
+        when,
         &[ShortcutKey::char('N')],
         Command::PrevSearchHit,
     );
-    register_static(&mut registry, &[ShortcutKey::char('q')], Command::Quit);
-    register_builtin_normal_reserved_bindings(&mut registry);
-    register_builtin_surface_bindings(&mut registry);
-    registry
 }
 
-fn register_static(registry: &mut SequenceRegistry, keys: &[ShortcutKey], command: Command) {
-    register_static_with_condition(registry, ConditionExpr::All(&WHEN_NORMAL), keys, command);
+fn register_quit_binding(registry: &mut SequenceRegistry) {
+    register_exact_binding(
+        registry,
+        ConditionExpr::All(&WHEN_NORMAL),
+        &[ShortcutKey::char('q')],
+        Command::Quit,
+    );
 }
 
-fn register_static_with_condition(
-    registry: &mut SequenceRegistry,
-    enabled_when: ConditionExpr,
-    keys: &[ShortcutKey],
-    command: Command,
-) {
-    registry
-        .register_static_with_condition(enabled_when, keys, command)
-        .expect("built-in key binding should register");
-}
-
-fn register_numeric_prefix(
-    registry: &mut SequenceRegistry,
-    command_id: &'static str,
-    suffix: ShortcutKey,
-    factory: fn(usize) -> Command,
-) {
-    registry
-        .register_numeric_prefix_with_condition(
-            ConditionExpr::All(&WHEN_NORMAL),
-            command_id,
-            suffix,
-            factory,
-        )
-        .expect("built-in numeric key binding should register");
-}
-
-pub(crate) fn register_builtin_normal_reserved_bindings(registry: &mut SequenceRegistry) {
+fn register_search_cancellation_binding(registry: &mut SequenceRegistry) {
     use crossterm::event::KeyCode;
 
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_NORMAL_SEARCH_ACTIVE),
         &[ShortcutKey::key(KeyCode::Esc)],
@@ -153,190 +184,190 @@ pub(crate) fn register_builtin_normal_reserved_bindings(registry: &mut SequenceR
     );
 }
 
-pub(crate) fn register_builtin_surface_bindings(registry: &mut SequenceRegistry) {
+fn register_palette_bindings(registry: &mut SequenceRegistry) {
     use crossterm::event::{KeyCode, KeyModifiers};
 
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::key(KeyCode::Esc)],
         Command::ClosePalette,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::key(KeyCode::Enter)],
         Command::PaletteSubmit,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::key(KeyCode::Tab)],
         Command::PaletteComplete,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::ctrl('p')],
         Command::PaletteSelectPrev,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::ctrl('n')],
         Command::PaletteSelectNext,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE_INPUT_HISTORY_AVAILABLE),
         &[ShortcutKey::key(KeyCode::Up)],
         Command::PaletteInputHistoryOlder,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE_INPUT_HISTORY_AVAILABLE),
         &[ShortcutKey::key(KeyCode::Down)],
         Command::PaletteInputHistoryNewer,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE_INPUT_HISTORY_UNAVAILABLE),
         &[ShortcutKey::key(KeyCode::Up)],
         Command::PaletteSelectPrev,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE_INPUT_HISTORY_UNAVAILABLE),
         &[ShortcutKey::key(KeyCode::Down)],
         Command::PaletteSelectNext,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::key(KeyCode::Backspace)],
         Command::TextDeleteBackward,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::ctrl('h')],
         Command::TextDeleteBackward,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::key(KeyCode::Delete)],
         Command::TextDeleteForward,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::new(KeyCode::Delete, KeyModifiers::CONTROL)],
         Command::TextDeleteNextWord,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::key(KeyCode::Left)],
         Command::TextMoveLeft,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::ctrl('b')],
         Command::TextMoveLeft,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::key(KeyCode::Right)],
         Command::TextMoveRight,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::ctrl('f')],
         Command::TextMoveRight,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::key(KeyCode::Home)],
         Command::TextMoveStart,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::ctrl('a')],
         Command::TextMoveStart,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::key(KeyCode::End)],
         Command::TextMoveEnd,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::ctrl('e')],
         Command::TextMoveEnd,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::new(KeyCode::Left, KeyModifiers::CONTROL)],
         Command::TextMovePrevWord,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::alt('b')],
         Command::TextMovePrevWord,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::new(KeyCode::Right, KeyModifiers::CONTROL)],
         Command::TextMoveNextWord,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::alt('f')],
         Command::TextMoveNextWord,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::ctrl('w')],
         Command::TextDeletePrevWord,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::alt('d')],
         Command::TextDeleteNextWord,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::new(KeyCode::Backspace, KeyModifiers::ALT)],
         Command::TextDeletePrevWord,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::ctrl('u')],
         Command::TextDeleteLine,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::ctrl('k')],
         Command::TextDeleteToEnd,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_PALETTE),
         &[ShortcutKey::ctrl('y')],
@@ -347,36 +378,64 @@ pub(crate) fn register_builtin_surface_bindings(registry: &mut SequenceRegistry)
         GeneratedKeyMatcher::PrintableCharacter,
         GeneratedCommand::TextInsert,
     );
-    register_static_with_condition(
+}
+
+fn register_help_bindings(registry: &mut SequenceRegistry) {
+    use crossterm::event::KeyCode;
+
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_HELP),
         &[ShortcutKey::key(KeyCode::Esc)],
         Command::CloseHelp,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_HELP),
         &[ShortcutKey::char('j')],
         Command::HelpScrollDown,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_HELP),
         &[ShortcutKey::key(KeyCode::Down)],
         Command::HelpScrollDown,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_HELP),
         &[ShortcutKey::char('k')],
         Command::HelpScrollUp,
     );
-    register_static_with_condition(
+    register_exact_binding(
         registry,
         ConditionExpr::All(&WHEN_HELP),
         &[ShortcutKey::key(KeyCode::Up)],
         Command::HelpScrollUp,
     );
+}
+
+fn register_exact_binding(
+    registry: &mut SequenceRegistry,
+    enabled_when: ConditionExpr,
+    keys: &[ShortcutKey],
+    command: Command,
+) {
+    registry
+        .register_exact(enabled_when, keys, command)
+        .expect("key binding should register");
+}
+
+fn register_numeric_prefix_binding(
+    registry: &mut SequenceRegistry,
+    enabled_when: ConditionExpr,
+    command_id: &'static str,
+    suffix: ShortcutKey,
+    factory: fn(usize) -> Command,
+) {
+    registry
+        .register_numeric_prefix(enabled_when, command_id, suffix, factory)
+        .expect("numeric key binding should register");
 }
 
 #[cfg(test)]
@@ -390,48 +449,77 @@ mod tests {
     use crate::input::sequence::KeyBindingContext;
     use crate::palette::PaletteKind;
 
-    use super::build_builtin_sequence_registry;
+    use super::build_default_sequence_registry;
     use crate::input::sequence::{DEFAULT_SEQUENCE_TIMEOUT, SequenceResolution, SequenceResolver};
 
+    fn handle_normal_key(resolver: &mut SequenceResolver, key: KeyEvent) -> SequenceResolution {
+        let extensions = ExtensionUiSnapshot::default();
+        resolver.handle_key_in_context(KeyBindingContext::normal(&extensions), key)
+    }
+
     #[test]
-    fn builtins_preserve_existing_single_key_bindings() {
-        let registry = build_builtin_sequence_registry();
+    fn defaults_preserve_existing_single_key_bindings() {
+        let registry = build_default_sequence_registry();
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
-        let search = resolver.handle_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE));
+        let search = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE),
+        );
         assert_eq!(search, SequenceResolution::Dispatch(Command::OpenSearch));
 
-        let help = resolver.handle_key(KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE));
+        let help = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE),
+        );
         assert_eq!(help, SequenceResolution::Dispatch(Command::OpenHelp));
 
-        let back = resolver.handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL));
+        let back = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL),
+        );
         assert_eq!(back, SequenceResolution::Dispatch(Command::HistoryBack));
     }
 
     #[test]
-    fn builtins_require_double_g_for_first_page() {
-        let registry = build_builtin_sequence_registry();
+    fn defaults_require_double_g_for_first_page() {
+        let registry = build_default_sequence_registry();
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
-        let first_g = resolver.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE));
+        let first_g = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+        );
         assert_eq!(first_g, SequenceResolution::Pending);
 
-        let second_g = resolver.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE));
+        let second_g = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+        );
         assert_eq!(second_g, SequenceResolution::Dispatch(Command::FirstPage));
     }
 
     #[test]
-    fn builtins_support_numeric_goto_prefix() {
-        let registry = build_builtin_sequence_registry();
+    fn defaults_support_numeric_goto_prefix() {
+        let registry = build_default_sequence_registry();
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
-        let four = resolver.handle_key(KeyEvent::new(KeyCode::Char('4'), KeyModifiers::NONE));
+        let four = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('4'), KeyModifiers::NONE),
+        );
         assert_eq!(four, SequenceResolution::Pending);
 
-        let two = resolver.handle_key(KeyEvent::new(KeyCode::Char('2'), KeyModifiers::NONE));
+        let two = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('2'), KeyModifiers::NONE),
+        );
         assert_eq!(two, SequenceResolution::Pending);
 
-        let goto = resolver.handle_key(KeyEvent::new(KeyCode::Char('G'), KeyModifiers::NONE));
+        let goto = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('G'), KeyModifiers::NONE),
+        );
         assert_eq!(
             goto,
             SequenceResolution::Dispatch(Command::GotoPage { page: 42 })
@@ -439,20 +527,26 @@ mod tests {
     }
 
     #[test]
-    fn builtins_map_equal_to_zoom_reset() {
-        let registry = build_builtin_sequence_registry();
+    fn defaults_map_equal_to_zoom_reset() {
+        let registry = build_default_sequence_registry();
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
-        let reset = resolver.handle_key(KeyEvent::new(KeyCode::Char('='), KeyModifiers::NONE));
+        let reset = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('='), KeyModifiers::NONE),
+        );
         assert_eq!(reset, SequenceResolution::Dispatch(Command::ZoomReset));
     }
 
     #[test]
-    fn builtins_include_pan_keys() {
-        let registry = build_builtin_sequence_registry();
+    fn defaults_include_pan_keys() {
+        let registry = build_default_sequence_registry();
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
-        let left = resolver.handle_key(KeyEvent::new(KeyCode::Char('H'), KeyModifiers::NONE));
+        let left = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('H'), KeyModifiers::NONE),
+        );
         assert_eq!(
             left,
             SequenceResolution::Dispatch(Command::Pan {
@@ -461,7 +555,10 @@ mod tests {
             })
         );
 
-        let down = resolver.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::NONE));
+        let down = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('J'), KeyModifiers::NONE),
+        );
         assert_eq!(
             down,
             SequenceResolution::Dispatch(Command::Pan {
@@ -472,14 +569,20 @@ mod tests {
     }
 
     #[test]
-    fn builtins_accept_shift_modified_char_events_for_uppercase_commands() {
-        let registry = build_builtin_sequence_registry();
+    fn defaults_accept_shift_modified_char_events_for_uppercase_commands() {
+        let registry = build_default_sequence_registry();
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
-        let last_page = resolver.handle_key(KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT));
+        let last_page = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT),
+        );
         assert_eq!(last_page, SequenceResolution::Dispatch(Command::LastPage));
 
-        let pan_down = resolver.handle_key(KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT));
+        let pan_down = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('J'), KeyModifiers::SHIFT),
+        );
         assert_eq!(
             pan_down,
             SequenceResolution::Dispatch(Command::Pan {
@@ -490,19 +593,22 @@ mod tests {
     }
 
     #[test]
-    fn builtins_accept_ctrl_shift_letter_as_ctrl_shortcut() {
-        let registry = build_builtin_sequence_registry();
+    fn defaults_accept_ctrl_shift_letter_as_ctrl_shortcut() {
+        let registry = build_default_sequence_registry();
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
-        let back = resolver.handle_key(KeyEvent::new(
-            KeyCode::Char('O'),
-            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
-        ));
+        let back = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(
+                KeyCode::Char('O'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+            ),
+        );
         assert_eq!(back, SequenceResolution::Dispatch(Command::HistoryBack));
     }
 
     #[test]
-    fn palette_builtins_map_common_line_editing_shortcuts() {
+    fn palette_bindings_map_common_line_editing_shortcuts() {
         let cases = [
             (
                 KeyEvent::new(KeyCode::Home, KeyModifiers::NONE),
@@ -555,7 +661,7 @@ mod tests {
         ];
 
         for (key, expected) in cases {
-            let registry = build_builtin_sequence_registry();
+            let registry = build_default_sequence_registry();
             let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
             let extensions = ExtensionUiSnapshot::default();
 
@@ -571,7 +677,7 @@ mod tests {
     }
 
     #[test]
-    fn palette_builtins_accept_meta_as_alt_for_word_editing() {
+    fn palette_bindings_accept_meta_as_alt_for_word_editing() {
         let cases = [
             (
                 KeyEvent::new(KeyCode::Char('b'), KeyModifiers::META),
@@ -592,7 +698,7 @@ mod tests {
         ];
 
         for (key, expected) in cases {
-            let registry = build_builtin_sequence_registry();
+            let registry = build_default_sequence_registry();
             let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
             let extensions = ExtensionUiSnapshot::default();
 

--- a/src/input/sequence.rs
+++ b/src/input/sequence.rs
@@ -109,15 +109,7 @@ impl SequenceRegistry {
         Self::default()
     }
 
-    pub fn register_static(
-        &mut self,
-        keys: &[ShortcutKey],
-        command: Command,
-    ) -> Result<(), SequenceRegistrationError> {
-        self.register_static_with_condition(ConditionExpr::Always, keys, command)
-    }
-
-    pub fn register_static_with_condition(
+    pub fn register_exact(
         &mut self,
         enabled_when: ConditionExpr,
         keys: &[ShortcutKey],
@@ -155,20 +147,6 @@ impl SequenceRegistry {
     }
 
     pub fn register_numeric_prefix(
-        &mut self,
-        command_id: &'static str,
-        suffix: ShortcutKey,
-        factory: NumericCommandFactory,
-    ) -> Result<(), SequenceRegistrationError> {
-        self.register_numeric_prefix_with_condition(
-            ConditionExpr::Always,
-            command_id,
-            suffix,
-            factory,
-        )
-    }
-
-    pub fn register_numeric_prefix_with_condition(
         &mut self,
         enabled_when: ConditionExpr,
         command_id: &'static str,
@@ -227,16 +205,9 @@ impl SequenceRegistry {
         });
     }
 
-    pub fn unregister_static(
+    pub fn unregister_exact(
         &mut self,
-        keys: &[ShortcutKey],
-    ) -> Result<bool, SequenceRegistrationError> {
-        self.unregister_static_with_condition(None, keys)
-    }
-
-    pub fn unregister_static_with_condition(
-        &mut self,
-        enabled_when: Option<ConditionExpr>,
+        enabled_when: ConditionExpr,
         keys: &[ShortcutKey],
     ) -> Result<bool, SequenceRegistrationError> {
         if keys.is_empty() {
@@ -255,7 +226,7 @@ impl SequenceRegistry {
                     enabled_when: existing_enabled_when,
                     keys: existing,
                     ..
-                } if enabled_when.is_none_or(|condition| condition == *existing_enabled_when)
+                } if enabled_when == *existing_enabled_when
                     && existing == &keys
             )
         });
@@ -264,14 +235,7 @@ impl SequenceRegistry {
 
     pub fn unregister_numeric_prefix(
         &mut self,
-        suffix: ShortcutKey,
-    ) -> Result<bool, SequenceRegistrationError> {
-        self.unregister_numeric_prefix_with_condition(None, suffix)
-    }
-
-    pub fn unregister_numeric_prefix_with_condition(
-        &mut self,
-        enabled_when: Option<ConditionExpr>,
+        enabled_when: ConditionExpr,
         suffix: ShortcutKey,
     ) -> Result<bool, SequenceRegistrationError> {
         let suffix = canonicalize_binding_key(suffix)?;
@@ -286,7 +250,7 @@ impl SequenceRegistry {
                     enabled_when: existing_enabled_when,
                     suffix: existing,
                     ..
-                } if enabled_when.is_none_or(|condition| condition == *existing_enabled_when)
+                } if enabled_when == *existing_enabled_when
                     && *existing == suffix
             )
         });
@@ -446,11 +410,6 @@ impl SequenceResolver {
             registry,
             state: SequenceState::new(timeout),
         }
-    }
-
-    pub fn handle_key(&mut self, key: KeyEvent) -> SequenceResolution {
-        let extensions = ExtensionUiSnapshot::default();
-        self.handle_key_in_context(KeyBindingContext::normal(&extensions), key)
     }
 
     pub fn handle_key_in_context(
@@ -821,15 +780,27 @@ mod tests {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use std::time::Duration;
 
+    fn handle_normal_key(resolver: &mut SequenceResolver, key: KeyEvent) -> SequenceResolution {
+        let extensions = ExtensionUiSnapshot::default();
+        resolver.handle_key_in_context(KeyBindingContext::normal(&extensions), key)
+    }
+
     #[test]
     fn exact_single_key_dispatches_immediately() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('j')], Command::NextPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('j')],
+                Command::NextPage,
+            )
             .expect("single-key binding should register");
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
-        let resolution = resolver.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        let resolution = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+        );
 
         assert_eq!(resolution, SequenceResolution::Dispatch(Command::NextPage));
         assert_eq!(resolver.pending_display(), None);
@@ -839,17 +810,25 @@ mod tests {
     fn ambiguous_exact_waits_for_timeout() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('g')], Command::FirstPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('g')],
+                Command::FirstPage,
+            )
             .expect("single-key binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::LastPage,
             )
             .expect("multi-key binding should register");
         let mut resolver = SequenceResolver::new(registry, Duration::ZERO);
 
-        let first = resolver.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE));
+        let first = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+        );
         assert_eq!(first, SequenceResolution::Pending);
         assert_eq!(resolver.pending_display().as_deref(), Some("g"));
 
@@ -862,11 +841,18 @@ mod tests {
     fn enter_dispatches_as_a_regular_exact_binding() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::key(KeyCode::Enter)], Command::NextPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::key(KeyCode::Enter)],
+                Command::NextPage,
+            )
             .expect("enter binding should register");
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
-        let resolution = resolver.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        let resolution = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
 
         assert_eq!(resolution, SequenceResolution::Dispatch(Command::NextPage));
         assert_eq!(resolver.pending_display(), None);
@@ -878,7 +864,7 @@ mod tests {
 
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static_with_condition(
+            .register_exact(
                 ConditionExpr::All(PALETTE_MODE),
                 &[ShortcutKey::key(KeyCode::Enter)],
                 Command::PaletteSubmit,
@@ -888,7 +874,10 @@ mod tests {
         let extensions = ExtensionUiSnapshot::default();
 
         assert_eq!(
-            resolver.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)
+            ),
             SequenceResolution::Noop
         );
         assert_eq!(
@@ -991,7 +980,7 @@ mod tests {
     fn generated_printable_binding_does_not_override_exact_binding() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static_with_condition(
+            .register_exact(
                 ConditionExpr::Always,
                 &[ShortcutKey::new(
                     KeyCode::Char('@'),
@@ -1040,25 +1029,40 @@ mod tests {
     fn enter_after_pending_exact_match_reprocesses_as_next_key() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('g')], Command::FirstPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('g')],
+                Command::FirstPage,
+            )
             .expect("single-key binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::LastPage,
             )
             .expect("multi-key binding should register");
         registry
-            .register_static(&[ShortcutKey::key(KeyCode::Enter)], Command::NextPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::key(KeyCode::Enter)],
+                Command::NextPage,
+            )
             .expect("enter binding should register");
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
         assert_eq!(
-            resolver.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)
+            ),
             SequenceResolution::Pending
         );
 
-        let resolution = resolver.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        let resolution = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
         assert_eq!(
             resolution,
             SequenceResolution::DispatchThen {
@@ -1073,25 +1077,40 @@ mod tests {
     fn expired_pending_sequence_dispatches_before_consuming_next_key() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('g')], Command::FirstPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('g')],
+                Command::FirstPage,
+            )
             .expect("single-key binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::LastPage,
             )
             .expect("multi-key binding should register");
         registry
-            .register_static(&[ShortcutKey::char('j')], Command::NextPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('j')],
+                Command::NextPage,
+            )
             .expect("single-key binding should register");
         let mut resolver = SequenceResolver::new(registry, Duration::ZERO);
 
         assert_eq!(
-            resolver.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)
+            ),
             SequenceResolution::Pending
         );
 
-        let resolution = resolver.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        let resolution = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+        );
         assert_eq!(
             resolution,
             SequenceResolution::DispatchThen {
@@ -1106,25 +1125,40 @@ mod tests {
     fn expired_pending_mode_change_does_not_reprocess_next_key() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('g')], Command::OpenHelp)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('g')],
+                Command::OpenHelp,
+            )
             .expect("single-key binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::LastPage,
             )
             .expect("multi-key binding should register");
         registry
-            .register_static(&[ShortcutKey::char('j')], Command::NextPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('j')],
+                Command::NextPage,
+            )
             .expect("single-key binding should register");
         let mut resolver = SequenceResolver::new(registry, Duration::ZERO);
 
         assert_eq!(
-            resolver.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)
+            ),
             SequenceResolution::Pending
         );
 
-        let resolution = resolver.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        let resolution = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+        );
         assert_eq!(resolution, SequenceResolution::Dispatch(Command::OpenHelp));
     }
 
@@ -1134,14 +1168,15 @@ mod tests {
 
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static_with_condition(
+            .register_exact(
                 ConditionExpr::All(SEARCH_ACTIVE),
                 &[ShortcutKey::char('g')],
                 Command::DebugStatusShow,
             )
             .expect("conditional binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::LastPage,
             )
@@ -1169,20 +1204,25 @@ mod tests {
 
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static_with_condition(
+            .register_exact(
                 ConditionExpr::All(SEARCH_ACTIVE),
                 &[ShortcutKey::char('g')],
                 Command::DebugStatusShow,
             )
             .expect("conditional binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::LastPage,
             )
             .expect("multi-key binding should register");
         registry
-            .register_static(&[ShortcutKey::char('x')], Command::DebugStatusHide)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('x')],
+                Command::DebugStatusHide,
+            )
             .expect("single-key binding should register");
         let mut resolver = SequenceResolver::new(registry, Duration::ZERO);
         let active_extensions = ExtensionUiSnapshot::with_search_active(true);
@@ -1211,7 +1251,7 @@ mod tests {
 
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static_with_condition(
+            .register_exact(
                 ConditionExpr::All(SEARCH_ACTIVE),
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::DebugStatusShow,
@@ -1244,7 +1284,7 @@ mod tests {
 
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static_with_condition(
+            .register_exact(
                 ConditionExpr::All(NORMAL_MODE),
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::FirstPage,
@@ -1270,7 +1310,8 @@ mod tests {
     fn enter_can_be_part_of_a_multi_key_binding() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::key(KeyCode::Enter)],
                 Command::FirstPage,
             )
@@ -1278,11 +1319,17 @@ mod tests {
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
         assert_eq!(
-            resolver.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)
+            ),
             SequenceResolution::Pending
         );
 
-        let resolution = resolver.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        let resolution = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
         assert_eq!(resolution, SequenceResolution::Dispatch(Command::FirstPage));
         assert_eq!(resolver.pending_display(), None);
     }
@@ -1291,25 +1338,40 @@ mod tests {
     fn mismatch_after_pending_exact_match_reprocesses_latest_key() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('g')], Command::FirstPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('g')],
+                Command::FirstPage,
+            )
             .expect("single-key binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::LastPage,
             )
             .expect("multi-key binding should register");
         registry
-            .register_static(&[ShortcutKey::char('x')], Command::NextPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('x')],
+                Command::NextPage,
+            )
             .expect("single-key binding should register");
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
         assert_eq!(
-            resolver.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)
+            ),
             SequenceResolution::Pending
         );
 
-        let mismatch = resolver.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+        let mismatch = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+        );
         assert_eq!(
             mismatch,
             SequenceResolution::DispatchThen {
@@ -1325,22 +1387,33 @@ mod tests {
     fn mismatch_after_pending_prefix_reprocesses_latest_key() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::FirstPage,
             )
             .expect("multi-key binding should register");
         registry
-            .register_static(&[ShortcutKey::char('x')], Command::NextPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('x')],
+                Command::NextPage,
+            )
             .expect("single-key binding should register");
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
         assert_eq!(
-            resolver.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)
+            ),
             SequenceResolution::Pending
         );
 
-        let mismatch = resolver.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+        let mismatch = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+        );
         assert_eq!(
             mismatch,
             SequenceResolution::DispatchWithRedraw(Command::NextPage)
@@ -1352,7 +1425,8 @@ mod tests {
     fn mismatch_after_pending_prefix_reports_clear_when_latest_key_is_unbound() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::FirstPage,
             )
@@ -1360,11 +1434,17 @@ mod tests {
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
         assert_eq!(
-            resolver.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)
+            ),
             SequenceResolution::Pending
         );
 
-        let mismatch = resolver.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+        let mismatch = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+        );
         assert_eq!(mismatch, SequenceResolution::Cleared);
         assert_eq!(resolver.pending_display(), None);
     }
@@ -1373,23 +1453,35 @@ mod tests {
     fn numeric_prefix_dispatches_and_formats_pending_digits() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_numeric_prefix("goto-page", ShortcutKey::char('G'), |page| {
-                Command::GotoPage { page }
-            })
+            .register_numeric_prefix(
+                ConditionExpr::Always,
+                "goto-page",
+                ShortcutKey::char('G'),
+                |page| Command::GotoPage { page },
+            )
             .expect("numeric prefix binding should register");
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
         assert_eq!(
-            resolver.handle_key(KeyEvent::new(KeyCode::Char('4'), KeyModifiers::NONE)),
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Char('4'), KeyModifiers::NONE)
+            ),
             SequenceResolution::Pending
         );
         assert_eq!(
-            resolver.handle_key(KeyEvent::new(KeyCode::Char('2'), KeyModifiers::NONE)),
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Char('2'), KeyModifiers::NONE)
+            ),
             SequenceResolution::Pending
         );
         assert_eq!(resolver.pending_display().as_deref(), Some("42"));
 
-        let dispatch = resolver.handle_key(KeyEvent::new(KeyCode::Char('G'), KeyModifiers::NONE));
+        let dispatch = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('G'), KeyModifiers::NONE),
+        );
         assert_eq!(
             dispatch,
             SequenceResolution::Dispatch(Command::GotoPage { page: 42 })
@@ -1400,35 +1492,52 @@ mod tests {
     fn non_digit_exact_binding_dispatches_immediately_alongside_numeric_prefix() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('=')], Command::ZoomReset)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('=')],
+                Command::ZoomReset,
+            )
             .expect("exact binding should register");
         registry
-            .register_numeric_prefix("goto-page", ShortcutKey::char('G'), |page| {
-                Command::GotoPage { page }
-            })
+            .register_numeric_prefix(
+                ConditionExpr::Always,
+                "goto-page",
+                ShortcutKey::char('G'),
+                |page| Command::GotoPage { page },
+            )
             .expect("numeric prefix binding should register");
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
-        let reset = resolver.handle_key(KeyEvent::new(KeyCode::Char('='), KeyModifiers::NONE));
+        let reset = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('='), KeyModifiers::NONE),
+        );
         assert_eq!(reset, SequenceResolution::Dispatch(Command::ZoomReset));
         assert_eq!(resolver.pending_display(), None);
     }
 
     #[test]
-    fn unregister_static_removes_exact_binding() {
+    fn unregister_exact_removes_exact_binding() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('j')], Command::NextPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('j')],
+                Command::NextPage,
+            )
             .expect("binding should register");
 
         assert!(
             registry
-                .unregister_static(&[ShortcutKey::char('j')])
+                .unregister_exact(ConditionExpr::Always, &[ShortcutKey::char('j')])
                 .expect("binding should unregister")
         );
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
         assert_eq!(
-            resolver.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)),
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)
+            ),
             SequenceResolution::Noop
         );
     }
@@ -1437,19 +1546,25 @@ mod tests {
     fn unregister_numeric_prefix_removes_count_binding() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_numeric_prefix("goto-page", ShortcutKey::char('G'), |page| {
-                Command::GotoPage { page }
-            })
+            .register_numeric_prefix(
+                ConditionExpr::Always,
+                "goto-page",
+                ShortcutKey::char('G'),
+                |page| Command::GotoPage { page },
+            )
             .expect("binding should register");
 
         assert!(
             registry
-                .unregister_numeric_prefix(ShortcutKey::char('G'))
+                .unregister_numeric_prefix(ConditionExpr::Always, ShortcutKey::char('G'))
                 .expect("binding should unregister")
         );
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
         assert_eq!(
-            resolver.handle_key(KeyEvent::new(KeyCode::Char('4'), KeyModifiers::NONE)),
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Char('4'), KeyModifiers::NONE)
+            ),
             SequenceResolution::Noop
         );
     }
@@ -1459,7 +1574,8 @@ mod tests {
         let mut registry = SequenceRegistry::new();
 
         let error = registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::key(KeyCode::Esc)],
                 Command::FirstPage,
             )
@@ -1472,9 +1588,12 @@ mod tests {
         let mut registry = SequenceRegistry::new();
 
         let error = registry
-            .register_numeric_prefix("goto-page", ShortcutKey::char('5'), |page| {
-                Command::GotoPage { page }
-            })
+            .register_numeric_prefix(
+                ConditionExpr::Always,
+                "goto-page",
+                ShortcutKey::char('5'),
+                |page| Command::GotoPage { page },
+            )
             .expect_err("digit suffix should be rejected");
         assert_eq!(error, SequenceRegistrationError::InvalidNumericSuffix);
     }
@@ -1483,12 +1602,19 @@ mod tests {
     fn snapshot_includes_exact_and_numeric_bindings() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('j')], Command::NextPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('j')],
+                Command::NextPage,
+            )
             .expect("single-key binding should register");
         registry
-            .register_numeric_prefix("goto-page", ShortcutKey::char('G'), |page| {
-                Command::GotoPage { page }
-            })
+            .register_numeric_prefix(
+                ConditionExpr::Always,
+                "goto-page",
+                ShortcutKey::char('G'),
+                |page| Command::GotoPage { page },
+            )
             .expect("numeric prefix binding should register");
 
         let snapshot = registry.snapshot();
@@ -1512,7 +1638,8 @@ mod tests {
         let mut registry = SequenceRegistry::new();
 
         let error = registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::new(KeyCode::Char('a'), KeyModifiers::SHIFT)],
                 Command::NextPage,
             )
@@ -1527,7 +1654,8 @@ mod tests {
     fn registry_canonicalizes_ctrl_shift_letters_to_ctrl_letters() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::new(
                     KeyCode::Char('O'),
                     KeyModifiers::CONTROL | KeyModifiers::SHIFT,
@@ -1537,8 +1665,10 @@ mod tests {
             .expect("Ctrl+Shift+letter should normalize to Ctrl+letter");
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
-        let resolution =
-            resolver.handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL));
+        let resolution = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL),
+        );
         assert_eq!(
             resolution,
             SequenceResolution::Dispatch(Command::HistoryBack)
@@ -1549,7 +1679,8 @@ mod tests {
     fn unsupported_modifier_input_is_ignored() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('g'), ShortcutKey::char('g')],
                 Command::LastPage,
             )
@@ -1557,12 +1688,17 @@ mod tests {
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
 
         assert_eq!(
-            resolver.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)
+            ),
             SequenceResolution::Pending
         );
 
-        let resolution =
-            resolver.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::SUPER));
+        let resolution = handle_normal_key(
+            &mut resolver,
+            KeyEvent::new(KeyCode::Char('k'), KeyModifiers::SUPER),
+        );
 
         assert_eq!(resolution, SequenceResolution::Cleared);
         assert_eq!(resolver.pending_display(), None);

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -272,13 +272,14 @@ fn help_rendered_height(lines: &[Line<'static>], width: u16, height: u16) -> usi
 mod tests {
     use super::{build_help_lines, help_rendered_height};
     use crate::command::{Command, PanAmount, PanDirection};
-    use crate::input::keymap::build_builtin_sequence_registry;
+    use crate::condition::ConditionExpr;
+    use crate::input::keymap::build_default_sequence_registry;
     use crate::input::sequence::SequenceRegistry;
     use crate::input::shortcut::ShortcutKey;
 
     #[test]
     fn help_lines_include_runtime_bindings() {
-        let keymap = build_builtin_sequence_registry().snapshot();
+        let keymap = build_default_sequence_registry().snapshot();
         let text = build_help_lines(&keymap)
             .iter()
             .map(|line| {
@@ -304,13 +305,22 @@ mod tests {
     fn help_lines_reflect_runtime_registry_changes() {
         let mut registry = SequenceRegistry::new();
         registry
-            .register_static(&[ShortcutKey::char('x')], Command::NextPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('x')],
+                Command::NextPage,
+            )
             .expect("next-page binding should register");
         registry
-            .register_static(&[ShortcutKey::char('y')], Command::PrevPage)
+            .register_exact(
+                ConditionExpr::Always,
+                &[ShortcutKey::char('y')],
+                Command::PrevPage,
+            )
             .expect("prev-page binding should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('A')],
                 Command::Pan {
                     direction: PanDirection::Left,
@@ -319,7 +329,8 @@ mod tests {
             )
             .expect("pan left should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('S')],
                 Command::Pan {
                     direction: PanDirection::Down,
@@ -328,7 +339,8 @@ mod tests {
             )
             .expect("pan down should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('W')],
                 Command::Pan {
                     direction: PanDirection::Up,
@@ -337,7 +349,8 @@ mod tests {
             )
             .expect("pan up should register");
         registry
-            .register_static(
+            .register_exact(
+                ConditionExpr::Always,
                 &[ShortcutKey::char('D')],
                 Command::Pan {
                     direction: PanDirection::Right,
@@ -367,7 +380,7 @@ mod tests {
 
     #[test]
     fn help_scroll_limit_accounts_for_wrapping() {
-        let keymap = build_builtin_sequence_registry().snapshot();
+        let keymap = build_default_sequence_registry().snapshot();
         let raw_limit = build_help_lines(&keymap).len().saturating_sub(5);
         let wrapped_limit = help_rendered_height(&build_help_lines(&keymap), 20, 5);
 


### PR DESCRIPTION
## Rationale

Follow up on #113 by making runtime conditions the explicit foundation of sequence registration and resolution. The previous API names and convenience paths still implied unconditional or static bindings.

## Changes

- rename exact sequence registration and removal APIs around matching behavior
- require an explicit runtime condition for every registered binding
- organize default and none preset construction by behavior
- remove the resolver path that implicitly assumed Normal mode
- update callers and tests to use the unified conditional registry API

## Verification

- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized keybinding sequence registration around explicit activation conditions, and consolidated key resolution to use context-aware handling.
  * Switched default input behavior to rely on the default sequence registry (including policy and interaction subsystem initialization), aligning help and palette key handling with the same source of truth.

* **Tests**
  * Updated and expanded the test suite to validate keybinding registration and invocation under the default registry, including condition-based bindings, timeout/palette interactions, and help-mode navigation/scroll behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->