### PR TITLE
feat(keymap): prioritize scoped palette bindings

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -226,7 +226,8 @@ Contract:
   `normal.search-inactive`, `help`, `palette`, `palette.command`,
   `palette.search`, `palette.search-results`, `palette.history`,
   `palette.outline`, `palette.with-input-history`, and
-  `palette.no-input-history`.
+  `palette.no-input-history`, `palette.input-empty`, and
+  `palette.input-not-empty`.
 - Keymap `enabled_when` uses the same runtime condition vocabulary as
   command `enabled_when`; do not add a separate keymap-only condition enum.
 - Every key input and sequence timeout resolves against the current runtime

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -214,6 +214,14 @@ Contract:
   sequence; `command` names the command to dispatch, or `false` to unbind.
 - When multiple configured keymap entries use the same `when` selector and `key`
   sequence, the later entry replaces the earlier entry.
+- Key binding conditions are normalized before priority is calculated. Implied
+  conditions are added once, so adding a condition already implied by another
+  condition does not increase priority; for example, `palette.command` and
+  `palette` plus `palette.command` have the same normalized priority.
+- When multiple enabled key bindings match the same key sequence, the binding
+  with the highest normalized condition priority wins. If matching bindings
+  have the same priority, the later registered binding wins; preset bindings
+  are registered before configured bindings.
 - Supported `when` selectors are `normal`, `normal.search-active`,
   `normal.search-inactive`, `help`, `palette`, `palette.command`,
   `palette.search`, `palette.search-results`, `palette.history`,

--- a/src/app/input_ops.rs
+++ b/src/app/input_ops.rs
@@ -69,9 +69,15 @@ impl InteractionSubsystem {
         extensions: &'a ExtensionUiSnapshot,
     ) -> KeyBindingContext<'a> {
         let active_palette = self.palette.manager.active_kind();
+        let palette_input_empty = self.palette.manager.active_input_is_empty();
 
         KeyBindingContext {
-            runtime: RuntimeConditionContext::new(state.mode, active_palette, extensions),
+            runtime: RuntimeConditionContext::with_palette_input_empty(
+                state.mode,
+                active_palette,
+                palette_input_empty,
+                extensions,
+            ),
         }
     }
 

