### PR TITLE
feat(config): refine keymap configuration handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ or install from crates.io:
 cargo install preview-pdf
 ```
 
-## Keys
+## Keymap
 
 | Key | Action |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -40,9 +40,12 @@ cargo install preview-pdf
 `$XDG_CONFIG_HOME/pvf/config.toml`, `$HOME/.config/pvf/config.toml`, or
 `%APPDATA%/pvf/config.toml`.
 
-The keymap can be patched with `[[keymap]]` entries:
+The keymap can be selected with `keymap_preset` and patched with `[[keymap]]`
+entries:
 
 ```toml
+keymap_preset = "default"
+
 [[keymap]]
 when = "normal"
 key = "j"

--- a/README.md
+++ b/README.md
@@ -40,23 +40,33 @@ cargo install preview-pdf
 `$XDG_CONFIG_HOME/pvf/config.toml`, `$HOME/.config/pvf/config.toml`, or
 `%APPDATA%/pvf/config.toml`.
 
-Normal-mode key bindings can be patched with `[keymap]`:
+The keymap can be patched with `[[keymap]]` entries:
 
 ```toml
-[keymap]
-preset = "default" # or "none"
-unbind = ["j"]
+[[keymap]]
+when = "normal"
+key = "j"
+command = false
 
-[keymap.bindings]
-"<down>" = "next-page"
-"gg" = "first-page"
-"[count]G" = "goto-page"
-":" = "open-palette command"
+[[keymap]]
+when = "normal"
+key = "<down>"
+command = "next-page"
+
+[[keymap]]
+when = "normal"
+key = "gg"
+command = "first-page"
+
+[[keymap]]
+when = "palette"
+key = "<esc>"
+command = "close-palette"
 ```
 
 Use the key labels shown in help, such as `G`, `<c-o>`, `<down>`, and
-`[count]G`. Palette-local keys are not part of the normal-mode keymap.
-`<esc>` is reserved for cancellation.
+`[count]G`. Common `when` values include `normal`, `help`, `palette`,
+`palette.with-input-history`, and `palette.no-input-history`.
 
 ## Note
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ source for architecture, reference contracts, and testing guidance.
   flow, subsystem boundaries, ownership, or event routing.
 - Put stable developer-facing behavior in [reference.md](reference.md) when a change
   intentionally changes CLI behavior, config compatibility, command policy,
-  key binding resolution, palette semantics, extension host behavior, render
+  keymap resolution, palette semantics, extension host behavior, render
   stale-result behavior, cache behavior visible outside the implementation, or
   performance diagnostics contracts.
 - Put testing policy in [testing.md](testing.md) when a change affects how behavior should

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,7 @@ can operate on resolved policies rather than re-reading config or CLI state.
   coordination.
 - [src/command/](../src/command/) owns command ids, metadata, parsing, source-aware validation,
   dispatch, typed command outcomes, and command effects.
-- [src/input/](../src/input/) owns key sequence normalization, built-in key bindings, numeric
+- [src/input/](../src/input/) owns key sequence normalization, built-in keymap entries, numeric
   prefixes, and input history used by palette inputs.
 - [src/palette/](../src/palette/) owns palette sessions, provider lookup, candidate matching,
   selection state, completion, submit, cancel, palette input state, and rendered
@@ -59,7 +59,7 @@ Palette providers receive read-only app and extension snapshots. They should
 request behavior by returning typed effects or commands instead of taking
 `AppState` directly. Surface-local operations such as palette submit, palette
 selection, palette input editing, palette input history recall, and help
-scrolling enter the same command dispatch path as normal-mode key bindings.
+scrolling enter the same command dispatch path as normal-mode keymap entries.
 
 Extensions own extension-local state and observe `AppEvent` values. Shared UI
 data crosses from extensions to palettes through `ExtensionUiSnapshot`.
@@ -94,14 +94,14 @@ communication uses snapshots, command requests, events, or worker completions.
 Terminal input enters as `DomainEvent::Input`.
 
 1. The loop router delegates input to app input handling.
-2. App input handling builds a key binding context from the active surface and
+2. App input handling builds a keymap context from the active surface and
    shared runtime condition state, such as palette kind, palette input history
    availability, and active search.
 3. Extension input hooks may intercept extension-local inputs in normal mode
    when no pending key sequence owns the input.
-4. The input sequence resolver evaluates every binding against the current
+4. The input sequence resolver evaluates every keymap entry against the current
    shared runtime conditions and maps matching key sequences to typed commands.
-   All resolved key bindings dispatch as binding input.
+   All resolved keymap entries dispatch as binding input.
 5. Command dispatch validates invocation source, resolves the required target
    such as app, active palette, or active help, checks the
    command `enabled_when` runtime condition, applies behavior, and applies

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,8 +31,7 @@ can operate on resolved policies rather than re-reading config or CLI state.
   dispatch, typed command outcomes, and command effects.
 - [src/input/](../src/input/) owns key sequence normalization, numeric prefixes,
   and input history used by palette inputs.
-- [src/config/](../src/config/) owns config loading, option resolution, and
-  built-in keymap presets.
+- [src/config/](../src/config/) owns config loading and option resolution.
 - [src/palette/](../src/palette/) owns palette sessions, provider lookup, candidate matching,
   selection state, completion, submit, cancel, palette input state, and rendered
   palette views. It does not own raw terminal key routing.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,8 +29,10 @@ can operate on resolved policies rather than re-reading config or CLI state.
   coordination.
 - [src/command/](../src/command/) owns command ids, metadata, parsing, source-aware validation,
   dispatch, typed command outcomes, and command effects.
-- [src/input/](../src/input/) owns key sequence normalization, built-in keymap entries, numeric
-  prefixes, and input history used by palette inputs.
+- [src/input/](../src/input/) owns key sequence normalization, numeric prefixes,
+  and input history used by palette inputs.
+- [src/config/](../src/config/) owns config loading, option resolution, and
+  built-in keymap presets.
 - [src/palette/](../src/palette/) owns palette sessions, provider lookup, candidate matching,
   selection state, completion, submit, cancel, palette input state, and rendered
   palette views. It does not own raw terminal key routing.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -79,9 +79,11 @@ Contract:
 - `--config` and `--no-config` are mutually exclusive.
 - Partial config files leave unspecified options absent so later sources and
   defaults can still apply.
-- Top-level `[keymap]` config patches the normal-mode key sequence registry.
+- `[[keymap]]` config entries patch the shared conditional key sequence
+  registry. Each entry has `when`, `key`, and `command` fields. `command` is
+  either a command string or `false` to unbind the key.
 - Validation and sanitization that users can observe, such as enum rejection,
-  keymap preset and command validation, safe duration minimums, and zoom bounds,
+  keymap condition and command validation, safe duration minimums, and zoom bounds,
   are part of the config contract.
 
 Compatibility:
@@ -120,7 +122,7 @@ Contract:
   invocation policy and `enabled_when` runtime condition allow it.
 - Internal commands are runtime plumbing and must not appear in the command
   palette.
-- Binding-only commands can be invoked from key bindings but not from direct
+- Binding-only commands can be invoked from the keymap but not from direct
   command palette input.
 - Internal-only commands can be invoked only as internal follow-ups that
   complete another user action.
@@ -143,10 +145,10 @@ Contract:
 - Typed command submission is separate from listing: a known typed command is
   parsed and then validated by dispatch policy, so "not listed" does not mean
   "unknown".
-- Help surfaces may describe configured commands and bindings without hiding
+- Help surfaces may describe configured commands and keymap entries without hiding
   them solely because `enabled_when` is currently false; a surface that claims
   to show only currently runnable actions must evaluate `enabled_when`.
-- Runtime condition vocabulary is shared by commands and key bindings. A
+- Runtime condition vocabulary is shared by commands and keymap entries. A
   palette-kind condition is true only when a palette is open and its active
   kind matches; a closed palette does not match any kind.
 - Command handlers return `CommandExecution`: an `Applied` or `Noop` outcome
@@ -192,7 +194,7 @@ Test coverage:
 - Command registry, parser, validation, and dispatch tests in [src/command/](../src/command/).
 - Command-palette provider tests where command metadata affects palette UI.
 
-## Key Bindings
+## Keymap
 
 Orientation:
 - Terminal key events are converted to typed command requests before behavior is
@@ -200,12 +202,22 @@ Orientation:
   conditional sequence registry.
 
 Contract:
-- Printable bindings are defined by resulting characters, not by physical keys.
+- Printable keymap entries are defined by resulting characters, not by physical keys.
 - Runtime `Meta` key events are normalized to the `Alt`/`<m-...>` shortcut
   representation. Unbound Alt-only chords are not treated as printable input.
-- Configured key bindings use the same key labels shown in help, such as
+- Configured keymap entries use the same key labels shown in help, such as
   `gg`, `<c-o>`, `<down>`, and `[count]G`.
-- Key binding `enabled_when` uses the same runtime condition vocabulary as
+- Configured keymap entries use one `when` selector, one `key` sequence, and one
+  `command` value. `when` names where the binding is active; `key` names the
+  sequence; `command` names the command to dispatch, or `false` to unbind.
+- When multiple configured keymap entries use the same `when` selector and `key`
+  sequence, the later entry replaces the earlier entry.
+- Supported `when` selectors are `normal`, `normal.search-active`,
+  `normal.search-inactive`, `help`, `palette`, `palette.command`,
+  `palette.search`, `palette.search-results`, `palette.history`,
+  `palette.outline`, `palette.with-input-history`, and
+  `palette.no-input-history`.
+- Keymap `enabled_when` uses the same runtime condition vocabulary as
   command `enabled_when`; do not add a separate keymap-only condition enum.
 - Every key input and sequence timeout resolves against the current runtime
   condition state. Pending sequences do not preserve the state in which they
@@ -214,28 +226,25 @@ Contract:
 - Multi-key sequences can remain pending until resolved or timed out.
 - Numeric prefixes are parsed by the input sequence layer and dispatch typed
   commands.
-- All key bindings dispatch with the binding invocation source, reference known
+- All keymap entries dispatch with the binding invocation source, reference known
   command ids, and satisfy command invocation policy.