--- a/src/command/dispatch.rs
+++ b/src/command/dispatch.rs
@@ -79,9 +79,15 @@ pub fn dispatch_with_view_policy(
     let command_id = cmd.command_id();
     let extensions = extension_host.ui_snapshot();
     let active_palette = palette_manager.active_kind();
+    let palette_input_empty = palette_manager.active_input_is_empty();
     let ctx = CommandPolicyContext {
         source,
-        runtime: RuntimeConditionContext::new(app.mode, active_palette, &extensions),
+        runtime: RuntimeConditionContext::with_palette_input_empty(
+            app.mode,
+            active_palette,
+            palette_input_empty,
+            &extensions,
+        ),
     };
     if let Some(message) = rejection_message_for_command(&cmd, &ctx) {
         apply_notice(app, rejection_notice(&cmd, message));

--- a/src/command/spec.rs
+++ b/src/command/spec.rs
@@ -173,6 +173,12 @@ fn condition_unavailable_message(id: &str, condition: RuntimeCondition) -> Strin
         RuntimeCondition::PaletteInputHistoryIsUnavailable => {
             format!("{id} is unavailable while palette input history is available")
         }
+        RuntimeCondition::PaletteInputIsEmpty => {
+            format!("{id} is unavailable while palette input is not empty")
+        }
+        RuntimeCondition::PaletteInputIsNotEmpty => {
+            format!("{id} is unavailable while palette input is empty")
+        }
     }
 }
 

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -9,69 +9,33 @@ pub enum ConditionExpr {
     Any(&'static [RuntimeCondition]),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum BindingConditionKind {
-    Always,
-    All,
-    Any,
-}
-
 #[derive(Debug, Clone, Eq)]
 pub struct BindingCondition {
     original: ConditionExpr,
-    kind: BindingConditionKind,
     alternatives: Vec<Vec<RuntimeCondition>>,
 }
 
 impl PartialEq for BindingCondition {
     fn eq(&self, other: &Self) -> bool {
-        self.kind == other.kind && self.alternatives == other.alternatives
+        self.alternatives == other.alternatives
     }
 }
 
 impl BindingCondition {
     pub fn new(expr: ConditionExpr) -> Self {
-        match expr {
-            ConditionExpr::Always => Self {
-                original: expr,
-                kind: BindingConditionKind::Always,
-                alternatives: Vec::new(),
-            },
-            ConditionExpr::All(conditions) => {
-                let mut normalized = Vec::new();
-                for condition in conditions {
-                    add_condition(&mut normalized, *condition);
-                }
-                normalized.sort_by_key(|condition| condition_key(*condition));
-                Self {
-                    original: expr,
-                    kind: BindingConditionKind::All,
-                    alternatives: vec![normalized],
-                }
-            }
-            ConditionExpr::Any(conditions) => {
-                let mut alternatives = Vec::new();
-                for condition in conditions {
-                    let mut normalized = Vec::new();
-                    add_condition(&mut normalized, *condition);
-                    normalized.sort_by_key(|condition| condition_key(*condition));
-                    if !alternatives.contains(&normalized) {
-                        alternatives.push(normalized);
-                    }
-                }
-                alternatives.sort_by_key(|conditions| {
-                    conditions
-                        .iter()
-                        .copied()
-                        .map(condition_key)
-                        .collect::<Vec<_>>()
-                });
-                Self {
-                    original: expr,
-                    kind: BindingConditionKind::Any,
-                    alternatives,
-                }
-            }
+        let mut alternatives = match expr {
+            ConditionExpr::Always => vec![Vec::new()],
+            ConditionExpr::All(conditions) => vec![normalize_conditions(conditions)],
+            ConditionExpr::Any(conditions) => conditions
+                .iter()
+                .copied()
+                .map(|condition| normalize_conditions(&[condition]))
+                .collect(),
+        };
+        sort_and_dedup_alternatives(&mut alternatives);
+        Self {
+            original: expr,
+            alternatives,
         }
     }
 
@@ -80,51 +44,47 @@ impl BindingCondition {
     }
 
     pub fn priority_score(&self) -> u16 {
-        match self.kind {
-            BindingConditionKind::Always => 0,
-            BindingConditionKind::All => self
-                .alternatives
-                .first()
-                .map(|conditions| {
-                    conditions
-                        .iter()
-                        .copied()
-                        .map(condition_weight)
-                        .sum::<u16>()
-                })
-                .unwrap_or(0),
-            BindingConditionKind::Any => self
-                .alternatives
-                .iter()
-                .map(|conditions| {
-                    conditions
-                        .iter()
-                        .copied()
-                        .map(condition_weight)
-                        .sum::<u16>()
-                })
-                .max()
-                .unwrap_or(0),
-        }
+        self.alternatives
+            .iter()
+            .map(|conditions| {
+                conditions
+                    .iter()
+                    .copied()
+                    .map(condition_weight)
+                    .sum::<u16>()
+            })
+            .max()
+            .unwrap_or(0)
     }
 
     pub fn is_met(&self, ctx: &RuntimeConditionContext<'_>) -> bool {
-        match self.kind {
-            BindingConditionKind::Always => true,
-            BindingConditionKind::All => self.alternatives.first().is_some_and(|conditions| {
-                conditions
-                    .iter()
-                    .copied()
-                    .all(|condition| runtime_condition_is_met(condition, ctx))
-            }),
-            BindingConditionKind::Any => self.alternatives.iter().any(|conditions| {
-                conditions
-                    .iter()
-                    .copied()
-                    .all(|condition| runtime_condition_is_met(condition, ctx))
-            }),
-        }
+        self.alternatives.iter().any(|conditions| {
+            conditions
+                .iter()
+                .copied()
+                .all(|condition| runtime_condition_is_met(condition, ctx))
+        })
     }
+}
+
+fn normalize_conditions(conditions: &[RuntimeCondition]) -> Vec<RuntimeCondition> {
+    let mut normalized = Vec::new();
+    for condition in conditions {
+        add_condition(&mut normalized, *condition);
+    }
+    normalized.sort_by_key(|condition| condition_key(*condition));
+    normalized
+}
+
+fn sort_and_dedup_alternatives(alternatives: &mut Vec<Vec<RuntimeCondition>>) {
+    alternatives.sort_by_key(|conditions| {
+        conditions
+            .iter()
+            .copied()
+            .map(condition_key)
+            .collect::<Vec<_>>()
+    });
+    alternatives.dedup();
 }
 
 /// Shared runtime predicates for command `enabled_when` and key binding
@@ -251,7 +211,9 @@ pub fn runtime_condition_is_met(
         RuntimeCondition::HelpIsOpen => ctx.mode == Mode::Help,
         RuntimeCondition::HelpIsClosed => ctx.mode != Mode::Help,
         RuntimeCondition::PaletteInputHistoryIsAvailable => ctx.palette_input_history_available,
-        RuntimeCondition::PaletteInputHistoryIsUnavailable => !ctx.palette_input_history_available,
+        RuntimeCondition::PaletteInputHistoryIsUnavailable => {
+            ctx.active_palette.is_some() && !ctx.palette_input_history_available
+        }
         RuntimeCondition::PaletteInputIsEmpty => {
             ctx.active_palette.is_some() && ctx.palette_input_empty
         }
@@ -289,6 +251,7 @@ fn add_condition(conditions: &mut Vec<RuntimeCondition>, condition: RuntimeCondi
         }
         RuntimeCondition::PaletteInputHistoryIsUnavailable => {
             add_atom(conditions, RuntimeCondition::ModeIs(Mode::Palette));
+            add_atom(conditions, RuntimeCondition::PaletteIsOpen);
             add_atom(
                 conditions,
                 RuntimeCondition::PaletteInputHistoryIsUnavailable,
@@ -405,6 +368,14 @@ mod tests {
         let outline =
             RuntimeConditionContext::new(Mode::Palette, Some(PaletteKind::Outline), &extensions);
         assert!(!outline.palette_input_history_available);
+        assert!(runtime_condition_is_met(
+            RuntimeCondition::PaletteInputHistoryIsUnavailable,
+            &outline
+        ));
+        assert!(!runtime_condition_is_met(
+            RuntimeCondition::PaletteInputHistoryIsUnavailable,
+            &RuntimeConditionContext::normal(&extensions)
+        ));
     }
 
     #[test]
@@ -477,6 +448,18 @@ mod tests {
         let duplicated = BindingCondition::new(ConditionExpr::All(PALETTE_DUPLICATED));
         assert_eq!(palette, duplicated);
         assert_eq!(palette.priority_score(), duplicated.priority_score());
+    }
+
+    #[test]
+    fn single_alternative_conditions_have_the_same_normalized_form() {
+        static PALETTE_COMMAND: &[RuntimeCondition] =
+            &[RuntimeCondition::PaletteKindIs(PaletteKind::Command)];
+
+        let all = BindingCondition::new(ConditionExpr::All(PALETTE_COMMAND));
+        let any = BindingCondition::new(ConditionExpr::Any(PALETTE_COMMAND));
+
+        assert_eq!(all, any);
+        assert_eq!(all.priority_score(), any.priority_score());
     }
 
     #[test]

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -148,6 +148,8 @@ pub enum RuntimeCondition {
     HelpIsClosed,
     PaletteInputHistoryIsAvailable,
     PaletteInputHistoryIsUnavailable,
+    PaletteInputIsEmpty,
+    PaletteInputIsNotEmpty,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -155,6 +157,7 @@ pub struct RuntimeConditionContext<'a> {
     pub mode: Mode,
     pub active_palette: Option<PaletteKind>,
     pub palette_input_history_available: bool,
+    pub palette_input_empty: bool,
     pub extensions: &'a ExtensionUiSnapshot,
 }
 
@@ -169,6 +172,23 @@ impl<'a> RuntimeConditionContext<'a> {
             active_palette,
             palette_input_history_available: active_palette
                 .is_some_and(PaletteKind::supports_input_history),
+            palette_input_empty: false,
+            extensions,
+        }
+    }
+
+    pub fn with_palette_input_empty(
+        mode: Mode,
+        active_palette: Option<PaletteKind>,
+        palette_input_empty: bool,
+        extensions: &'a ExtensionUiSnapshot,
+    ) -> RuntimeConditionContext<'a> {
+        RuntimeConditionContext {
+            mode,
+            active_palette,
+            palette_input_history_available: active_palette
+                .is_some_and(PaletteKind::supports_input_history),
+            palette_input_empty,
             extensions,
         }
     }
@@ -232,6 +252,12 @@ pub fn runtime_condition_is_met(
         RuntimeCondition::HelpIsClosed => ctx.mode != Mode::Help,
         RuntimeCondition::PaletteInputHistoryIsAvailable => ctx.palette_input_history_available,
         RuntimeCondition::PaletteInputHistoryIsUnavailable => !ctx.palette_input_history_available,
+        RuntimeCondition::PaletteInputIsEmpty => {
+            ctx.active_palette.is_some() && ctx.palette_input_empty
+        }
+        RuntimeCondition::PaletteInputIsNotEmpty => {
+            ctx.active_palette.is_some() && !ctx.palette_input_empty
+        }
     }
 }
 
@@ -268,6 +294,16 @@ fn add_condition(conditions: &mut Vec<RuntimeCondition>, condition: RuntimeCondi
                 RuntimeCondition::PaletteInputHistoryIsUnavailable,
             );
         }
+        RuntimeCondition::PaletteInputIsEmpty => {
+            add_atom(conditions, RuntimeCondition::ModeIs(Mode::Palette));
+            add_atom(conditions, RuntimeCondition::PaletteIsOpen);
+            add_atom(conditions, RuntimeCondition::PaletteInputIsEmpty);
+        }
+        RuntimeCondition::PaletteInputIsNotEmpty => {
+            add_atom(conditions, RuntimeCondition::ModeIs(Mode::Palette));
+            add_atom(conditions, RuntimeCondition::PaletteIsOpen);
+            add_atom(conditions, RuntimeCondition::PaletteInputIsNotEmpty);
+        }
     }
 }
 