-- Configured key bindings currently receive a normal-mode runtime condition and
-  must reference known app-target commands that can be invoked from bindings.
-  Built-in surface bindings carry palette or help runtime conditions. Dispatch
-  still validates the resolved command before applying behavior.
+- Configured keymap entries may target normal, help, and palette conditions.
+  Palette-target commands require a palette `when` selector; help-target
+  commands require `when = "help"`. Dispatch still validates the resolved
+  command before applying behavior.
 - Palette keys dispatch hidden palette binding-only commands such as
   submit, complete, selection movement, input editing, and palette input
   history recall.
 - Help keys dispatch hidden help binding-only commands such as close and
   scroll.
-- The `none` keymap preset omits normal-mode default bindings while keeping
-  base UI bindings for active surfaces such as palette input, help scrolling,
-  and search cancellation.
 - When a multi-key sequence is already pending, `<esc>` clears the pending
   sequence instead of dispatching another command.
 
 Compatibility:
-- Changing a default key binding affects user muscle memory and help output; do
+- Changing a default keymap entry affects user muscle memory and help output; do
   it intentionally with tests.
 - Complete key inventories belong in `src/input/keymap.rs` and rendered help.
-  Docs may summarize categories of bindings, but should not own the table.
+  Docs may summarize categories of keymap entries, but should not own the table.
 
 Owned by:
 - [src/input/keymap.rs](../src/input/keymap.rs)
@@ -252,7 +261,7 @@ Test coverage:
 Orientation:
 - Palette behavior splits into common session mechanics and provider-owned
   semantics. The common path owns opening, palette input state, selection,
-  completion, submit, and closing. Palette key bindings turn terminal keys into
+  completion, submit, and closing. Palette keymap entries turn terminal keys into
   commands when their runtime conditions match; providers own candidate meaning
   and the effects returned for completion and submit.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -207,6 +207,8 @@ Contract:
   representation. Unbound Alt-only chords are not treated as printable input.
 - Configured keymap entries use the same key labels shown in help, such as
   `gg`, `<c-o>`, `<down>`, and `[count]G`.
+- `keymap_preset` selects the starting keymap. Supported values are `default`
+  and `none`.
 - Configured keymap entries use one `when` selector, one `key` sequence, and one
   `command` value. `when` names where the binding is active; `key` names the
   sequence; `command` names the command to dispatch, or `false` to unbind.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -243,11 +243,11 @@ Contract:
 Compatibility:
 - Changing a default keymap entry affects user muscle memory and help output; do
   it intentionally with tests.
-- Complete key inventories belong in `src/input/keymap.rs` and rendered help.
+- Complete key inventories belong in config keymap presets and rendered help.
   Docs may summarize categories of keymap entries, but should not own the table.
 
 Owned by:
-- [src/input/keymap.rs](../src/input/keymap.rs)
+- [src/config/keymap/](../src/config/keymap/)
 - [src/input/sequence.rs](../src/input/sequence.rs)
 - [src/input/shortcut.rs](../src/input/shortcut.rs)
 - [src/ui/help.rs](../src/ui/help.rs)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -45,7 +45,7 @@ protection: parser behavior, compatibility rules, cross-module consistency,
 stale-result handling, and observable user-facing outcomes.
 
 Use both when a topic needs a mental model and a guardrail. For example,
-[reference.md](reference.md) explains that key bindings are owned by the input registry and
+[reference.md](reference.md) explains that keymap entries are owned by the input registry and
 must resolve to invocable commands; command tests verify that registry
 consistency.
 
@@ -90,7 +90,7 @@ through the subsystem boundary. If not, add an in-file unit test near the code.
 Prefer writing or updating the test before changing behavior.
 
 Use test-first work for bug fixes, command parsing or dispatch behavior, key
-binding resolution, palette interaction semantics, extension event propagation,
+keymap resolution, palette interaction semantics, extension event propagation,
 render stale-result handling, config compatibility, and CLI-visible behavior.
 
 For pure refactors, first check whether existing tests already cover the

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -45,9 +45,8 @@ protection: parser behavior, compatibility rules, cross-module consistency,
 stale-result handling, and observable user-facing outcomes.
 
 Use both when a topic needs a mental model and a guardrail. For example,
-[reference.md](reference.md) explains that keymap entries are owned by the input registry and
-must resolve to invocable commands; command tests verify that registry
-consistency.
+[reference.md](reference.md) explains that keymap entries must resolve to
+invocable commands; command tests verify that registry consistency.
 
 Avoid both extremes:
 
@@ -89,7 +88,7 @@ through the subsystem boundary. If not, add an in-file unit test near the code.
 
 Prefer writing or updating the test before changing behavior.
 
-Use test-first work for bug fixes, command parsing or dispatch behavior, key
+Use test-first work for bug fixes, command parsing or dispatch behavior,
 keymap resolution, palette interaction semantics, extension event propagation,
 render stale-result handling, config compatibility, and CLI-visible behavior.
 

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 
 use crate::config::Config;
+use crate::config::keymap::build_default_sequence_registry;
 use crate::config::{
     AppOptions, AppOptionsResolver, CachePolicy, EventLoopPolicy, InputPolicy, RenderPolicy,
     ResolvedAppOptions, ViewPolicy, WatchPolicy, load_default_app_options,
@@ -8,7 +9,6 @@ use crate::config::{
 use crate::error::AppResult;
 use crate::extension::ExtensionHost;
 use crate::input::InputHistoryService;
-use crate::input::keymap::build_default_sequence_registry;
 use crate::input::sequence::{DEFAULT_SEQUENCE_TIMEOUT, SequenceRegistry, SequenceResolver};
 use crate::palette::{PaletteManager, PaletteRegistry};
 use crate::presenter::{ImagePresenter, PresenterKind, create_presenter_with_cache_limits};

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -21,13 +21,11 @@ pub use parse::{parse_command_text, parse_invocable_command_text};
 pub use spec::command_registry;
 pub use spec::{
     CommandPolicyContext, all_command_specs, find_command_spec, is_command_visible_in_palette,
-    validate_command_for_normal_keymap, validate_command_id_for_normal_keymap,
 };
 pub use types::{
     ArgHint, ArgKind, ArgSpec, CommandInvocationSource, CommandOutcome, CommandSpec, PanAmount,
     PanDirection, SearchMatcherKind,
 };
 #[cfg(test)]
-pub use types::{
-    CommandExposure, CommandInvocationPolicy, SpreadCoverPolicyArg, SpreadDirectionArg,
-};
+pub use types::{CommandExposure, SpreadCoverPolicyArg, SpreadDirectionArg};
+pub(crate) use types::{CommandInvocationPolicy, CommandTargetRequirement};

--- a/src/command/spec.rs
+++ b/src/command/spec.rs
@@ -59,24 +59,6 @@ pub fn validate_command_for_policy(
     validate_command_spec_for_policy(spec, ctx)
 }
 
-pub fn validate_command_for_normal_keymap(command: &Command) -> AppResult<()> {
-    let Some(spec) = spec_for_command(command) else {
-        return Err(AppError::unsupported(
-            "command spec should exist for typed command",
-        ));
-    };
-    validate_command_spec_for_normal_keymap(spec)?;
-    validate_command_spec_invocation_for_source(spec, CommandInvocationSource::Binding)
-}
-
-pub fn validate_command_id_for_normal_keymap(id: &str) -> AppResult<()> {
-    let Some(spec) = find_command_spec(id) else {
-        return Err(AppError::invalid_argument("unknown command id"));
-    };
-    validate_command_spec_for_normal_keymap(spec)?;
-    validate_command_spec_invocation_for_source(spec, CommandInvocationSource::Binding)
-}
-
 pub fn rejection_message_for_command(
     command: &Command,
     ctx: &CommandPolicyContext<'_>,
@@ -114,18 +96,6 @@ fn validate_command_spec_invocation_for_source(
     Err(AppError::invalid_argument(format!(
         "{} is an internal command and cannot be invoked directly",
         spec.id
-    )))
-}
-
-fn validate_command_spec_for_normal_keymap(spec: CommandSpec) -> AppResult<()> {
-    if spec.target == CommandTargetRequirement::App {
-        return Ok(());
-    }
-
-    Err(AppError::invalid_argument(format!(
-        "{} cannot be bound in normal keymap because it {}",
-        spec.id,
-        target_requirement_label(spec.target)
     )))
 }
 
@@ -218,14 +188,6 @@ fn target_unavailable_message(spec: CommandSpec) -> String {
     }
 }
 
-fn target_requirement_label(target: CommandTargetRequirement) -> &'static str {
-    match target {
-        CommandTargetRequirement::App => "targets the app",
-        CommandTargetRequirement::ActivePalette => "requires an active palette",
-        CommandTargetRequirement::ActiveHelp => "requires active help",
-    }
-}
-
 fn app_error_message(err: AppError) -> String {
     match err {
         AppError::InvalidArgument(message)
@@ -246,8 +208,7 @@ mod tests {
 
     use super::{
         CommandPolicyContext, command_registry, find_command_spec, is_command_visible_in_palette,
-        validate_command_for_normal_keymap, validate_command_for_policy,
-        validate_command_id_for_policy,
+        validate_command_for_policy, validate_command_id_for_policy,
     };
     use crate::command::types::{CommandRole, CommandTargetRequirement};
     use crate::command::{
@@ -455,12 +416,6 @@ mod tests {
             validate_command_for_policy(&Command::PaletteInputHistoryOlder, &outline_palette_ctx)
                 .expect_err("outline palette should not support input history");
         assert!(err.to_string().contains("palette input history"));
-    }
-
-    #[test]
-    fn invocation_validation_ignores_runtime_enabled_when() {
-        validate_command_for_normal_keymap(&Command::NextSearchHit)
-            .expect("configured bindings may invoke state-dependent commands");
     }
 
     fn policy_context<'a>(

--- a/src/command/tests/mod.rs
+++ b/src/command/tests/mod.rs
@@ -3,8 +3,8 @@ use crate::command::{
     CommandInvocationSource, CommandPolicyContext, command_registry, find_command_spec,
 };
 use crate::condition::{ConditionExpr, RuntimeConditionContext, evaluate_condition};
+use crate::config::keymap::build_default_sequence_registry;
 use crate::extension::ExtensionUiSnapshot;
-use crate::input::keymap::build_default_sequence_registry;
 use crate::palette::PaletteKind;
 
 use super::spec::validate_command_id_for_policy;

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -66,7 +65,7 @@ struct RawConfig {
     cache: Option<RawCacheConfig>,
     view: Option<RawViewConfig>,
     input: Option<RawInputConfig>,
-    keymap: Option<RawKeymapConfig>,
+    keymap: Option<Vec<RawKeymapConfig>>,
     watch: Option<RawWatchConfig>,
 }
 
@@ -108,12 +107,18 @@ struct RawInputConfig {
     sequence_timeout_ms: Option<u64>,
 }
 
-#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
-#[serde(default)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 struct RawKeymapConfig {
-    preset: Option<String>,
-    unbind: Vec<String>,
-    bindings: BTreeMap<String, String>,
+    when: String,
+    key: String,
+    command: RawKeymapCommand,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+enum RawKeymapCommand {
+    Command(String),
+    Unbind(bool),
 }
 
 #[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
@@ -205,31 +210,27 @@ impl From<RawInputConfig> for InputOptions {
     }
 }
 
-impl TryFrom<RawKeymapConfig> for KeymapOptions {
+impl TryFrom<Vec<RawKeymapConfig>> for KeymapOptions {
     type Error = AppError;
 
-    fn try_from(raw: RawKeymapConfig) -> Result<Self, Self::Error> {
-        let preset = raw
-            .preset
-            .as_deref()
-            .map(super::keymap::parse_keymap_preset)
-            .transpose()?;
-        let unbind = raw
-            .unbind
-            .iter()
-            .map(|key| super::keymap::parse_keymap_target(key))
-            .collect::<AppResult<Vec<_>>>()?;
+    fn try_from(raw: Vec<RawKeymapConfig>) -> Result<Self, Self::Error> {
         let bindings = raw
-            .bindings
             .iter()
-            .map(|(key, command)| super::keymap::parse_keymap_binding(key, command))
+            .map(|entry| {
+                let command = match &entry.command {
+                    RawKeymapCommand::Command(command) => Some(command.as_str()),
+                    RawKeymapCommand::Unbind(false) => None,
+                    RawKeymapCommand::Unbind(true) => {
+                        return Err(AppError::invalid_argument(
+                            "keymap command must be a command string or false",
+                        ));
+                    }
+                };
+                super::keymap::parse_keymap_binding(&entry.when, &entry.key, command)
+            })
             .collect::<AppResult<Vec<_>>>()?;
 
-        Ok(Self {
-            preset,
-            unbind,
-            bindings,
-        })
+        Ok(Self { bindings })
     }
 }
 
@@ -366,7 +367,7 @@ mod tests {
 
     use crate::app::{PageLayoutMode, SpreadCoverPolicy, SpreadDirection};
     use crate::command::Command;
-    use crate::config::{AppOptionsResolver, KeymapBinding, KeymapPreset, KeymapTarget};
+    use crate::config::{AppOptionsResolver, KeymapBinding, KeymapWhen};
     use crate::extension::ExtensionUiSnapshot;
     use crate::input::sequence::{
         DEFAULT_SEQUENCE_TIMEOUT, KeyBindingContext, SequenceResolution, SequenceResolver,
@@ -464,41 +465,46 @@ mod tests {
     }
 
     #[test]
-    fn explicit_config_reads_keymap_section() {
+    fn explicit_config_reads_keymap_entries() {
         let path = unique_temp_path("keymap.toml");
         fs::write(
             &path,
             r#"
-            [keymap]
-            preset = "none"
-            unbind = ["j", "[count]G"]
+            [[keymap]]
+            when = "normal"
+            key = "<down>"
+            command = "next-page"
 
-            [keymap.bindings]
-            "<down>" = "next-page"
-            "[count]G" = "goto-page"
+            [[keymap]]
+            when = "normal"
+            key = "[count]G"
+            command = "goto-page"
+
+            [[keymap]]
+            when = "normal"
+            key = "j"
+            command = false
             "#,
         )
         .expect("config file should be written");
 
         let options = load_options_from_explicit_path(&path).expect("config should parse");
-        assert_eq!(options.keymap.preset, Some(KeymapPreset::None));
-        assert_eq!(
-            options.keymap.unbind,
-            vec![
-                KeymapTarget::Exact(vec![ShortcutKey::char('j')]),
-                KeymapTarget::NumericPrefix(ShortcutKey::char('G')),
-            ]
-        );
         assert_eq!(
             options.keymap.bindings,
             vec![
                 KeymapBinding::Exact {
+                    when: KeymapWhen::Normal,
                     keys: vec![ShortcutKey::key(KeyCode::Down)],
                     command: Command::NextPage,
                 },
                 KeymapBinding::NumericPrefix {
+                    when: KeymapWhen::Normal,
                     suffix: ShortcutKey::char('G'),
                     command_id: "goto-page",
+                },
+                KeymapBinding::UnbindExact {
+                    when: KeymapWhen::Normal,
+                    keys: vec![ShortcutKey::char('j')],
                 },
             ]
         );
@@ -512,12 +518,15 @@ mod tests {
         fs::write(
             &path,
             r#"
-            [keymap]
-            preset = "none"
+            [[keymap]]
+            when = "normal"
+            key = "<down>"
+            command = "next-page"
 
-            [keymap.bindings]
-            "<down>" = "next-page"
-            "[count]G" = "goto-page"
+            [[keymap]]
+            when = "normal"
+            key = "j"
+            command = false
             "#,
         )
         .expect("config file should be written");
@@ -541,28 +550,6 @@ mod tests {
             ),
             SequenceResolution::Dispatch(Command::NextPage)
         );
-        assert_eq!(
-            handle_normal_key(
-                &mut resolver,
-                KeyEvent::new(KeyCode::Char('4'), KeyModifiers::NONE)
-            ),
-            SequenceResolution::Pending
-        );
-        assert_eq!(
-            handle_normal_key(
-                &mut resolver,
-                KeyEvent::new(KeyCode::Char('2'), KeyModifiers::NONE)
-            ),
-            SequenceResolution::Pending
-        );
-        assert_eq!(
-            handle_normal_key(
-                &mut resolver,
-                KeyEvent::new(KeyCode::Char('G'), KeyModifiers::NONE)
-            ),
-            SequenceResolution::Dispatch(Command::GotoPage { page: 42 })
-        );
-
         fs::remove_file(&path).expect("config file should be removed");
     }
 
@@ -572,11 +559,10 @@ mod tests {
         fs::write(
             &path,
             r#"
-            [keymap]
-            preset = "none"
-
-            [keymap.bindings]
-            "<" = "prev-page"
+            [[keymap]]
+            when = "normal"
+            key = "<"
+            command = "prev-page"
             "#,
         )
         .expect("config file should be written");
@@ -598,20 +584,92 @@ mod tests {
     }
 
     #[test]
-    fn keymap_config_rejects_unknown_preset() {
-        let path = unique_temp_path("bad-keymap-preset.toml");
+    fn keymap_config_rejects_unknown_when() {
+        let path = unique_temp_path("bad-keymap-when.toml");
         fs::write(
             &path,
             r#"
-            [keymap]
-            preset = "emacs"
+            [[keymap]]
+            when = "emacs"
+            key = "x"
+            command = "next-page"
             "#,
         )
         .expect("config file should be written");
 
         let err = load_options_from_explicit_path(&path).expect_err("config should be rejected");
         assert!(
-            err.to_string().contains("unknown keymap preset"),
+            err.to_string().contains("unknown keymap condition"),
+            "unexpected error: {err}"
+        );
+
+        fs::remove_file(&path).expect("config file should be removed");
+    }
+
+    #[test]
+    fn keymap_config_rejects_legacy_table_shape() {
+        let path = unique_temp_path("legacy-keymap.toml");
+        fs::write(
+            &path,
+            r#"
+            [keymap]
+            preset = "none"
+
+            [keymap.bindings]
+            "j" = "next-page"
+            "#,
+        )
+        .expect("config file should be written");
+
+        let err = load_options_from_explicit_path(&path).expect_err("config should be rejected");
+        assert!(
+            err.to_string().contains("invalid"),
+            "unexpected error: {err}"
+        );
+
+        fs::remove_file(&path).expect("config file should be removed");
+    }
+
+    #[test]
+    fn keymap_config_rejects_true_command_value() {
+        let path = unique_temp_path("true-keymap-command.toml");
+        fs::write(
+            &path,
+            r#"
+            [[keymap]]
+            when = "normal"
+            key = "j"
+            command = true
+            "#,
+        )
+        .expect("config file should be written");
+
+        let err = load_options_from_explicit_path(&path).expect_err("config should be rejected");
+        assert!(
+            err.to_string()
+                .contains("command must be a command string or false"),
+            "unexpected error: {err}"
+        );
+
+        fs::remove_file(&path).expect("config file should be removed");
+    }
+
+    #[test]
+    fn keymap_config_requires_command() {
+        let path = unique_temp_path("missing-keymap-action.toml");
+        fs::write(
+            &path,
+            r#"
+            [[keymap]]
+            when = "normal"
+            key = "j"
+            "#,
+        )
+        .expect("config file should be written");
+
+        let err = load_options_from_explicit_path(&path).expect_err("config should be rejected");
+        assert!(
+            err.to_string().contains("missing field `command`"),
             "unexpected error: {err}"
         );
 
@@ -624,8 +682,10 @@ mod tests {
         fs::write(
             &path,
             r#"
-            [keymap.bindings]
-            "x" = "submit-search needle"
+            [[keymap]]
+            when = "normal"
+            key = "x"
+            command = "submit-search needle"
             "#,
         )
         .expect("config file should be written");
@@ -650,8 +710,10 @@ mod tests {
                 &path,
                 format!(
                     r#"
-                    [keymap.bindings]
-                    "x" = "{command}"
+                    [[keymap]]
+                    when = "normal"
+                    key = "x"
+                    command = "{command}"
                     "#
                 ),
             )
@@ -670,19 +732,28 @@ mod tests {
     }
 
     #[test]
-    fn keymap_config_rejects_escape_bindings() {
-        let path = unique_temp_path("bad-keymap-key.toml");
+    fn keymap_config_accepts_single_escape_bindings() {
+        let path = unique_temp_path("esc-keymap-key.toml");
         fs::write(
             &path,
             r#"
-            [keymap.bindings]
-            "<esc>" = "quit"
+            [[keymap]]
+            when = "normal"
+            key = "<esc>"
+            command = "quit"
             "#,
         )
         .expect("config file should be written");
 
-        let err = load_options_from_explicit_path(&path).expect_err("config should be rejected");
-        assert!(err.to_string().contains("<esc>"), "unexpected error: {err}");
+        let options = load_options_from_explicit_path(&path).expect("config should load");
+        assert_eq!(
+            options.keymap.bindings,
+            vec![KeymapBinding::Exact {
+                when: KeymapWhen::Normal,
+                keys: vec![ShortcutKey::key(KeyCode::Esc)],
+                command: Command::Quit,
+            }]
+        );
 
         fs::remove_file(&path).expect("config file should be removed");
     }
@@ -693,8 +764,10 @@ mod tests {
         fs::write(
             &path,
             r#"
-            [keymap.bindings]
-            "<enter>" = "next-page"
+            [[keymap]]
+            when = "normal"
+            key = "<enter>"
+            command = "next-page"
             "#,
         )
         .expect("config file should be written");
@@ -703,6 +776,7 @@ mod tests {
         assert_eq!(
             options.keymap.bindings,
             vec![KeymapBinding::Exact {
+                when: KeymapWhen::Normal,
                 keys: vec![ShortcutKey::key(KeyCode::Enter)],
                 command: Command::NextPage,
             }]
@@ -730,8 +804,6 @@ mod tests {
         assert_eq!(options.render.max_render_scale, None);
         assert_eq!(options.view.initial_page, None);
         assert_eq!(options.input.sequence_timeout_ms, None);
-        assert_eq!(options.keymap.preset, None);
-        assert!(options.keymap.unbind.is_empty());
         assert!(options.keymap.bindings.is_empty());
         assert_eq!(options.watch.enabled, None);
 

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -65,6 +65,7 @@ struct RawConfig {
     cache: Option<RawCacheConfig>,
     view: Option<RawViewConfig>,
     input: Option<RawInputConfig>,
+    keymap_preset: Option<String>,
     keymap: Option<Vec<RawKeymapConfig>>,
     watch: Option<RawWatchConfig>,
 }
@@ -140,11 +141,19 @@ impl RawConfig {
                 .transpose()?
                 .unwrap_or_default(),
             input: self.input.map(InputOptions::from).unwrap_or_default(),
-            keymap: self
-                .keymap
-                .map(KeymapOptions::try_from)
-                .transpose()?
-                .unwrap_or_default(),
+            keymap: KeymapOptions {
+                preset: self
+                    .keymap_preset
+                    .as_deref()
+                    .map(super::keymap::parse_keymap_preset)
+                    .transpose()?,
+                bindings: self
+                    .keymap
+                    .map(KeymapOptions::try_from)
+                    .transpose()?
+                    .unwrap_or_default()
+                    .bindings,
+            },
             watch: self.watch.map(WatchOptions::from).unwrap_or_default(),
         })
     }
@@ -230,7 +239,10 @@ impl TryFrom<Vec<RawKeymapConfig>> for KeymapOptions {
             })
             .collect::<AppResult<Vec<_>>>()?;
 
-        Ok(Self { bindings })
+        Ok(Self {
+            preset: None,
+            bindings,
+        })
     }
 }
 
@@ -367,7 +379,7 @@ mod tests {
 
     use crate::app::{PageLayoutMode, SpreadCoverPolicy, SpreadDirection};
     use crate::command::Command;
-    use crate::config::{AppOptionsResolver, KeymapBinding, KeymapWhen};
+    use crate::config::{AppOptionsResolver, KeymapBinding, KeymapPreset, KeymapWhen};
     use crate::extension::ExtensionUiSnapshot;
     use crate::input::sequence::{
         DEFAULT_SEQUENCE_TIMEOUT, KeyBindingContext, SequenceResolution, SequenceResolver,
@@ -554,6 +566,47 @@ mod tests {
     }
 
     #[test]
+    fn keymap_preset_none_starts_from_empty_keymap() {
+        let path = unique_temp_path("keymap-preset-none.toml");
+        fs::write(
+            &path,
+            r#"
+            keymap_preset = "none"
+
+            [[keymap]]
+            when = "normal"
+            key = "x"
+            command = "next-page"
+            "#,
+        )
+        .expect("config file should be written");
+
+        let options = load_options_from_explicit_path(&path).expect("config should parse");
+        assert_eq!(options.keymap.preset, Some(KeymapPreset::None));
+
+        let resolved = AppOptionsResolver::new().apply_options(options).resolve();
+        let mut resolver =
+            SequenceResolver::new(resolved.input.sequence_registry, DEFAULT_SEQUENCE_TIMEOUT);
+
+        assert_eq!(
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)
+            ),
+            SequenceResolution::Noop
+        );
+        assert_eq!(
+            handle_normal_key(
+                &mut resolver,
+                KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)
+            ),
+            SequenceResolution::Dispatch(Command::NextPage)
+        );
+
+        fs::remove_file(&path).expect("config file should be removed");
+    }
+
+    #[test]
     fn keymap_config_allows_literal_less_than_binding() {
         let path = unique_temp_path("keymap-less-than.toml");
         fs::write(
@@ -600,6 +653,26 @@ mod tests {
         let err = load_options_from_explicit_path(&path).expect_err("config should be rejected");
         assert!(
             err.to_string().contains("unknown keymap condition"),
+            "unexpected error: {err}"
+        );
+
+        fs::remove_file(&path).expect("config file should be removed");
+    }
+
+    #[test]
+    fn keymap_config_rejects_unknown_preset() {
+        let path = unique_temp_path("bad-keymap-preset.toml");
+        fs::write(
+            &path,
+            r#"
+            keymap_preset = "bob"
+            "#,
+        )
+        .expect("config file should be written");
+
+        let err = load_options_from_explicit_path(&path).expect_err("config should be rejected");
+        assert!(
+            err.to_string().contains("unknown keymap preset"),
             "unexpected error: {err}"
         );
 

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -66,7 +66,7 @@ struct RawConfig {
     view: Option<RawViewConfig>,
     input: Option<RawInputConfig>,
     keymap_preset: Option<String>,
-    keymap: Option<Vec<RawKeymapConfig>>,
+    keymap: Option<Vec<RawKeymapEntry>>,
     watch: Option<RawWatchConfig>,
 }
 
@@ -109,7 +109,7 @@ struct RawInputConfig {
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-struct RawKeymapConfig {
+struct RawKeymapEntry {
     when: String,
     key: String,
     command: RawKeymapCommand,
@@ -141,19 +141,7 @@ impl RawConfig {
                 .transpose()?
                 .unwrap_or_default(),
             input: self.input.map(InputOptions::from).unwrap_or_default(),
-            keymap: KeymapOptions {
-                preset: self
-                    .keymap_preset
-                    .as_deref()
-                    .map(super::keymap::parse_keymap_preset)
-                    .transpose()?,
-                bindings: self
-                    .keymap
-                    .map(KeymapOptions::try_from)
-                    .transpose()?
-                    .unwrap_or_default()
-                    .bindings,
-            },
+            keymap: parse_keymap_options(self.keymap_preset.as_deref(), self.keymap)?,
             watch: self.watch.map(WatchOptions::from).unwrap_or_default(),
         })
     }
@@ -219,31 +207,31 @@ impl From<RawInputConfig> for InputOptions {
     }
 }
 
-impl TryFrom<Vec<RawKeymapConfig>> for KeymapOptions {
-    type Error = AppError;
-
-    fn try_from(raw: Vec<RawKeymapConfig>) -> Result<Self, Self::Error> {
-        let bindings = raw
+fn parse_keymap_options(
+    preset: Option<&str>,
+    entries: Option<Vec<RawKeymapEntry>>,
+) -> AppResult<KeymapOptions> {
+    Ok(KeymapOptions {
+        preset: preset.map(super::keymap::parse_keymap_preset).transpose()?,
+        bindings: entries
+            .unwrap_or_default()
             .iter()
-            .map(|entry| {
-                let command = match &entry.command {
-                    RawKeymapCommand::Command(command) => Some(command.as_str()),
-                    RawKeymapCommand::Unbind(false) => None,
-                    RawKeymapCommand::Unbind(true) => {
-                        return Err(AppError::invalid_argument(
-                            "keymap command must be a command string or false",
-                        ));
-                    }
-                };
-                super::keymap::parse_keymap_binding(&entry.when, &entry.key, command)
-            })
-            .collect::<AppResult<Vec<_>>>()?;
+            .map(parse_keymap_entry)
+            .collect::<AppResult<Vec<_>>>()?,
+    })
+}
 
-        Ok(Self {
-            preset: None,
-            bindings,
-        })
-    }
+fn parse_keymap_entry(entry: &RawKeymapEntry) -> AppResult<super::keymap::KeymapBinding> {
+    let command = match &entry.command {
+        RawKeymapCommand::Command(command) => Some(command.as_str()),
+        RawKeymapCommand::Unbind(false) => None,
+        RawKeymapCommand::Unbind(true) => {
+            return Err(AppError::invalid_argument(
+                "keymap command must be a command string or false",
+            ));
+        }
+    };
+    super::keymap::parse_keymap_binding(&entry.when, &entry.key, command)
 }
 
 impl From<RawWatchConfig> for WatchOptions {

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -1,104 +1,194 @@
+use crate::app::Mode;
 use crate::command::{
-    Command, parse_command_text, validate_command_for_normal_keymap,
-    validate_command_id_for_normal_keymap,
+    Command, CommandInvocationPolicy, CommandTargetRequirement, find_command_spec, first_token,
+    parse_command_text,
 };
-use crate::condition::ConditionExpr;
+use crate::condition::{ConditionExpr, RuntimeCondition};
 use crate::error::{AppError, AppResult};
-use crate::input::keymap::{
-    WHEN_NORMAL, build_default_sequence_registry, build_none_sequence_registry,
-};
+use crate::input::keymap::build_default_sequence_registry;
 use crate::input::sequence::{SequenceRegistrationError, SequenceRegistry};
 use crate::input::shortcut::{ShortcutKey, parse_shortcut_sequence};
+use crate::palette::PaletteKind;
+
+const WHEN_NORMAL: [RuntimeCondition; 1] = [RuntimeCondition::ModeIs(Mode::Normal)];
+const WHEN_NORMAL_SEARCH_ACTIVE: [RuntimeCondition; 2] = [
+    RuntimeCondition::ModeIs(Mode::Normal),
+    RuntimeCondition::SearchIsActive,
+];
+const WHEN_NORMAL_SEARCH_INACTIVE: [RuntimeCondition; 2] = [
+    RuntimeCondition::ModeIs(Mode::Normal),
+    RuntimeCondition::SearchIsInactive,
+];
+const WHEN_HELP: [RuntimeCondition; 1] = [RuntimeCondition::ModeIs(Mode::Help)];
+const WHEN_PALETTE: [RuntimeCondition; 1] = [RuntimeCondition::ModeIs(Mode::Palette)];
+const WHEN_PALETTE_COMMAND: [RuntimeCondition; 2] = [
+    RuntimeCondition::ModeIs(Mode::Palette),
+    RuntimeCondition::PaletteKindIs(PaletteKind::Command),
+];
+const WHEN_PALETTE_SEARCH: [RuntimeCondition; 2] = [
+    RuntimeCondition::ModeIs(Mode::Palette),
+    RuntimeCondition::PaletteKindIs(PaletteKind::Search),
+];
+const WHEN_PALETTE_SEARCH_RESULTS: [RuntimeCondition; 2] = [
+    RuntimeCondition::ModeIs(Mode::Palette),
+    RuntimeCondition::PaletteKindIs(PaletteKind::SearchResults),
+];
+const WHEN_PALETTE_HISTORY: [RuntimeCondition; 2] = [
+    RuntimeCondition::ModeIs(Mode::Palette),
+    RuntimeCondition::PaletteKindIs(PaletteKind::History),
+];
+const WHEN_PALETTE_OUTLINE: [RuntimeCondition; 2] = [
+    RuntimeCondition::ModeIs(Mode::Palette),
+    RuntimeCondition::PaletteKindIs(PaletteKind::Outline),
+];
+const WHEN_PALETTE_WITH_INPUT_HISTORY: [RuntimeCondition; 2] = [
+    RuntimeCondition::ModeIs(Mode::Palette),
+    RuntimeCondition::PaletteInputHistoryIsAvailable,
+];
+const WHEN_PALETTE_NO_INPUT_HISTORY: [RuntimeCondition; 2] = [
+    RuntimeCondition::ModeIs(Mode::Palette),
+    RuntimeCondition::PaletteInputHistoryIsUnavailable,
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum KeymapPreset {
-    Default,
-    None,
+pub enum KeymapWhen {
+    Normal,
+    NormalSearchActive,
+    NormalSearchInactive,
+    Help,
+    Palette,
+    PaletteCommand,
+    PaletteSearch,
+    PaletteSearchResults,
+    PaletteHistory,
+    PaletteOutline,
+    PaletteWithInputHistory,
+    PaletteNoInputHistory,
 }
 
-impl KeymapPreset {
-    pub(crate) fn parse(value: &str) -> Option<Self> {
+impl KeymapWhen {
+    fn parse(value: &str) -> Option<Self> {
         match value {
-            "default" => Some(Self::Default),
-            "none" => Some(Self::None),
+            "normal" => Some(Self::Normal),
+            "normal.search-active" => Some(Self::NormalSearchActive),
+            "normal.search-inactive" => Some(Self::NormalSearchInactive),
+            "help" => Some(Self::Help),
+            "palette" => Some(Self::Palette),
+            "palette.command" => Some(Self::PaletteCommand),
+            "palette.search" => Some(Self::PaletteSearch),
+            "palette.search-results" => Some(Self::PaletteSearchResults),
+            "palette.history" => Some(Self::PaletteHistory),
+            "palette.outline" => Some(Self::PaletteOutline),
+            "palette.with-input-history" => Some(Self::PaletteWithInputHistory),
+            "palette.no-input-history" => Some(Self::PaletteNoInputHistory),
             _ => None,
         }
     }
-}
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum KeymapTarget {
-    Exact(Vec<ShortcutKey>),
-    NumericPrefix(ShortcutKey),
+    pub(crate) fn condition(self) -> ConditionExpr {
+        match self {
+            Self::Normal => ConditionExpr::All(&WHEN_NORMAL),
+            Self::NormalSearchActive => ConditionExpr::All(&WHEN_NORMAL_SEARCH_ACTIVE),
+            Self::NormalSearchInactive => ConditionExpr::All(&WHEN_NORMAL_SEARCH_INACTIVE),
+            Self::Help => ConditionExpr::All(&WHEN_HELP),
+            Self::Palette => ConditionExpr::All(&WHEN_PALETTE),
+            Self::PaletteCommand => ConditionExpr::All(&WHEN_PALETTE_COMMAND),
+            Self::PaletteSearch => ConditionExpr::All(&WHEN_PALETTE_SEARCH),
+            Self::PaletteSearchResults => ConditionExpr::All(&WHEN_PALETTE_SEARCH_RESULTS),
+            Self::PaletteHistory => ConditionExpr::All(&WHEN_PALETTE_HISTORY),
+            Self::PaletteOutline => ConditionExpr::All(&WHEN_PALETTE_OUTLINE),
+            Self::PaletteWithInputHistory => ConditionExpr::All(&WHEN_PALETTE_WITH_INPUT_HISTORY),
+            Self::PaletteNoInputHistory => ConditionExpr::All(&WHEN_PALETTE_NO_INPUT_HISTORY),
+        }
+    }
+
+    pub(crate) fn includes_palette(self) -> bool {
+        matches!(
+            self,
+            Self::Palette
+                | Self::PaletteCommand
+                | Self::PaletteSearch
+                | Self::PaletteSearchResults
+                | Self::PaletteHistory
+                | Self::PaletteOutline
+                | Self::PaletteWithInputHistory
+                | Self::PaletteNoInputHistory
+        )
+    }
+
+    pub(crate) fn includes_help(self) -> bool {
+        self == Self::Help
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum KeymapBinding {
     Exact {
+        when: KeymapWhen,
         keys: Vec<ShortcutKey>,
         command: Command,
     },
     NumericPrefix {
+        when: KeymapWhen,
         suffix: ShortcutKey,
         command_id: &'static str,
+    },
+    UnbindExact {
+        when: KeymapWhen,
+        keys: Vec<ShortcutKey>,
+    },
+    UnbindNumericPrefix {
+        when: KeymapWhen,
+        suffix: ShortcutKey,
     },
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct KeymapOptions {
-    pub preset: Option<KeymapPreset>,
-    pub unbind: Vec<KeymapTarget>,
     pub bindings: Vec<KeymapBinding>,
 }
 
 impl KeymapOptions {
     pub(crate) fn merge(mut self, next: Self) -> Self {
-        self.preset = next.preset.or(self.preset);
-        self.unbind.extend(next.unbind);
         self.bindings.extend(next.bindings);
         self
     }
 }
 
 pub(crate) fn resolve_sequence_registry(options: &KeymapOptions) -> SequenceRegistry {
-    let mut registry = match options.preset.unwrap_or(KeymapPreset::Default) {
-        KeymapPreset::Default => build_default_sequence_registry(),
-        KeymapPreset::None => build_none_sequence_registry(),
-    };
-
-    for target in &options.unbind {
-        match target {
-            KeymapTarget::Exact(keys) => {
-                registry
-                    .unregister_exact(ConditionExpr::All(&WHEN_NORMAL), keys)
-                    .expect("validated exact keymap target should unregister");
-            }
-            KeymapTarget::NumericPrefix(suffix) => {
-                registry
-                    .unregister_numeric_prefix(ConditionExpr::All(&WHEN_NORMAL), *suffix)
-                    .expect("validated numeric keymap target should unregister");
-            }
-        }
-    }
+    let mut registry = build_default_sequence_registry();
 
     for binding in &options.bindings {
         match binding {
-            KeymapBinding::Exact { keys, command } => {
+            KeymapBinding::Exact {
+                when,
+                keys,
+                command,
+            } => {
                 registry
-                    .register_exact(ConditionExpr::All(&WHEN_NORMAL), keys, command.clone())
+                    .register_exact(when.condition(), keys, command.clone())
                     .expect("validated exact keymap binding should register");
             }
-            KeymapBinding::NumericPrefix { suffix, command_id } => {
+            KeymapBinding::NumericPrefix {
+                when,
+                suffix,
+                command_id,
+            } => {
                 let factory = numeric_prefix_factory(command_id)
                     .expect("validated numeric prefix command should have a factory");
                 registry
-                    .register_numeric_prefix(
-                        ConditionExpr::All(&WHEN_NORMAL),
-                        command_id,
-                        *suffix,
-                        factory,
-                    )
+                    .register_numeric_prefix(when.condition(), command_id, *suffix, factory)
                     .expect("validated numeric keymap binding should register");
+            }
+            KeymapBinding::UnbindExact { when, keys } => {
+                registry
+                    .unregister_exact(when.condition(), keys)
+                    .expect("validated exact keymap binding should unregister");
+            }
+            KeymapBinding::UnbindNumericPrefix { when, suffix } => {
+                registry
+                    .unregister_numeric_prefix(when.condition(), *suffix)
+                    .expect("validated numeric keymap binding should unregister");
             }
         }
     }
@@ -106,44 +196,49 @@ pub(crate) fn resolve_sequence_registry(options: &KeymapOptions) -> SequenceRegi
     registry
 }
 
-pub(crate) fn parse_keymap_preset(value: &str) -> AppResult<KeymapPreset> {
-    KeymapPreset::parse(value).ok_or(AppError::invalid_argument("unknown keymap preset"))
+pub(crate) fn parse_keymap_when(value: &str) -> AppResult<KeymapWhen> {
+    KeymapWhen::parse(value).ok_or(AppError::invalid_argument("unknown keymap condition"))
 }
 
-pub(crate) fn parse_keymap_target(value: &str) -> AppResult<KeymapTarget> {
-    if let Some(suffix_text) = value.strip_prefix("[count]") {
+pub(crate) fn parse_keymap_binding(
+    when_text: &str,
+    key_text: &str,
+    command_text: Option<&str>,
+) -> AppResult<KeymapBinding> {
+    let when = parse_keymap_when(when_text)?;
+
+    if let Some(suffix_text) = key_text.strip_prefix("[count]") {
         let suffix = parse_numeric_suffix(suffix_text)?;
-        validate_configurable_key(&[suffix])?;
         validate_numeric_suffix(suffix)?;
-        return Ok(KeymapTarget::NumericPrefix(suffix));
+        let Some(command_text) = command_text else {
+            return Ok(KeymapBinding::UnbindNumericPrefix { when, suffix });
+        };
+        let command_id = parse_numeric_prefix_command(command_text)?;
+        validate_command_for_keymap_condition(command_id, when)?;
+        return Ok(KeymapBinding::NumericPrefix {
+            when,
+            suffix,
+            command_id,
+        });
     }
 
-    let keys = parse_exact_keys(value)?;
-    Ok(KeymapTarget::Exact(keys))
-}
-
-pub(crate) fn parse_keymap_binding(key: &str, command_text: &str) -> AppResult<KeymapBinding> {
-    match parse_keymap_target(key)? {
-        KeymapTarget::Exact(keys) => {
-            let command = parse_command_text(command_text)?;
-            validate_command_for_normal_keymap(&command)?;
-            validate_exact_keys(&keys)?;
-            Ok(KeymapBinding::Exact { keys, command })
-        }
-        KeymapTarget::NumericPrefix(suffix) => {
-            let command_id = parse_numeric_prefix_command(command_text)?;
-            validate_command_id_for_normal_keymap(command_id)?;
-            validate_numeric_suffix(suffix)?;
-            Ok(KeymapBinding::NumericPrefix { suffix, command_id })
-        }
-    }
+    let keys = parse_exact_keys(key_text)?;
+    let Some(command_text) = command_text else {
+        return Ok(KeymapBinding::UnbindExact { when, keys });
+    };
+    let command = parse_command_text(command_text)?;
+    validate_command_for_keymap_condition(first_token(command_text), when)?;
+    Ok(KeymapBinding::Exact {
+        when,
+        keys,
+        command,
+    })
 }
 
 fn parse_exact_keys(value: &str) -> AppResult<Vec<ShortcutKey>> {
     let keys = parse_shortcut_sequence(value).map_err(|err| {
         AppError::invalid_argument(format!("invalid key sequence {value:?}: {err}"))
     })?;
-    validate_configurable_key(&keys)?;
     validate_exact_keys(&keys)?;
     Ok(keys)
 }
@@ -175,16 +270,33 @@ fn parse_numeric_prefix_command(command_text: &str) -> AppResult<&'static str> {
     Ok("goto-page")
 }
 
-fn validate_configurable_key(keys: &[ShortcutKey]) -> AppResult<()> {
-    if keys
-        .iter()
-        .any(|key| matches!(key.code(), crossterm::event::KeyCode::Esc))
-    {
-        return Err(AppError::invalid_argument(
-            "keymap bindings cannot use <esc>",
-        ));
+fn validate_command_for_keymap_condition(id: &str, when: KeymapWhen) -> AppResult<()> {
+    let Some(spec) = find_command_spec(id) else {
+        return Err(AppError::invalid_argument("unknown command id"));
+    };
+    if !matches!(
+        spec.invocation,
+        CommandInvocationPolicy::User | CommandInvocationPolicy::BindingOnly
+    ) {
+        return Err(AppError::invalid_argument(format!(
+            "{} is an internal command and cannot be invoked directly",
+            spec.id
+        )));
     }
-    Ok(())
+
+    match spec.target {
+        CommandTargetRequirement::App => Ok(()),
+        CommandTargetRequirement::ActivePalette if when.includes_palette() => Ok(()),
+        CommandTargetRequirement::ActiveHelp if when.includes_help() => Ok(()),
+        CommandTargetRequirement::ActivePalette => Err(AppError::invalid_argument(format!(
+            "{} requires an active palette",
+            spec.id
+        ))),
+        CommandTargetRequirement::ActiveHelp => Err(AppError::invalid_argument(format!(
+            "{} requires active help",
+            spec.id
+        ))),
+    }
 }
 
 fn validate_exact_keys(keys: &[ShortcutKey]) -> AppResult<()> {
@@ -236,26 +348,34 @@ mod tests {
     use crate::input::sequence::{
         DEFAULT_SEQUENCE_TIMEOUT, KeyBindingContext, SequenceResolution, SequenceResolver,
     };
+    use crate::input::shortcut::ShortcutKey;
     use crate::palette::PaletteKind;
 
-    use super::{KeymapOptions, KeymapPreset, resolve_sequence_registry};
+    use super::{KeymapBinding, KeymapOptions, KeymapWhen, resolve_sequence_registry};
 
     #[test]
-    fn none_preset_keeps_base_ui_bindings_and_omits_normal_defaults() {
+    fn configured_bindings_resolve_against_their_when_condition() {
         let registry = resolve_sequence_registry(&KeymapOptions {
-            preset: Some(KeymapPreset::None),
-            ..KeymapOptions::default()
+            bindings: vec![
+                KeymapBinding::UnbindExact {
+                    when: KeymapWhen::Normal,
+                    keys: vec![ShortcutKey::char('j')],
+                },
+                KeymapBinding::Exact {
+                    when: KeymapWhen::Normal,
+                    keys: vec![ShortcutKey::char('x')],
+                    command: Command::NextPage,
+                },
+                KeymapBinding::Exact {
+                    when: KeymapWhen::Help,
+                    keys: vec![ShortcutKey::char('x')],
+                    command: Command::HelpScrollDown,
+                },
+            ],
         });
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
-        let extensions = ExtensionUiSnapshot::with_search_active(true);
+        let extensions = ExtensionUiSnapshot::default();
 
-        assert_eq!(
-            resolver.handle_key_in_context(
-                KeyBindingContext::normal(&extensions),
-                KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
-            ),
-            SequenceResolution::Dispatch(Command::CancelSearch)
-        );
         assert_eq!(
             resolver.handle_key_in_context(
                 KeyBindingContext::normal(&extensions),
@@ -266,10 +386,39 @@ mod tests {
         assert_eq!(
             resolver.handle_key_in_context(
                 KeyBindingContext::normal(&extensions),
-                KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+                KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
             ),
-            SequenceResolution::Noop
+            SequenceResolution::Dispatch(Command::NextPage)
         );
+        assert_eq!(
+            resolver.handle_key_in_context(
+                KeyBindingContext {
+                    runtime: RuntimeConditionContext::new(Mode::Help, None, &extensions),
+                },
+                KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+            ),
+            SequenceResolution::Dispatch(Command::HelpScrollDown)
+        );
+    }
+
+    #[test]
+    fn palette_input_history_conditions_select_distinct_bindings() {
+        let registry = resolve_sequence_registry(&KeymapOptions {
+            bindings: vec![
+                KeymapBinding::Exact {
+                    when: KeymapWhen::PaletteWithInputHistory,
+                    keys: vec![ShortcutKey::key(KeyCode::Up)],
+                    command: Command::PaletteInputHistoryOlder,
+                },
+                KeymapBinding::Exact {
+                    when: KeymapWhen::PaletteNoInputHistory,
+                    keys: vec![ShortcutKey::key(KeyCode::Up)],
+                    command: Command::PaletteSelectPrev,
+                },
+            ],
+        });
+        let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
+        let extensions = ExtensionUiSnapshot::default();
 
         assert_eq!(
             resolver.handle_key_in_context(
@@ -280,39 +429,22 @@ mod tests {
                         &extensions,
                     ),
                 },
-                KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+                KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
             ),
-            SequenceResolution::Dispatch(Command::PaletteSubmit)
+            SequenceResolution::Dispatch(Command::PaletteInputHistoryOlder)
         );
         assert_eq!(
             resolver.handle_key_in_context(
                 KeyBindingContext {
-                    runtime: RuntimeConditionContext::new(Mode::Help, None, &extensions),
+                    runtime: RuntimeConditionContext::new(
+                        Mode::Palette,
+                        Some(PaletteKind::Outline),
+                        &extensions,
+                    ),
                 },
-                KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+                KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
             ),
-            SequenceResolution::Dispatch(Command::CloseHelp)
-        );
-    }
-
-    #[test]
-    fn none_preset_accepts_explicit_bindings() {
-        let registry = resolve_sequence_registry(&KeymapOptions {
-            preset: Some(KeymapPreset::None),
-            bindings: vec![super::KeymapBinding::Exact {
-                keys: vec![crate::input::shortcut::ShortcutKey::char('j')],
-                command: Command::NextPage,
-            }],
-            ..KeymapOptions::default()
-        });
-        let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
-
-        assert_eq!(
-            resolver.handle_key_in_context(
-                KeyBindingContext::normal(&ExtensionUiSnapshot::default()),
-                KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
-            ),
-            SequenceResolution::Dispatch(Command::NextPage)
+            SequenceResolution::Dispatch(Command::PaletteSelectPrev)
         );
     }
 }

--- a/src/config/keymap/mod.rs
+++ b/src/config/keymap/mod.rs
@@ -462,4 +462,38 @@ mod tests {
             SequenceResolution::Dispatch(Command::PaletteSelectPrev)
         );
     }
+
+    #[test]
+    fn unbind_ignores_missing_bindings() {
+        let registry = resolve_sequence_registry(&KeymapOptions {
+            preset: Some(super::KeymapPreset::None),
+            bindings: vec![
+                KeymapBinding::UnbindExact {
+                    when: KeymapWhen::Normal,
+                    keys: vec![ShortcutKey::char('x')],
+                },
+                KeymapBinding::UnbindNumericPrefix {
+                    when: KeymapWhen::Normal,
+                    suffix: ShortcutKey::char('g'),
+                },
+            ],
+        });
+        let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
+        let extensions = ExtensionUiSnapshot::default();
+
+        assert_eq!(
+            resolver.handle_key_in_context(
+                KeyBindingContext::normal(&extensions),
+                KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+            ),
+            SequenceResolution::Noop
+        );
+        assert_eq!(
+            resolver.handle_key_in_context(
+                KeyBindingContext::normal(&extensions),
+                KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+            ),
+            SequenceResolution::Noop
+        );
+    }
 }

--- a/src/config/keymap/mod.rs
+++ b/src/config/keymap/mod.rs
@@ -11,7 +11,8 @@ use crate::palette::PaletteKind;
 
 mod presets;
 
-pub(crate) use presets::{KeymapPreset, build_default_sequence_registry};
+pub use presets::KeymapPreset;
+pub(crate) use presets::build_default_sequence_registry;
 
 const WHEN_NORMAL: [RuntimeCondition; 1] = [RuntimeCondition::ModeIs(Mode::Normal)];
 const WHEN_NORMAL_SEARCH_ACTIVE: [RuntimeCondition; 2] = [
@@ -148,18 +149,23 @@ pub enum KeymapBinding {
 
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct KeymapOptions {
+    pub preset: Option<KeymapPreset>,
     pub bindings: Vec<KeymapBinding>,
 }
 
 impl KeymapOptions {
     pub(crate) fn merge(mut self, next: Self) -> Self {
+        self.preset = next.preset.or(self.preset);
         self.bindings.extend(next.bindings);
         self
     }
 }
 
 pub(crate) fn resolve_sequence_registry(options: &KeymapOptions) -> SequenceRegistry {
-    let mut registry = KeymapPreset::Default.build_sequence_registry();
+    let mut registry = options
+        .preset
+        .unwrap_or(KeymapPreset::Default)
+        .build_sequence_registry();
 
     for binding in &options.bindings {
         match binding {
@@ -197,6 +203,10 @@ pub(crate) fn resolve_sequence_registry(options: &KeymapOptions) -> SequenceRegi
     }
 
     registry
+}
+
+pub(crate) fn parse_keymap_preset(value: &str) -> AppResult<KeymapPreset> {
+    KeymapPreset::parse(value).ok_or(AppError::invalid_argument("unknown keymap preset"))
 }
 
 pub(crate) fn parse_keymap_when(value: &str) -> AppResult<KeymapWhen> {
@@ -359,6 +369,7 @@ mod tests {
     #[test]
     fn configured_bindings_resolve_against_their_when_condition() {
         let registry = resolve_sequence_registry(&KeymapOptions {
+            preset: None,
             bindings: vec![
                 KeymapBinding::UnbindExact {
                     when: KeymapWhen::Normal,
@@ -407,6 +418,7 @@ mod tests {
     #[test]
     fn palette_input_history_conditions_select_distinct_bindings() {
         let registry = resolve_sequence_registry(&KeymapOptions {
+            preset: None,
             bindings: vec![
                 KeymapBinding::Exact {
                     when: KeymapWhen::PaletteWithInputHistory,

--- a/src/config/keymap/mod.rs
+++ b/src/config/keymap/mod.rs
@@ -5,10 +5,13 @@ use crate::command::{
 };
 use crate::condition::{ConditionExpr, RuntimeCondition};
 use crate::error::{AppError, AppResult};
-use crate::input::keymap::build_default_sequence_registry;
 use crate::input::sequence::{SequenceRegistrationError, SequenceRegistry};
 use crate::input::shortcut::{ShortcutKey, parse_shortcut_sequence};
 use crate::palette::PaletteKind;
+
+mod presets;
+
+pub(crate) use presets::{KeymapPreset, build_default_sequence_registry};
 
 const WHEN_NORMAL: [RuntimeCondition; 1] = [RuntimeCondition::ModeIs(Mode::Normal)];
 const WHEN_NORMAL_SEARCH_ACTIVE: [RuntimeCondition; 2] = [
@@ -156,7 +159,7 @@ impl KeymapOptions {
 }
 
 pub(crate) fn resolve_sequence_registry(options: &KeymapOptions) -> SequenceRegistry {
-    let mut registry = build_default_sequence_registry();
+    let mut registry = KeymapPreset::Default.build_sequence_registry();
 
     for binding in &options.bindings {
         match binding {

--- a/src/config/keymap/presets.rs
+++ b/src/config/keymap/presets.rs
@@ -1,26 +1,11 @@
 use crate::command::{Command, PanAmount, PanDirection};
-use crate::condition::{ConditionExpr, RuntimeCondition};
+use crate::condition::ConditionExpr;
 use crate::palette::PaletteKind;
 
 use crate::input::sequence::{GeneratedCommand, GeneratedKeyMatcher, SequenceRegistry};
 use crate::input::shortcut::ShortcutKey;
 
-pub(crate) const WHEN_NORMAL: [RuntimeCondition; 1] =
-    [RuntimeCondition::ModeIs(crate::app::Mode::Normal)];
-const WHEN_NORMAL_SEARCH_ACTIVE: [RuntimeCondition; 2] = [
-    RuntimeCondition::ModeIs(crate::app::Mode::Normal),
-    RuntimeCondition::SearchIsActive,
-];
-const WHEN_PALETTE: [RuntimeCondition; 1] = [RuntimeCondition::ModeIs(crate::app::Mode::Palette)];
-const WHEN_PALETTE_INPUT_HISTORY_AVAILABLE: [RuntimeCondition; 2] = [
-    RuntimeCondition::ModeIs(crate::app::Mode::Palette),
-    RuntimeCondition::PaletteInputHistoryIsAvailable,
-];
-const WHEN_PALETTE_INPUT_HISTORY_UNAVAILABLE: [RuntimeCondition; 2] = [
-    RuntimeCondition::ModeIs(crate::app::Mode::Palette),
-    RuntimeCondition::PaletteInputHistoryIsUnavailable,
-];
-const WHEN_HELP: [RuntimeCondition; 1] = [RuntimeCondition::ModeIs(crate::app::Mode::Help)];
+use super::KeymapWhen;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeymapPreset {
@@ -69,7 +54,7 @@ fn build_base_sequence_registry() -> SequenceRegistry {
 }
 
 fn register_surface_open_bindings(registry: &mut SequenceRegistry) {
-    let when = ConditionExpr::All(&WHEN_NORMAL);
+    let when = KeymapWhen::Normal.condition();
     register_exact_binding(
         registry,
         when,
@@ -89,7 +74,7 @@ fn register_surface_open_bindings(registry: &mut SequenceRegistry) {
 }
 
 fn register_page_navigation_bindings(registry: &mut SequenceRegistry) {
-    let when = ConditionExpr::All(&WHEN_NORMAL);
+    let when = KeymapWhen::Normal.condition();
     register_exact_binding(registry, when, &[ShortcutKey::char('j')], Command::NextPage);
     register_exact_binding(registry, when, &[ShortcutKey::char('k')], Command::PrevPage);
     register_exact_binding(
@@ -109,7 +94,7 @@ fn register_page_navigation_bindings(registry: &mut SequenceRegistry) {
 }
 
 fn register_view_bindings(registry: &mut SequenceRegistry) {
-    let when = ConditionExpr::All(&WHEN_NORMAL);
+    let when = KeymapWhen::Normal.condition();
     register_exact_binding(
         registry,
         when,
@@ -157,7 +142,7 @@ fn register_view_bindings(registry: &mut SequenceRegistry) {
 }
 
 fn register_history_bindings(registry: &mut SequenceRegistry) {
-    let when = ConditionExpr::All(&WHEN_NORMAL);
+    let when = KeymapWhen::Normal.condition();
     register_exact_binding(
         registry,
         when,
@@ -173,7 +158,7 @@ fn register_history_bindings(registry: &mut SequenceRegistry) {
 }
 
 fn register_search_navigation_bindings(registry: &mut SequenceRegistry) {
-    let when = ConditionExpr::All(&WHEN_NORMAL);
+    let when = KeymapWhen::Normal.condition();
     register_exact_binding(
         registry,
         when,
@@ -191,7 +176,7 @@ fn register_search_navigation_bindings(registry: &mut SequenceRegistry) {
 fn register_quit_binding(registry: &mut SequenceRegistry) {
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_NORMAL),
+        KeymapWhen::Normal.condition(),
         &[ShortcutKey::char('q')],
         Command::Quit,
     );
@@ -202,7 +187,7 @@ fn register_search_cancellation_binding(registry: &mut SequenceRegistry) {
 
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_NORMAL_SEARCH_ACTIVE),
+        KeymapWhen::NormalSearchActive.condition(),
         &[ShortcutKey::key(KeyCode::Esc)],
         Command::CancelSearch,
     );
@@ -213,192 +198,192 @@ fn register_palette_bindings(registry: &mut SequenceRegistry) {
 
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::key(KeyCode::Esc)],
         Command::ClosePalette,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::key(KeyCode::Enter)],
         Command::PaletteSubmit,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::key(KeyCode::Tab)],
         Command::PaletteComplete,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::ctrl('p')],
         Command::PaletteSelectPrev,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::ctrl('n')],
         Command::PaletteSelectNext,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE_INPUT_HISTORY_AVAILABLE),
+        KeymapWhen::PaletteWithInputHistory.condition(),
         &[ShortcutKey::key(KeyCode::Up)],
         Command::PaletteInputHistoryOlder,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE_INPUT_HISTORY_AVAILABLE),
+        KeymapWhen::PaletteWithInputHistory.condition(),
         &[ShortcutKey::key(KeyCode::Down)],
         Command::PaletteInputHistoryNewer,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE_INPUT_HISTORY_UNAVAILABLE),
+        KeymapWhen::PaletteNoInputHistory.condition(),
         &[ShortcutKey::key(KeyCode::Up)],
         Command::PaletteSelectPrev,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE_INPUT_HISTORY_UNAVAILABLE),
+        KeymapWhen::PaletteNoInputHistory.condition(),
         &[ShortcutKey::key(KeyCode::Down)],
         Command::PaletteSelectNext,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::key(KeyCode::Backspace)],
         Command::TextDeleteBackward,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::ctrl('h')],
         Command::TextDeleteBackward,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::key(KeyCode::Delete)],
         Command::TextDeleteForward,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::new(KeyCode::Delete, KeyModifiers::CONTROL)],
         Command::TextDeleteNextWord,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::key(KeyCode::Left)],
         Command::TextMoveLeft,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::ctrl('b')],
         Command::TextMoveLeft,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::key(KeyCode::Right)],
         Command::TextMoveRight,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::ctrl('f')],
         Command::TextMoveRight,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::key(KeyCode::Home)],
         Command::TextMoveStart,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::ctrl('a')],
         Command::TextMoveStart,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::key(KeyCode::End)],
         Command::TextMoveEnd,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::ctrl('e')],
         Command::TextMoveEnd,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::new(KeyCode::Left, KeyModifiers::CONTROL)],
         Command::TextMovePrevWord,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::alt('b')],
         Command::TextMovePrevWord,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::new(KeyCode::Right, KeyModifiers::CONTROL)],
         Command::TextMoveNextWord,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::alt('f')],
         Command::TextMoveNextWord,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::ctrl('w')],
         Command::TextDeletePrevWord,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::alt('d')],
         Command::TextDeleteNextWord,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::new(KeyCode::Backspace, KeyModifiers::ALT)],
         Command::TextDeletePrevWord,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::ctrl('u')],
         Command::TextDeleteLine,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::ctrl('k')],
         Command::TextDeleteToEnd,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         &[ShortcutKey::ctrl('y')],
         Command::TextYank,
     );
     registry.register_generated(
-        ConditionExpr::All(&WHEN_PALETTE),
+        KeymapWhen::Palette.condition(),
         GeneratedKeyMatcher::PrintableCharacter,
         GeneratedCommand::TextInsert,
     );
@@ -409,31 +394,31 @@ fn register_help_bindings(registry: &mut SequenceRegistry) {
 
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_HELP),
+        KeymapWhen::Help.condition(),
         &[ShortcutKey::key(KeyCode::Esc)],
         Command::CloseHelp,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_HELP),
+        KeymapWhen::Help.condition(),
         &[ShortcutKey::char('j')],
         Command::HelpScrollDown,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_HELP),
+        KeymapWhen::Help.condition(),
         &[ShortcutKey::key(KeyCode::Down)],
         Command::HelpScrollDown,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_HELP),
+        KeymapWhen::Help.condition(),
         &[ShortcutKey::char('k')],
         Command::HelpScrollUp,
     );
     register_exact_binding(
         registry,
-        ConditionExpr::All(&WHEN_HELP),
+        KeymapWhen::Help.condition(),
         &[ShortcutKey::key(KeyCode::Up)],
         Command::HelpScrollUp,
     );

--- a/src/config/keymap/presets.rs
+++ b/src/config/keymap/presets.rs
@@ -2,8 +2,8 @@ use crate::command::{Command, PanAmount, PanDirection};
 use crate::condition::{ConditionExpr, RuntimeCondition};
 use crate::palette::PaletteKind;
 
-use super::sequence::{GeneratedCommand, GeneratedKeyMatcher, SequenceRegistry};
-use super::shortcut::ShortcutKey;
+use crate::input::sequence::{GeneratedCommand, GeneratedKeyMatcher, SequenceRegistry};
+use crate::input::shortcut::ShortcutKey;
 
 pub(crate) const WHEN_NORMAL: [RuntimeCondition; 1] =
     [RuntimeCondition::ModeIs(crate::app::Mode::Normal)];
@@ -22,7 +22,23 @@ const WHEN_PALETTE_INPUT_HISTORY_UNAVAILABLE: [RuntimeCondition; 2] = [
 ];
 const WHEN_HELP: [RuntimeCondition; 1] = [RuntimeCondition::ModeIs(crate::app::Mode::Help)];
 
-pub fn build_default_sequence_registry() -> SequenceRegistry {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum KeymapPreset {
+    Default,
+    #[allow(dead_code, reason = "reserved for config-owned empty keymap preset")]
+    None,
+}
+
+impl KeymapPreset {
+    pub(crate) fn build_sequence_registry(self) -> SequenceRegistry {
+        match self {
+            Self::Default => build_default_sequence_registry(),
+            Self::None => build_none_sequence_registry(),
+        }
+    }
+}
+
+pub(crate) fn build_default_sequence_registry() -> SequenceRegistry {
     let mut registry = build_base_sequence_registry();
     register_surface_open_bindings(&mut registry);
     register_page_navigation_bindings(&mut registry);
@@ -31,6 +47,10 @@ pub fn build_default_sequence_registry() -> SequenceRegistry {
     register_search_navigation_bindings(&mut registry);
     register_quit_binding(&mut registry);
     registry
+}
+
+pub(crate) fn build_none_sequence_registry() -> SequenceRegistry {
+    SequenceRegistry::new()
 }
 
 fn build_base_sequence_registry() -> SequenceRegistry {
@@ -446,12 +466,21 @@ mod tests {
     use crate::input::sequence::KeyBindingContext;
     use crate::palette::PaletteKind;
 
-    use super::build_default_sequence_registry;
+    use super::{KeymapPreset, build_default_sequence_registry};
     use crate::input::sequence::{DEFAULT_SEQUENCE_TIMEOUT, SequenceResolution, SequenceResolver};
 
     fn handle_normal_key(resolver: &mut SequenceResolver, key: KeyEvent) -> SequenceResolution {
         let extensions = ExtensionUiSnapshot::default();
         resolver.handle_key_in_context(KeyBindingContext::normal(&extensions), key)
+    }
+
+    #[test]
+    fn none_preset_builds_empty_registry() {
+        let snapshot = KeymapPreset::None.build_sequence_registry().snapshot();
+
+        assert!(snapshot.exact_bindings.is_empty());
+        assert!(snapshot.numeric_prefix_bindings.is_empty());
+        assert!(snapshot.generated_bindings.is_empty());
     }
 
     #[test]

--- a/src/config/keymap/presets.rs
+++ b/src/config/keymap/presets.rs
@@ -23,13 +23,20 @@ const WHEN_PALETTE_INPUT_HISTORY_UNAVAILABLE: [RuntimeCondition; 2] = [
 const WHEN_HELP: [RuntimeCondition; 1] = [RuntimeCondition::ModeIs(crate::app::Mode::Help)];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum KeymapPreset {
+pub enum KeymapPreset {
     Default,
-    #[allow(dead_code, reason = "reserved for config-owned empty keymap preset")]
     None,
 }
 
 impl KeymapPreset {
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        match value {
+            "default" => Some(Self::Default),
+            "none" => Some(Self::None),
+            _ => None,
+        }
+    }
+
     pub(crate) fn build_sequence_registry(self) -> SequenceRegistry {
         match self {
             Self::Default => build_default_sequence_registry(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,8 +9,8 @@ pub use file::{
     load_options_from_explicit_path,
 };
 pub use options::{
-    AppOptions, CacheOptions, InputOptions, KeymapBinding, KeymapOptions, KeymapPreset,
-    KeymapTarget, RenderOptions, ViewOptions, WatchOptions,
+    AppOptions, CacheOptions, InputOptions, KeymapBinding, KeymapOptions, KeymapWhen,
+    RenderOptions, ViewOptions, WatchOptions,
 };
 pub use policy::{
     AppOptionsResolver, CachePolicy, EventLoopPolicy, InputPolicy, RenderPolicy,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,7 +9,7 @@ pub use file::{
     load_options_from_explicit_path,
 };
 pub use options::{
-    AppOptions, CacheOptions, InputOptions, KeymapBinding, KeymapOptions, KeymapWhen,
+    AppOptions, CacheOptions, InputOptions, KeymapBinding, KeymapOptions, KeymapPreset, KeymapWhen,
     RenderOptions, ViewOptions, WatchOptions,
 };
 pub use policy::{

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,5 @@
 mod file;
-mod keymap;
+pub(crate) mod keymap;
 mod options;
 mod policy;
 mod types;

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -1,6 +1,6 @@
 use crate::app::{PageLayoutMode, SpreadCoverPolicy, SpreadDirection};
 
-pub use super::keymap::{KeymapBinding, KeymapOptions, KeymapWhen};
+pub use super::keymap::{KeymapBinding, KeymapOptions, KeymapPreset, KeymapWhen};
 use super::types::Config;
 
 #[derive(Debug, Clone, Default, PartialEq)]

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -1,6 +1,6 @@
 use crate::app::{PageLayoutMode, SpreadCoverPolicy, SpreadDirection};
 
-pub use super::keymap::{KeymapBinding, KeymapOptions, KeymapPreset, KeymapTarget};
+pub use super::keymap::{KeymapBinding, KeymapOptions, KeymapWhen};
 use super::types::Config;
 
 #[derive(Debug, Clone, Default, PartialEq)]

--- a/src/config/policy.rs
+++ b/src/config/policy.rs
@@ -2,9 +2,9 @@ use std::time::Duration;
 
 use crate::app::scale::{ZOOM_MAX, ZOOM_MIN};
 use crate::app::{PageLayoutMode, SpreadCoverPolicy, SpreadDirection};
-use crate::input::keymap::build_default_sequence_registry;
 use crate::input::sequence::{DEFAULT_SEQUENCE_TIMEOUT, SequenceRegistry};
 
+use super::keymap::build_default_sequence_registry;
 use super::options::AppOptions;
 use super::types::{CacheConfig, Config, InputConfig, RenderConfig, ViewConfig, WatchConfig};
 

--- a/src/input/keymap.rs
+++ b/src/input/keymap.rs
@@ -33,10 +33,6 @@ pub fn build_default_sequence_registry() -> SequenceRegistry {
     registry
 }
 
-pub(crate) fn build_none_sequence_registry() -> SequenceRegistry {
-    build_base_sequence_registry()
-}
-
 fn build_base_sequence_registry() -> SequenceRegistry {
     let mut registry = SequenceRegistry::new();
     register_search_cancellation_binding(&mut registry);

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,6 +1,5 @@
 pub mod events;
 pub mod history;
-pub mod keymap;
 pub mod sequence;
 pub mod shortcut;
 

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -273,7 +273,7 @@ mod tests {
     use super::{build_help_lines, help_rendered_height};
     use crate::command::{Command, PanAmount, PanDirection};
     use crate::condition::ConditionExpr;
-    use crate::input::keymap::build_default_sequence_registry;
+    use crate::config::keymap::build_default_sequence_registry;
     use crate::input::sequence::SequenceRegistry;
     use crate::input::shortcut::ShortcutKey;
 


### PR DESCRIPTION
Keymap configuration handling was refined so presets are treated as ordinary options and the parsing logic is simpler and easier to follow.

Problem: the previous setup split keymap behavior across multiple places and made the configuration flow harder to reason about.

Solution: consolidate the keymap configuration behavior, simplify option parsing, and update the documentation to match the new semantics.

Impact: the change is focused on configuration handling and documentation. It does not introduce a broad UI or runtime behavior change.

Verification: cargo fmt --check, cargo test, cargo clippy --all-targets --all-features -- -D warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Keymap configuration format updated: replaced `[keymap]` table structure with `keymap_preset` scalar and `[[keymap]]` array entries
  * `[[keymap]]` entries now require `when`, `key`, and `command` fields; use `command = false` to unbind

* **Documentation**
  * Updated README and guides to document new keymap configuration format and conditional "when" contexts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->