@@ -289,7 +325,9 @@ fn condition_weight(condition: RuntimeCondition) -> u16 {
         | RuntimeCondition::HelpIsOpen
         | RuntimeCondition::HelpIsClosed
         | RuntimeCondition::PaletteInputHistoryIsAvailable
-        | RuntimeCondition::PaletteInputHistoryIsUnavailable => 1,
+        | RuntimeCondition::PaletteInputHistoryIsUnavailable
+        | RuntimeCondition::PaletteInputIsEmpty
+        | RuntimeCondition::PaletteInputIsNotEmpty => 1,
     }
 }
 
@@ -306,6 +344,8 @@ fn condition_key(condition: RuntimeCondition) -> (u8, u8) {
         RuntimeCondition::HelpIsClosed => (8, 0),
         RuntimeCondition::PaletteInputHistoryIsAvailable => (9, 0),
         RuntimeCondition::PaletteInputHistoryIsUnavailable => (10, 0),
+        RuntimeCondition::PaletteInputIsEmpty => (11, 0),
+        RuntimeCondition::PaletteInputIsNotEmpty => (12, 0),
     }
 }
 
@@ -365,6 +405,49 @@ mod tests {
         let outline =
             RuntimeConditionContext::new(Mode::Palette, Some(PaletteKind::Outline), &extensions);
         assert!(!outline.palette_input_history_available);
+    }
+
+    #[test]
+    fn palette_input_conditions_require_an_active_palette() {
+        let extensions = ExtensionUiSnapshot::default();
+        let empty = RuntimeConditionContext::with_palette_input_empty(
+            Mode::Palette,
+            Some(PaletteKind::Command),
+            true,
+            &extensions,
+        );
+        let not_empty = RuntimeConditionContext::with_palette_input_empty(
+            Mode::Palette,
+            Some(PaletteKind::Command),
+            false,
+            &extensions,
+        );
+        let closed = RuntimeConditionContext::normal(&extensions);
+
+        assert!(runtime_condition_is_met(
+            RuntimeCondition::PaletteInputIsEmpty,
+            &empty
+        ));
+        assert!(!runtime_condition_is_met(
+            RuntimeCondition::PaletteInputIsNotEmpty,
+            &empty
+        ));
+        assert!(runtime_condition_is_met(
+            RuntimeCondition::PaletteInputIsNotEmpty,
+            &not_empty
+        ));
+        assert!(!runtime_condition_is_met(
+            RuntimeCondition::PaletteInputIsEmpty,
+            &not_empty
+        ));
+        assert!(!runtime_condition_is_met(
+            RuntimeCondition::PaletteInputIsEmpty,
+            &closed
+        ));
+        assert!(!runtime_condition_is_met(
+            RuntimeCondition::PaletteInputIsNotEmpty,
+            &closed
+        ));
     }
 
     #[test]

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -9,6 +9,124 @@ pub enum ConditionExpr {
     Any(&'static [RuntimeCondition]),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BindingConditionKind {
+    Always,
+    All,
+    Any,
+}
+
+#[derive(Debug, Clone, Eq)]
+pub struct BindingCondition {
+    original: ConditionExpr,
+    kind: BindingConditionKind,
+    alternatives: Vec<Vec<RuntimeCondition>>,
+}
+
+impl PartialEq for BindingCondition {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind && self.alternatives == other.alternatives
+    }
+}
+
+impl BindingCondition {
+    pub fn new(expr: ConditionExpr) -> Self {
+        match expr {
+            ConditionExpr::Always => Self {
+                original: expr,
+                kind: BindingConditionKind::Always,
+                alternatives: Vec::new(),
+            },
+            ConditionExpr::All(conditions) => {
+                let mut normalized = Vec::new();
+                for condition in conditions {
+                    add_condition(&mut normalized, *condition);
+                }
+                normalized.sort_by_key(|condition| condition_key(*condition));
+                Self {
+                    original: expr,
+                    kind: BindingConditionKind::All,
+                    alternatives: vec![normalized],
+                }
+            }
+            ConditionExpr::Any(conditions) => {
+                let mut alternatives = Vec::new();
+                for condition in conditions {
+                    let mut normalized = Vec::new();
+                    add_condition(&mut normalized, *condition);
+                    normalized.sort_by_key(|condition| condition_key(*condition));
+                    if !alternatives.contains(&normalized) {
+                        alternatives.push(normalized);
+                    }
+                }
+                alternatives.sort_by_key(|conditions| {
+                    conditions
+                        .iter()
+                        .copied()
+                        .map(condition_key)
+                        .collect::<Vec<_>>()
+                });
+                Self {
+                    original: expr,
+                    kind: BindingConditionKind::Any,
+                    alternatives,
+                }
+            }
+        }
+    }
+
+    pub fn original(&self) -> ConditionExpr {
+        self.original
+    }
+
+    pub fn priority_score(&self) -> u16 {
+        match self.kind {
+            BindingConditionKind::Always => 0,
+            BindingConditionKind::All => self
+                .alternatives
+                .first()
+                .map(|conditions| {
+                    conditions
+                        .iter()
+                        .copied()
+                        .map(condition_weight)
+                        .sum::<u16>()
+                })
+                .unwrap_or(0),
+            BindingConditionKind::Any => self
+                .alternatives
+                .iter()
+                .map(|conditions| {
+                    conditions
+                        .iter()
+                        .copied()
+                        .map(condition_weight)
+                        .sum::<u16>()
+                })
+                .max()
+                .unwrap_or(0),
+        }
+    }
+
+    pub fn is_met(&self, ctx: &RuntimeConditionContext<'_>) -> bool {
+        match self.kind {
+            BindingConditionKind::Always => true,
+            BindingConditionKind::All => self.alternatives.first().is_some_and(|conditions| {
+                conditions
+                    .iter()
+                    .copied()
+                    .all(|condition| runtime_condition_is_met(condition, ctx))
+            }),
+            BindingConditionKind::Any => self.alternatives.iter().any(|conditions| {
+                conditions
+                    .iter()
+                    .copied()
+                    .all(|condition| runtime_condition_is_met(condition, ctx))
+            }),
+        }
+    }
+}
+
 /// Shared runtime predicates for command `enabled_when` and key binding
 /// `enabled_when`.
 ///
@@ -117,13 +235,108 @@ pub fn runtime_condition_is_met(
     }
 }
 
+fn add_condition(conditions: &mut Vec<RuntimeCondition>, condition: RuntimeCondition) {
+    match condition {
+        RuntimeCondition::ModeIs(_)
+        | RuntimeCondition::ModeIsNot(_)
+        | RuntimeCondition::SearchIsActive
+        | RuntimeCondition::SearchIsInactive
+        | RuntimeCondition::PaletteIsClosed
+        | RuntimeCondition::HelpIsClosed => add_atom(conditions, condition),
+        RuntimeCondition::PaletteIsOpen => {
+            add_atom(conditions, RuntimeCondition::ModeIs(Mode::Palette));
+            add_atom(conditions, RuntimeCondition::PaletteIsOpen);
+        }
+        RuntimeCondition::PaletteKindIs(kind) => {
+            add_atom(conditions, RuntimeCondition::ModeIs(Mode::Palette));
+            add_atom(conditions, RuntimeCondition::PaletteIsOpen);
+            add_atom(conditions, RuntimeCondition::PaletteKindIs(kind));
+        }
+        RuntimeCondition::HelpIsOpen => {
+            add_atom(conditions, RuntimeCondition::ModeIs(Mode::Help));
+            add_atom(conditions, RuntimeCondition::HelpIsOpen);
+        }
+        RuntimeCondition::PaletteInputHistoryIsAvailable => {
+            add_atom(conditions, RuntimeCondition::ModeIs(Mode::Palette));
+            add_atom(conditions, RuntimeCondition::PaletteIsOpen);
+            add_atom(conditions, RuntimeCondition::PaletteInputHistoryIsAvailable);
+        }
+        RuntimeCondition::PaletteInputHistoryIsUnavailable => {
+            add_atom(conditions, RuntimeCondition::ModeIs(Mode::Palette));
+            add_atom(
+                conditions,
+                RuntimeCondition::PaletteInputHistoryIsUnavailable,
+            );
+        }
+    }
+}
+
+fn add_atom(conditions: &mut Vec<RuntimeCondition>, condition: RuntimeCondition) {
+    if !conditions.contains(&condition) {
+        conditions.push(condition);
+    }
+}
+
+fn condition_weight(condition: RuntimeCondition) -> u16 {
+    match condition {
+        RuntimeCondition::ModeIs(_)
+        | RuntimeCondition::ModeIsNot(_)
+        | RuntimeCondition::SearchIsActive
+        | RuntimeCondition::SearchIsInactive
+        | RuntimeCondition::PaletteIsOpen
+        | RuntimeCondition::PaletteIsClosed
+        | RuntimeCondition::PaletteKindIs(_)
+        | RuntimeCondition::HelpIsOpen
+        | RuntimeCondition::HelpIsClosed
+        | RuntimeCondition::PaletteInputHistoryIsAvailable
+        | RuntimeCondition::PaletteInputHistoryIsUnavailable => 1,
+    }
+}
+
+fn condition_key(condition: RuntimeCondition) -> (u8, u8) {
+    match condition {
+        RuntimeCondition::ModeIs(mode) => (0, mode_key(mode)),
+        RuntimeCondition::ModeIsNot(mode) => (1, mode_key(mode)),
+        RuntimeCondition::SearchIsActive => (2, 0),
+        RuntimeCondition::SearchIsInactive => (3, 0),
+        RuntimeCondition::PaletteIsOpen => (4, 0),
+        RuntimeCondition::PaletteIsClosed => (5, 0),
+        RuntimeCondition::PaletteKindIs(kind) => (6, palette_kind_key(kind)),
+        RuntimeCondition::HelpIsOpen => (7, 0),
+        RuntimeCondition::HelpIsClosed => (8, 0),
+        RuntimeCondition::PaletteInputHistoryIsAvailable => (9, 0),
+        RuntimeCondition::PaletteInputHistoryIsUnavailable => (10, 0),
+    }
+}
+
+fn mode_key(mode: Mode) -> u8 {
+    match mode {
+        Mode::Normal => 0,
+        Mode::Palette => 1,
+        Mode::Help => 2,
+    }
+}
+
+fn palette_kind_key(kind: PaletteKind) -> u8 {
+    match kind {
+        PaletteKind::Command => 0,
+        PaletteKind::Search => 1,
+        PaletteKind::SearchResults => 2,
+        PaletteKind::History => 3,
+        PaletteKind::Outline => 4,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::app::Mode;
     use crate::extension::ExtensionUiSnapshot;
     use crate::palette::PaletteKind;
 
-    use super::{RuntimeCondition, RuntimeConditionContext, runtime_condition_is_met};
+    use super::{
+        BindingCondition, ConditionExpr, RuntimeCondition, RuntimeConditionContext,
+        runtime_condition_is_met,
+    };
 
     #[test]
     fn palette_kind_condition_requires_an_open_matching_palette() {
@@ -152,5 +365,53 @@ mod tests {
         let outline =
             RuntimeConditionContext::new(Mode::Palette, Some(PaletteKind::Outline), &extensions);
         assert!(!outline.palette_input_history_available);
+    }
+
+    #[test]
+    fn binding_conditions_are_normalized_idempotently() {
+        static PALETTE_COMMAND: &[RuntimeCondition] =
+            &[RuntimeCondition::PaletteKindIs(PaletteKind::Command)];
+        static PALETTE_PLUS_COMMAND: &[RuntimeCondition] = &[
+            RuntimeCondition::ModeIs(Mode::Palette),
+            RuntimeCondition::PaletteKindIs(PaletteKind::Command),
+        ];
+        static PALETTE_DUPLICATED: &[RuntimeCondition] = &[
+            RuntimeCondition::ModeIs(Mode::Palette),
+            RuntimeCondition::ModeIs(Mode::Palette),
+        ];
+
+        let command = BindingCondition::new(ConditionExpr::All(PALETTE_COMMAND));
+        let palette_plus_command = BindingCondition::new(ConditionExpr::All(PALETTE_PLUS_COMMAND));
+        assert_eq!(command, palette_plus_command);
+        assert_eq!(
+            command.priority_score(),
+            palette_plus_command.priority_score()
+        );
+
+        let palette = BindingCondition::new(ConditionExpr::All(&[RuntimeCondition::ModeIs(
+            Mode::Palette,
+        )]));
+        let duplicated = BindingCondition::new(ConditionExpr::All(PALETTE_DUPLICATED));
+        assert_eq!(palette, duplicated);
+        assert_eq!(palette.priority_score(), duplicated.priority_score());
+    }
+
+    #[test]
+    fn binding_condition_priority_counts_distinct_normalized_constraints() {
+        static PALETTE: &[RuntimeCondition] = &[RuntimeCondition::ModeIs(Mode::Palette)];
+        static PALETTE_COMMAND: &[RuntimeCondition] =
+            &[RuntimeCondition::PaletteKindIs(PaletteKind::Command)];
+        static PALETTE_COMMAND_WITH_HISTORY: &[RuntimeCondition] = &[
+            RuntimeCondition::PaletteKindIs(PaletteKind::Command),
+            RuntimeCondition::PaletteInputHistoryIsAvailable,
+        ];
+
+        let palette = BindingCondition::new(ConditionExpr::All(PALETTE));
+        let command = BindingCondition::new(ConditionExpr::All(PALETTE_COMMAND));
+        let command_with_history =
+            BindingCondition::new(ConditionExpr::All(PALETTE_COMMAND_WITH_HISTORY));
+
+        assert!(palette.priority_score() < command.priority_score());
+        assert!(command.priority_score() < command_with_history.priority_score());
     }
 }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -872,6 +872,45 @@ mod tests {
     }
 
     #[test]
+    fn keymap_config_accepts_palette_input_state_bindings() {
+        let path = unique_temp_path("palette-input-state-keymap.toml");
+        fs::write(
+            &path,
+            r#"
+            [[keymap]]
+            when = "palette.input-empty"
+            key = "<backspace>"
+            command = "close-palette"
+
+            [[keymap]]
+            when = "palette.input-not-empty"
+            key = "<backspace>"
+            command = "text.delete-backward"
+            "#,
+        )
+        .expect("config file should be written");
+
+        let options = load_options_from_explicit_path(&path).expect("config should load");
+        assert_eq!(
+            options.keymap.bindings,
+            vec![
+                KeymapBinding::Exact {
+                    when: KeymapWhen::PaletteInputEmpty,
+                    keys: vec![ShortcutKey::key(KeyCode::Backspace)],
+                    command: Command::ClosePalette,
+                },
+                KeymapBinding::Exact {
+                    when: KeymapWhen::PaletteInputNotEmpty,
+                    keys: vec![ShortcutKey::key(KeyCode::Backspace)],
+                    command: Command::TextDeleteBackward,
+                },
+            ]
+        );
+
+        fs::remove_file(&path).expect("config file should be removed");
+    }
+
+    #[test]
     fn explicit_config_reads_view_input_and_watch_sections() {
         let path = unique_temp_path("view-input-watch-options.toml");
         fs::write(

--- a/src/config/keymap/mod.rs
+++ b/src/config/keymap/mod.rs
@@ -530,6 +530,49 @@ mod tests {
     }
 
     #[test]
+    fn configured_palette_input_empty_binding_overrides_default_palette_backspace() {
+        let registry = resolve_sequence_registry(&KeymapOptions {
+            preset: Some(super::KeymapPreset::Default),
+            bindings: vec![KeymapBinding::Exact {
+                when: KeymapWhen::PaletteInputEmpty,
+                keys: vec![ShortcutKey::key(KeyCode::Backspace)],
+                command: Command::ClosePalette,
+            }],
+        });
+        let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
+        let extensions = ExtensionUiSnapshot::default();
+
+        assert_eq!(
+            resolver.handle_key_in_context(
+                KeyBindingContext {
+                    runtime: RuntimeConditionContext::with_palette_input_empty(
+                        Mode::Palette,
+                        Some(PaletteKind::Command),
+                        true,
+                        &extensions,
+                    ),
+                },
+                KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
+            ),
+            SequenceResolution::Dispatch(Command::ClosePalette)
+        );
+        assert_eq!(
+            resolver.handle_key_in_context(
+                KeyBindingContext {
+                    runtime: RuntimeConditionContext::with_palette_input_empty(
+                        Mode::Palette,
+                        Some(PaletteKind::Command),
+                        false,
+                        &extensions,
+                    ),
+                },
+                KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
+            ),
+            SequenceResolution::Dispatch(Command::TextDeleteBackward)
+        );
+    }
+
+    #[test]
     fn unbind_ignores_missing_bindings() {
         let registry = resolve_sequence_registry(&KeymapOptions {
             preset: Some(super::KeymapPreset::None),

--- a/src/config/keymap/mod.rs
+++ b/src/config/keymap/mod.rs
@@ -25,42 +25,23 @@ const WHEN_NORMAL_SEARCH_INACTIVE: [RuntimeCondition; 2] = [
 ];
 const WHEN_HELP: [RuntimeCondition; 1] = [RuntimeCondition::ModeIs(Mode::Help)];
 const WHEN_PALETTE: [RuntimeCondition; 1] = [RuntimeCondition::ModeIs(Mode::Palette)];
-const WHEN_PALETTE_COMMAND: [RuntimeCondition; 2] = [
-    RuntimeCondition::ModeIs(Mode::Palette),
-    RuntimeCondition::PaletteKindIs(PaletteKind::Command),
-];
-const WHEN_PALETTE_SEARCH: [RuntimeCondition; 2] = [
-    RuntimeCondition::ModeIs(Mode::Palette),
-    RuntimeCondition::PaletteKindIs(PaletteKind::Search),
-];
-const WHEN_PALETTE_SEARCH_RESULTS: [RuntimeCondition; 2] = [
-    RuntimeCondition::ModeIs(Mode::Palette),
-    RuntimeCondition::PaletteKindIs(PaletteKind::SearchResults),
-];
-const WHEN_PALETTE_HISTORY: [RuntimeCondition; 2] = [
-    RuntimeCondition::ModeIs(Mode::Palette),
-    RuntimeCondition::PaletteKindIs(PaletteKind::History),
-];
-const WHEN_PALETTE_OUTLINE: [RuntimeCondition; 2] = [
-    RuntimeCondition::ModeIs(Mode::Palette),
-    RuntimeCondition::PaletteKindIs(PaletteKind::Outline),
-];
-const WHEN_PALETTE_WITH_INPUT_HISTORY: [RuntimeCondition; 2] = [
-    RuntimeCondition::ModeIs(Mode::Palette),
-    RuntimeCondition::PaletteInputHistoryIsAvailable,
-];
-const WHEN_PALETTE_NO_INPUT_HISTORY: [RuntimeCondition; 2] = [
-    RuntimeCondition::ModeIs(Mode::Palette),
-    RuntimeCondition::PaletteInputHistoryIsUnavailable,
-];
-const WHEN_PALETTE_INPUT_EMPTY: [RuntimeCondition; 2] = [
-    RuntimeCondition::ModeIs(Mode::Palette),
-    RuntimeCondition::PaletteInputIsEmpty,
-];
-const WHEN_PALETTE_INPUT_NOT_EMPTY: [RuntimeCondition; 2] = [
-    RuntimeCondition::ModeIs(Mode::Palette),
-    RuntimeCondition::PaletteInputIsNotEmpty,
-];
+const WHEN_PALETTE_COMMAND: [RuntimeCondition; 1] =
+    [RuntimeCondition::PaletteKindIs(PaletteKind::Command)];
+const WHEN_PALETTE_SEARCH: [RuntimeCondition; 1] =
+    [RuntimeCondition::PaletteKindIs(PaletteKind::Search)];
+const WHEN_PALETTE_SEARCH_RESULTS: [RuntimeCondition; 1] =
+    [RuntimeCondition::PaletteKindIs(PaletteKind::SearchResults)];
+const WHEN_PALETTE_HISTORY: [RuntimeCondition; 1] =
+    [RuntimeCondition::PaletteKindIs(PaletteKind::History)];
+const WHEN_PALETTE_OUTLINE: [RuntimeCondition; 1] =
+    [RuntimeCondition::PaletteKindIs(PaletteKind::Outline)];
+const WHEN_PALETTE_WITH_INPUT_HISTORY: [RuntimeCondition; 1] =
+    [RuntimeCondition::PaletteInputHistoryIsAvailable];
+const WHEN_PALETTE_NO_INPUT_HISTORY: [RuntimeCondition; 1] =
+    [RuntimeCondition::PaletteInputHistoryIsUnavailable];
+const WHEN_PALETTE_INPUT_EMPTY: [RuntimeCondition; 1] = [RuntimeCondition::PaletteInputIsEmpty];
+const WHEN_PALETTE_INPUT_NOT_EMPTY: [RuntimeCondition; 1] =
+    [RuntimeCondition::PaletteInputIsNotEmpty];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeymapWhen {

--- a/src/config/keymap/mod.rs
+++ b/src/config/keymap/mod.rs
@@ -53,6 +53,14 @@ const WHEN_PALETTE_NO_INPUT_HISTORY: [RuntimeCondition; 2] = [
     RuntimeCondition::ModeIs(Mode::Palette),
     RuntimeCondition::PaletteInputHistoryIsUnavailable,
 ];
+const WHEN_PALETTE_INPUT_EMPTY: [RuntimeCondition; 2] = [
+    RuntimeCondition::ModeIs(Mode::Palette),
+    RuntimeCondition::PaletteInputIsEmpty,
+];
+const WHEN_PALETTE_INPUT_NOT_EMPTY: [RuntimeCondition; 2] = [
+    RuntimeCondition::ModeIs(Mode::Palette),
+    RuntimeCondition::PaletteInputIsNotEmpty,
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeymapWhen {
@@ -68,6 +76,8 @@ pub enum KeymapWhen {
     PaletteOutline,
     PaletteWithInputHistory,
     PaletteNoInputHistory,
+    PaletteInputEmpty,
+    PaletteInputNotEmpty,
 }
 
 impl KeymapWhen {
@@ -85,6 +95,8 @@ impl KeymapWhen {
             "palette.outline" => Some(Self::PaletteOutline),
             "palette.with-input-history" => Some(Self::PaletteWithInputHistory),
             "palette.no-input-history" => Some(Self::PaletteNoInputHistory),
+            "palette.input-empty" => Some(Self::PaletteInputEmpty),
+            "palette.input-not-empty" => Some(Self::PaletteInputNotEmpty),
             _ => None,
         }
     }
@@ -103,6 +115,8 @@ impl KeymapWhen {
             Self::PaletteOutline => ConditionExpr::All(&WHEN_PALETTE_OUTLINE),
             Self::PaletteWithInputHistory => ConditionExpr::All(&WHEN_PALETTE_WITH_INPUT_HISTORY),
             Self::PaletteNoInputHistory => ConditionExpr::All(&WHEN_PALETTE_NO_INPUT_HISTORY),
+            Self::PaletteInputEmpty => ConditionExpr::All(&WHEN_PALETTE_INPUT_EMPTY),
+            Self::PaletteInputNotEmpty => ConditionExpr::All(&WHEN_PALETTE_INPUT_NOT_EMPTY),
         }
     }
 
@@ -117,6 +131,8 @@ impl KeymapWhen {
                 | Self::PaletteOutline
                 | Self::PaletteWithInputHistory
                 | Self::PaletteNoInputHistory
+                | Self::PaletteInputEmpty
+                | Self::PaletteInputNotEmpty
         )
     }
 
@@ -460,6 +476,56 @@ mod tests {
                 KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
             ),
             SequenceResolution::Dispatch(Command::PaletteSelectPrev)
+        );
+    }
+
+    #[test]
+    fn palette_input_empty_condition_can_override_broad_palette_binding() {
+        let registry = resolve_sequence_registry(&KeymapOptions {
+            preset: None,
+            bindings: vec![
+                KeymapBinding::Exact {
+                    when: KeymapWhen::Palette,
+                    keys: vec![ShortcutKey::key(KeyCode::Backspace)],
+                    command: Command::TextDeleteBackward,
+                },
+                KeymapBinding::Exact {
+                    when: KeymapWhen::PaletteInputEmpty,
+                    keys: vec![ShortcutKey::key(KeyCode::Backspace)],
+                    command: Command::ClosePalette,
+                },
+            ],
+        });
+        let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
+        let extensions = ExtensionUiSnapshot::default();
+
+        assert_eq!(
+            resolver.handle_key_in_context(
+                KeyBindingContext {
+                    runtime: RuntimeConditionContext::with_palette_input_empty(
+                        Mode::Palette,
+                        Some(PaletteKind::Command),
+                        true,
+                        &extensions,
+                    ),
+                },
+                KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
+            ),
+            SequenceResolution::Dispatch(Command::ClosePalette)
+        );
+        assert_eq!(
+            resolver.handle_key_in_context(
+                KeyBindingContext {
+                    runtime: RuntimeConditionContext::with_palette_input_empty(
+                        Mode::Palette,
+                        Some(PaletteKind::Command),
+                        false,
+                        &extensions,
+                    ),
+                },
+                KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
+            ),
+            SequenceResolution::Dispatch(Command::TextDeleteBackward)
         );
     }
 

--- a/src/input/sequence.rs
+++ b/src/input/sequence.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::command::Command;
-use crate::condition::{ConditionExpr, RuntimeConditionContext, evaluate_condition};
+use crate::condition::{BindingCondition, ConditionExpr, RuntimeConditionContext};
 use crate::extension::ExtensionUiSnapshot;
 
 use super::shortcut::{ShortcutKey, format_shortcut_key};
@@ -54,21 +54,30 @@ impl GeneratedCommand {
 #[derive(Debug, Clone)]
 enum SequenceBinding {
     Exact {
-        enabled_when: ConditionExpr,
+        enabled_when: BindingCondition,
+        priority: BindingPriority,
         keys: Vec<ShortcutKey>,
         command: Command,
     },
     NumericPrefix {
-        enabled_when: ConditionExpr,
+        enabled_when: BindingCondition,
+        priority: BindingPriority,
         suffix: ShortcutKey,
         command_id: &'static str,
         factory: NumericCommandFactory,
     },
     Generated {
-        enabled_when: ConditionExpr,
+        enabled_when: BindingCondition,
+        priority: BindingPriority,
         matcher: GeneratedKeyMatcher,
         command: GeneratedCommand,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct BindingPriority {
+    score: u16,
+    order: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -102,6 +111,7 @@ pub struct SequenceRegistrySnapshot {
 #[derive(Debug, Clone, Default)]
 pub struct SequenceRegistry {
     bindings: Vec<SequenceBinding>,
+    next_order: u64,
 }
 
 impl SequenceRegistry {
@@ -127,6 +137,9 @@ impl SequenceRegistry {
             .map(canonicalize_binding_key)
             .collect::<Result<Vec<_>, _>>()?;
 
+        let enabled_when = BindingCondition::new(enabled_when);
+        let priority = self.next_priority(&enabled_when);
+
         self.bindings.retain(|binding| {
             !matches!(
                 binding,
@@ -134,12 +147,13 @@ impl SequenceRegistry {
                     enabled_when: existing_enabled_when,
                     keys: existing,
                     ..
-                } if *existing_enabled_when == enabled_when
+                } if existing_enabled_when == &enabled_when
                     && existing == &keys
             )
         });
         self.bindings.push(SequenceBinding::Exact {
             enabled_when,
+            priority,
             keys,
             command,
         });
@@ -161,6 +175,9 @@ impl SequenceRegistry {
             return Err(SequenceRegistrationError::InvalidNumericSuffix);
         }
 
+        let enabled_when = BindingCondition::new(enabled_when);
+        let priority = self.next_priority(&enabled_when);
+
         self.bindings.retain(|binding| {
             !matches!(
                 binding,
@@ -168,12 +185,13 @@ impl SequenceRegistry {
                     enabled_when: existing_enabled_when,
                     suffix: existing,
                     ..
-                } if *existing_enabled_when == enabled_when
+                } if existing_enabled_when == &enabled_when
                     && *existing == suffix
             )
         });
         self.bindings.push(SequenceBinding::NumericPrefix {
             enabled_when,
+            priority,
             suffix,
             command_id,
             factory,
@@ -187,6 +205,9 @@ impl SequenceRegistry {
         matcher: GeneratedKeyMatcher,
         command: GeneratedCommand,
     ) {
+        let enabled_when = BindingCondition::new(enabled_when);
+        let priority = self.next_priority(&enabled_when);
+
         self.bindings.retain(|binding| {
             !matches!(
                 binding,
@@ -194,12 +215,13 @@ impl SequenceRegistry {
                     enabled_when: existing_enabled_when,
                     matcher: existing_matcher,
                     ..
-                } if *existing_enabled_when == enabled_when
+                } if existing_enabled_when == &enabled_when
                     && *existing_matcher == matcher
             )
         });
         self.bindings.push(SequenceBinding::Generated {
             enabled_when,
+            priority,
             matcher,
             command,
         });
@@ -219,6 +241,7 @@ impl SequenceRegistry {
             .map(canonicalize_binding_key)
             .collect::<Result<Vec<_>, _>>()?;
         let original_len = self.bindings.len();
+        let enabled_when = BindingCondition::new(enabled_when);
         self.bindings.retain(|binding| {
             !matches!(
                 binding,
@@ -226,7 +249,7 @@ impl SequenceRegistry {
                     enabled_when: existing_enabled_when,
                     keys: existing,
                     ..
-                } if enabled_when == *existing_enabled_when
+                } if &enabled_when == existing_enabled_when
                     && existing == &keys
             )
         });
@@ -243,6 +266,7 @@ impl SequenceRegistry {
             return Err(SequenceRegistrationError::InvalidNumericSuffix);
         }
         let original_len = self.bindings.len();
+        let enabled_when = BindingCondition::new(enabled_when);
         self.bindings.retain(|binding| {
             !matches!(
                 binding,
@@ -250,7 +274,7 @@ impl SequenceRegistry {
                     enabled_when: existing_enabled_when,
                     suffix: existing,
                     ..
-                } if enabled_when == *existing_enabled_when
+                } if &enabled_when == existing_enabled_when
                     && *existing == suffix
             )
         });
@@ -265,9 +289,10 @@ impl SequenceRegistry {
                     enabled_when,
                     keys,
                     command,
+                    ..
                 } => {
                     snapshot.exact_bindings.push(ExactSequenceBinding {
-                        enabled_when: *enabled_when,
+                        enabled_when: enabled_when.original(),
                         keys: keys.clone(),
                         command_id: command.id(),
                     });
@@ -280,7 +305,7 @@ impl SequenceRegistry {
                 } => snapshot
                     .numeric_prefix_bindings
                     .push(NumericSequenceBinding {
-                        enabled_when: *enabled_when,
+                        enabled_when: enabled_when.original(),
                         suffix: *suffix,
                         command_id,
                     }),
@@ -288,8 +313,9 @@ impl SequenceRegistry {
                     enabled_when,
                     matcher,
                     command,
+                    ..
                 } => snapshot.generated_bindings.push(GeneratedSequenceBinding {
-                    enabled_when: *enabled_when,
+                    enabled_when: enabled_when.original(),
                     matcher: *matcher,
                     command_id: command.command_id(),
                 }),
@@ -298,8 +324,18 @@ impl SequenceRegistry {
         snapshot
     }
 
+    fn next_priority(&mut self, enabled_when: &BindingCondition) -> BindingPriority {
+        let order = self.next_order;
+        self.next_order = self.next_order.saturating_add(1);
+        BindingPriority {
+            score: enabled_when.priority_score(),
+            order,
+        }
+    }
+
     fn match_buffer(&self, buffer: &[ShortcutKey], ctx: KeyBindingContext<'_>) -> RegistryMatch {
         let mut exact = None;
+        let mut generated = None;
         let mut has_prefix = false;
 
         for binding in &self.bindings {
@@ -308,35 +344,68 @@ impl SequenceRegistry {
             }
 
             match binding {
-                SequenceBinding::Exact { keys, command, .. } => {
+                SequenceBinding::Exact {
+                    priority,
+                    keys,
+                    command,
+                    ..
+                } => {
                     if keys.as_slice() == buffer {
-                        exact = Some(command.clone());
+                        exact = select_higher_priority_command(
+                            exact,
+                            CommandMatch {
+                                priority: *priority,
+                                command: command.clone(),
+                            },
+                        );
                     } else if keys.starts_with(buffer) {
                         has_prefix = true;
                     }
                 }
                 SequenceBinding::NumericPrefix {
-                    suffix, factory, ..
+                    priority,
+                    suffix,
+                    factory,
+                    ..
                 } => match match_numeric_prefix(buffer, *suffix, *factory) {
                     NumericMatch::None => {}
                     NumericMatch::Prefix => has_prefix = true,
-                    NumericMatch::Exact(command) => exact = Some(command),
+                    NumericMatch::Exact(command) => {
+                        exact = select_higher_priority_command(
+                            exact,
+                            CommandMatch {
+                                priority: *priority,
+                                command,
+                            },
+                        );
+                    }
                 },
                 SequenceBinding::Generated {
-                    matcher, command, ..
+                    priority,
+                    matcher,
+                    command,
+                    ..
                 } => {
-                    if exact.is_none()
-                        && buffer.len() == 1
+                    if buffer.len() == 1
                         && let Some(command) =
                             generated_command_for_key(*matcher, *command, buffer[0], ctx)
                     {
-                        exact = Some(command);
+                        generated = select_higher_priority_command(
+                            generated,
+                            CommandMatch {
+                                priority: *priority,
+                                command,
+                            },
+                        );
                     }
                 }
             }
         }
 
-        RegistryMatch { exact, has_prefix }
+        RegistryMatch {
+            exact: exact.or(generated).map(|matched| matched.command),
+            has_prefix,
+        }
     }
 }
 
@@ -609,10 +678,10 @@ fn binding_matches_context(binding: &SequenceBinding, ctx: KeyBindingContext<'_>
     let enabled_when = match binding {
         SequenceBinding::Exact { enabled_when, .. }
         | SequenceBinding::NumericPrefix { enabled_when, .. }
-        | SequenceBinding::Generated { enabled_when, .. } => *enabled_when,
+        | SequenceBinding::Generated { enabled_when, .. } => enabled_when,
     };
 
-    evaluate_condition(enabled_when, &ctx.runtime)
+    enabled_when.is_met(&ctx.runtime)
 }
 
 fn generated_command_for_key(
@@ -642,6 +711,22 @@ fn generated_command_for_key(
 struct RegistryMatch {
     exact: Option<Command>,
     has_prefix: bool,
+}
+
+#[derive(Debug, Clone)]
+struct CommandMatch {
+    priority: BindingPriority,
+    command: Command,
+}
+
+fn select_higher_priority_command(
+    current: Option<CommandMatch>,
+    candidate: CommandMatch,
+) -> Option<CommandMatch> {
+    match current {
+        Some(current) if current.priority > candidate.priority => Some(current),
+        _ => Some(candidate),
+    }
 }
 
 enum NumericMatch {
@@ -890,6 +975,71 @@ mod tests {
     }
 
     #[test]
+    fn more_specific_binding_wins_over_later_broad_binding() {
+        static PALETTE_MODE: &[RuntimeCondition] = &[RuntimeCondition::ModeIs(Mode::Palette)];
+        static COMMAND_PALETTE: &[RuntimeCondition] =
+            &[RuntimeCondition::PaletteKindIs(PaletteKind::Command)];
+
+        let mut registry = SequenceRegistry::new();
+        registry
+            .register_exact(
+                ConditionExpr::All(COMMAND_PALETTE),
+                &[ShortcutKey::key(KeyCode::Enter)],
+                Command::PaletteSubmit,
+            )
+            .expect("specific binding should register");
+        registry
+            .register_exact(
+                ConditionExpr::All(PALETTE_MODE),
+                &[ShortcutKey::key(KeyCode::Enter)],
+                Command::ClosePalette,
+            )
+            .expect("broad binding should register");
+        let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
+        let extensions = ExtensionUiSnapshot::default();
+
+        assert_eq!(
+            resolver.handle_key_in_context(
+                palette_context(&extensions),
+                KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            ),
+            SequenceResolution::Dispatch(Command::PaletteSubmit)
+        );
+    }
+
+    #[test]
+    fn equal_priority_bindings_use_later_registration() {
+        static SEARCH_ACTIVE: &[RuntimeCondition] = &[RuntimeCondition::SearchIsActive];
+        static NORMAL_MODE: &[RuntimeCondition] = &[RuntimeCondition::ModeIs(Mode::Normal)];
+
+        let mut registry = SequenceRegistry::new();
+        registry
+            .register_exact(
+                ConditionExpr::All(SEARCH_ACTIVE),
+                &[ShortcutKey::char('x')],
+                Command::DebugStatusShow,
+            )
+            .expect("first binding should register");
+        registry
+            .register_exact(
+                ConditionExpr::All(NORMAL_MODE),
+                &[ShortcutKey::char('x')],
+                Command::DebugStatusHide,
+            )
+            .expect("later binding should register");
+        let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
+        let extensions = ExtensionUiSnapshot::with_search_active(true);
+
+        assert_eq!(
+            resolver.handle_key_in_context(
+                normal_context(&extensions),
+                KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+            ),
+            SequenceResolution::Dispatch(Command::DebugStatusHide)
+        );
+    }
+
+    #[test]
     fn generated_printable_binding_builds_text_insert_command() {
         let mut registry = SequenceRegistry::new();
         registry.register_generated(
@@ -1006,6 +1156,37 @@ mod tests {
                 ),
             ),
             SequenceResolution::Dispatch(Command::TextYank)
+        );
+    }
+
+    #[test]
+    fn generated_printable_binding_does_not_override_lower_priority_exact_binding() {
+        static PALETTE_MODE: &[RuntimeCondition] = &[RuntimeCondition::ModeIs(Mode::Palette)];
+        static COMMAND_PALETTE: &[RuntimeCondition] =
+            &[RuntimeCondition::PaletteKindIs(PaletteKind::Command)];
+
+        let mut registry = SequenceRegistry::new();
+        registry.register_generated(
+            ConditionExpr::All(COMMAND_PALETTE),
+            GeneratedKeyMatcher::PrintableCharacter,
+            GeneratedCommand::TextInsert,
+        );
+        registry
+            .register_exact(
+                ConditionExpr::All(PALETTE_MODE),
+                &[ShortcutKey::char('x')],
+                Command::ClosePalette,
+            )
+            .expect("exact binding should register");
+        let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
+        let extensions = ExtensionUiSnapshot::default();
+
+        assert_eq!(
+            resolver.handle_key_in_context(
+                palette_context(&extensions),
+                KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+            ),
+            SequenceResolution::Dispatch(Command::ClosePalette)
         );
     }
 

--- a/src/palette/manager.rs
+++ b/src/palette/manager.rs
@@ -153,6 +153,12 @@ impl PaletteManager {
         self.active.as_ref().map(|session| session.kind)
     }
 
+    pub fn active_input_is_empty(&self) -> bool {
+        self.active
+            .as_ref()
+            .is_some_and(|session| session.input.value().is_empty())
+    }
+
     pub fn close(&mut self) -> bool {
         self.active.take().is_some()
     }


### PR DESCRIPTION
## Summary
- Normalize key binding conditions and resolve overlapping bindings by specificity, then registration order.
- Add palette input empty/not-empty runtime selectors and config `when` values.
- Keep default palette Backspace behavior unchanged while allowing users to bind `palette.input-empty` to `close-palette`.

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `palette.input-empty` and `palette.input-not-empty` binding conditions to distinguish key behaviors based on palette input state.

* **Documentation**
  * Updated keymap reference documentation with clarified guidance on condition normalization and binding priority resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->