### PR TITLE
refactor(search): unify text extraction

### DIFF
--- a/src/app/runtime/mod.rs
+++ b/src/app/runtime/mod.rs
@@ -259,11 +259,7 @@ mod tests {
             Err(AppError::unsupported("not needed in runtime test"))
         }
 
-        fn extract_text(&self, _page: usize) -> AppResult<String> {
-            Err(AppError::unsupported("not needed in runtime test"))
-        }
-
-        fn extract_positioned_text(&self, _page: usize) -> AppResult<crate::backend::TextPage> {
+        fn extract_text_page(&self, _page: usize) -> AppResult<crate::backend::TextPage> {
             Err(AppError::unsupported("not needed in runtime test"))
         }
 
@@ -306,11 +302,7 @@ mod tests {
             Err(AppError::unsupported("not needed in runtime test"))
         }
 
-        fn extract_text(&self, _page: usize) -> AppResult<String> {
-            Err(AppError::unsupported("not needed in runtime test"))
-        }
-
-        fn extract_positioned_text(&self, _page: usize) -> AppResult<crate::backend::TextPage> {
+        fn extract_text_page(&self, _page: usize) -> AppResult<crate::backend::TextPage> {
             Err(AppError::unsupported("not needed in runtime test"))
         }
 

--- a/src/app/tests/runtime_worker.rs
+++ b/src/app/tests/runtime_worker.rs
@@ -126,11 +126,7 @@ impl PdfBackend for PageDimensionFailingPdf {
         })
     }
 
-    fn extract_text(&self, _page: usize) -> AppResult<String> {
-        Err(AppError::unsupported("not needed in runtime test"))
-    }
-
-    fn extract_positioned_text(&self, _page: usize) -> AppResult<crate::backend::TextPage> {
+    fn extract_text_page(&self, _page: usize) -> AppResult<crate::backend::TextPage> {
         Err(AppError::unsupported("not needed in runtime test"))
     }
 

--- a/src/app/view_ops/mod.rs
+++ b/src/app/view_ops/mod.rs
@@ -780,10 +780,15 @@ mod tests {
             })
         }
 
-        fn extract_text_page(&self, _page: usize) -> crate::error::AppResult<TextPage> {
+        fn extract_text_page(&self, page: usize) -> crate::error::AppResult<TextPage> {
+            let (width_pt, height_pt) = self
+                .dims
+                .get(page)
+                .copied()
+                .ok_or(crate::error::AppError::invalid_argument("out of range"))?;
             Ok(TextPage {
-                width_pt: 612.0,
-                height_pt: 792.0,
+                width_pt,
+                height_pt,
                 glyphs: Vec::new(),
                 dropped_glyphs: 0,
             })

--- a/src/app/view_ops/mod.rs
+++ b/src/app/view_ops/mod.rs
@@ -780,11 +780,7 @@ mod tests {
             })
         }
 
-        fn extract_text(&self, _page: usize) -> crate::error::AppResult<String> {
-            Ok(String::new())
-        }
-
-        fn extract_positioned_text(&self, _page: usize) -> crate::error::AppResult<TextPage> {
+        fn extract_text_page(&self, _page: usize) -> crate::error::AppResult<TextPage> {
             Ok(TextPage {
                 width_pt: 612.0,
                 height_pt: 792.0,

--- a/src/backend/hayro/document.rs
+++ b/src/backend/hayro/document.rs
@@ -15,7 +15,7 @@ use crate::error::{AppError, AppResult};
 
 use super::PdfDoc;
 use super::outline::extract_outline_nodes;
-use super::text::{extract_positioned_text_with_device, extract_text_with_device};
+use super::text::extract_text_page_with_device;
 
 impl PdfDoc {
     pub fn open(path: impl AsRef<Path>) -> AppResult<Self> {
@@ -142,7 +142,7 @@ impl PdfDoc {
         })
     }
 
-    pub fn extract_text(&self, page: usize) -> AppResult<String> {
+    pub fn extract_text_page(&self, page: usize) -> AppResult<TextPage> {
         if page >= self.page_count() {
             return Err(AppError::invalid_argument("page index is out of range"));
         }
@@ -153,21 +153,7 @@ impl PdfDoc {
             .get(page)
             .ok_or(AppError::invalid_argument("page index is out of range"))?;
 
-        Ok(extract_text_with_device(page_ref).trim().to_owned())
-    }
-
-    pub fn extract_positioned_text(&self, page: usize) -> AppResult<TextPage> {
-        if page >= self.page_count() {
-            return Err(AppError::invalid_argument("page index is out of range"));
-        }
-
-        let page_ref = self
-            .pdf
-            .pages()
-            .get(page)
-            .ok_or(AppError::invalid_argument("page index is out of range"))?;
-
-        Ok(extract_positioned_text_with_device(page_ref))
+        Ok(extract_text_page_with_device(page_ref))
     }
 
     pub fn extract_outline(&self) -> AppResult<Vec<OutlineNode>> {

--- a/src/backend/hayro/mod.rs
+++ b/src/backend/hayro/mod.rs
@@ -53,12 +53,8 @@ impl PdfBackend for PdfDoc {
         })
     }
 
-    fn extract_text(&self, page: usize) -> AppResult<String> {
-        PdfDoc::extract_text(self, page)
-    }
-
-    fn extract_positioned_text(&self, page: usize) -> AppResult<TextPage> {
-        PdfDoc::extract_positioned_text(self, page)
+    fn extract_text_page(&self, page: usize) -> AppResult<TextPage> {
+        PdfDoc::extract_text_page(self, page)
     }
 
     fn extract_outline(&self) -> AppResult<Vec<OutlineNode>> {
@@ -86,10 +82,8 @@ mod tests {
     use crate::backend::{PdfBackend, PdfRect};
 
     use super::{
-        PdfDoc,
-        document::pixel_buffer_from_pixmap,
-        encoding::decode_pdf_text_string,
-        text::{PlainTextExtractDevice, PositionedTextExtractDevice},
+        PdfDoc, document::pixel_buffer_from_pixmap, encoding::decode_pdf_text_string,
+        text::TextPageExtractDevice,
     };
 
     #[test]
@@ -186,13 +180,16 @@ mod tests {
     }
 
     #[test]
-    fn extract_text_returns_page_bucket_text() {
+    fn extract_text_page_returns_page_bucket_text() {
         let file = unique_temp_path("text.pdf");
         fs::write(&file, build_pdf(&["hello world", "second page"]))
             .expect("test file should be created");
 
         let doc = PdfDoc::open(&file).expect("pdf should open");
-        let text = doc.extract_text(0).expect("extract should succeed");
+        let text = doc
+            .extract_text_page(0)
+            .expect("extract should succeed")
+            .plain_text();
         let normalized: String = text.chars().filter(|ch| !ch.is_whitespace()).collect();
         assert!(normalized.contains("helloworld"));
 
@@ -200,7 +197,7 @@ mod tests {
     }
 
     #[test]
-    fn extract_text_does_not_insert_false_space_from_tj_position_gap() {
+    fn extract_text_page_does_not_insert_false_space_from_tj_position_gap() {
         let file = unique_temp_path("tj_gap.pdf");
         fs::write(
             &file,
@@ -209,7 +206,10 @@ mod tests {
         .expect("test file should be created");
 
         let doc = PdfDoc::open(&file).expect("pdf should open");
-        let text = doc.extract_text(0).expect("extract should succeed");
+        let text = doc
+            .extract_text_page(0)
+            .expect("extract should succeed")
+            .plain_text();
         let normalized: String = text.chars().filter(|ch| !ch.is_whitespace()).collect();
         assert!(
             normalized.to_lowercase().contains("helloworld"),
@@ -263,18 +263,8 @@ mod tests {
     }
 
     #[test]
-    fn plain_text_duplicate_filter_preserves_repeated_chars_in_same_glyph_token() {
-        let mut device = PlainTextExtractDevice::default();
-
-        device.push_glyph_text("ll".to_owned(), 10.0, 20.0);
-        device.push_glyph_text("ll".to_owned(), 10.0, 20.0);
-
-        assert_eq!(device.finish(), "ll");
-    }
-
-    #[test]
-    fn positioned_text_duplicate_filter_preserves_repeated_chars_in_same_glyph_token() {
-        let mut device = PositionedTextExtractDevice::default();
+    fn text_page_duplicate_filter_preserves_repeated_chars_in_same_glyph_token() {
+        let mut device = TextPageExtractDevice::default();
         let bbox = Some(PdfRect {
             x0: 1.0,
             y0: 2.0,

--- a/src/backend/hayro/mod.rs
+++ b/src/backend/hayro/mod.rs
@@ -79,12 +79,9 @@ mod tests {
     };
     use crate::error::AppError;
 
-    use crate::backend::{PdfBackend, PdfRect};
+    use crate::backend::PdfBackend;
 
-    use super::{
-        PdfDoc, document::pixel_buffer_from_pixmap, encoding::decode_pdf_text_string,
-        text::TextPageExtractDevice,
-    };
+    use super::{PdfDoc, document::pixel_buffer_from_pixmap, encoding::decode_pdf_text_string};
 
     #[test]
     fn open_rejects_directory_path() {
@@ -192,6 +189,10 @@ mod tests {
             .plain_text();
         let normalized: String = text.chars().filter(|ch| !ch.is_whitespace()).collect();
         assert!(normalized.contains("helloworld"));
+        assert!(
+            !normalized.contains("secondpage"),
+            "page 0 extraction leaked text from another page: {text:?}"
+        );
 
         fs::remove_file(&file).expect("test file should be removed");
     }
@@ -210,9 +211,9 @@ mod tests {
             .extract_text_page(0)
             .expect("extract should succeed")
             .plain_text();
-        let normalized: String = text.chars().filter(|ch| !ch.is_whitespace()).collect();
+        let lower = text.to_lowercase();
         assert!(
-            normalized.to_lowercase().contains("helloworld"),
+            lower.contains("helloworld") && !lower.contains("hello world"),
             "expected stable extraction without false splits, got: {text:?}"
         );
 
@@ -260,24 +261,6 @@ mod tests {
         );
 
         fs::remove_file(&file).expect("test file should be removed");
-    }
-
-    #[test]
-    fn text_page_duplicate_filter_preserves_repeated_chars_in_same_glyph_token() {
-        let mut device = TextPageExtractDevice::default();
-        let bbox = Some(PdfRect {
-            x0: 1.0,
-            y0: 2.0,
-            x1: 3.0,
-            y1: 4.0,
-        });
-
-        device.push_glyph_text("ff".to_owned(), bbox, 10.0, 20.0);
-        device.push_glyph_text("ff".to_owned(), bbox, 10.0, 20.0);
-
-        let text: String = device.glyphs.iter().map(|glyph| glyph.ch).collect();
-        assert_eq!(text, "ff");
-        assert_eq!(device.glyphs.len(), 2);
     }
 
     #[test]

--- a/src/backend/hayro/text.rs
+++ b/src/backend/hayro/text.rs
@@ -10,126 +10,7 @@ use kurbo::{Affine, BezPath, Point, Shape};
 
 use crate::backend::{PdfRect, TextGlyph, TextPage};
 
-pub(super) fn extract_text_with_device(page: &Page<'_>) -> String {
-    let cache = InterpreterCache::new();
-    let mut context = Context::new(
-        page.initial_transform(true).to_kurbo(),
-        page.intersected_crop_box().to_kurbo(),
-        &cache,
-        page.xref(),
-        InterpreterSettings::default(),
-    );
-    let mut device = PlainTextExtractDevice::default();
-    interpret_page(page, &mut context, &mut device);
-    device.finish()
-}
-
-#[derive(Default)]
-pub(super) struct PlainTextExtractDevice {
-    text: String,
-    last_point: Option<Point>,
-    last_glyph: Option<(String, i32, i32)>,
-}
-
-impl PlainTextExtractDevice {
-    pub(super) fn finish(self) -> String {
-        self.text
-    }
-
-    fn push_char(&mut self, ch: char, x: f64, y: f64) {
-        if ch == '\n' || ch == '\r' {
-            push_plain_newline(&mut self.text);
-            self.last_point = Some(Point::new(x, y));
-            return;
-        }
-        if ch.is_whitespace() {
-            push_plain_space(&mut self.text);
-            self.last_point = Some(Point::new(x, y));
-            return;
-        }
-
-        if let Some(last) = self.last_point
-            && (y - last.y).abs() > PLAIN_TEXT_LINE_BREAK_THRESHOLD
-        {
-            push_plain_newline(&mut self.text);
-        }
-
-        self.text.push(ch);
-        self.last_point = Some(Point::new(x, y));
-    }
-
-    pub(super) fn push_glyph_text(&mut self, text: String, x: f64, y: f64) {
-        if self.is_duplicate_glyph(&text, x, y) {
-            return;
-        }
-
-        for ch in text.chars() {
-            self.push_char(ch, x, y);
-        }
-        self.set_last_glyph(text, x, y);
-    }
-
-    fn is_duplicate_glyph(&self, text: &str, x: f64, y: f64) -> bool {
-        self.last_glyph
-            .as_ref()
-            .is_some_and(|(last, last_x, last_y)| {
-                last == text && *last_x == quantize_coord(x) && *last_y == quantize_coord(y)
-            })
-    }
-
-    fn set_last_glyph(&mut self, text: String, x: f64, y: f64) {
-        self.last_glyph = Some((text, quantize_coord(x), quantize_coord(y)));
-    }
-}
-
-impl<'a> Device<'a> for PlainTextExtractDevice {
-    fn set_soft_mask(&mut self, _mask: Option<SoftMask<'a>>) {}
-
-    fn set_blend_mode(&mut self, _blend_mode: BlendMode) {}
-
-    fn draw_path(
-        &mut self,
-        _path: &BezPath,
-        _transform: Affine,
-        _paint: &Paint<'a>,
-        _draw_mode: &PathDrawMode,
-    ) {
-    }
-
-    fn push_clip_path(&mut self, _clip_path: &ClipPath) {}
-
-    fn push_transparency_group(
-        &mut self,
-        _opacity: f32,
-        _mask: Option<SoftMask<'a>>,
-        _blend_mode: BlendMode,
-    ) {
-    }
-
-    fn draw_glyph(
-        &mut self,
-        glyph: &Glyph<'a>,
-        transform: Affine,
-        glyph_transform: Affine,
-        _paint: &Paint<'a>,
-        _draw_mode: &GlyphDrawMode,
-    ) {
-        let Some(ch) = glyph.as_unicode() else {
-            return;
-        };
-
-        let position = (transform * glyph_transform) * Point::ORIGIN;
-        self.push_glyph_text(bf_string_text(ch), position.x, position.y);
-    }
-
-    fn draw_image(&mut self, _image: Image<'a, '_>, _transform: Affine) {}
-
-    fn pop_clip_path(&mut self) {}
-
-    fn pop_transparency_group(&mut self) {}
-}
-
-pub(super) fn extract_positioned_text_with_device(page: &Page<'_>) -> TextPage {
+pub(super) fn extract_text_page_with_device(page: &Page<'_>) -> TextPage {
     let cache = InterpreterCache::new();
     let mut context = Context::new(
         page.initial_transform(true).to_kurbo(),
@@ -139,19 +20,19 @@ pub(super) fn extract_positioned_text_with_device(page: &Page<'_>) -> TextPage {
         InterpreterSettings::default(),
     );
     let (width_pt, height_pt) = page.render_dimensions();
-    let mut device = PositionedTextExtractDevice::default();
+    let mut device = TextPageExtractDevice::default();
     interpret_page(page, &mut context, &mut device);
     device.finish(width_pt, height_pt)
 }
 
 #[derive(Default)]
-pub(super) struct PositionedTextExtractDevice {
+pub(super) struct TextPageExtractDevice {
     last_glyph: Option<(String, i32, i32)>,
     pub(super) glyphs: Vec<TextGlyph>,
     dropped_glyphs: usize,
 }
 
-impl PositionedTextExtractDevice {
+impl TextPageExtractDevice {
     pub(super) fn finish(self, width_pt: f32, height_pt: f32) -> TextPage {
         TextPage {
             width_pt,
@@ -184,7 +65,7 @@ impl PositionedTextExtractDevice {
     }
 }
 
-impl<'a> Device<'a> for PositionedTextExtractDevice {
+impl<'a> Device<'a> for TextPageExtractDevice {
     fn set_soft_mask(&mut self, _mask: Option<SoftMask<'a>>) {}
 
     fn set_blend_mode(&mut self, _blend_mode: BlendMode) {}
@@ -237,20 +118,6 @@ impl<'a> Device<'a> for PositionedTextExtractDevice {
 
 fn quantize_coord(value: f64) -> i32 {
     (value * 100.0).round() as i32
-}
-
-const PLAIN_TEXT_LINE_BREAK_THRESHOLD: f64 = 6.0;
-
-fn push_plain_newline(out: &mut String) {
-    if !out.is_empty() && !out.ends_with('\n') {
-        out.push('\n');
-    }
-}
-
-fn push_plain_space(out: &mut String) {
-    if !out.ends_with([' ', '\n']) {
-        out.push(' ');
-    }
 }
 
 fn glyph_bbox(glyph: &Glyph<'_>, transform: Affine, glyph_transform: Affine) -> Option<PdfRect> {

--- a/src/backend/hayro/text.rs
+++ b/src/backend/hayro/text.rs
@@ -26,14 +26,14 @@ pub(super) fn extract_text_page_with_device(page: &Page<'_>) -> TextPage {
 }
 
 #[derive(Default)]
-pub(super) struct TextPageExtractDevice {
+struct TextPageExtractDevice {
     last_glyph: Option<(String, i32, i32)>,
-    pub(super) glyphs: Vec<TextGlyph>,
+    glyphs: Vec<TextGlyph>,
     dropped_glyphs: usize,
 }
 
 impl TextPageExtractDevice {
-    pub(super) fn finish(self, width_pt: f32, height_pt: f32) -> TextPage {
+    fn finish(self, width_pt: f32, height_pt: f32) -> TextPage {
         TextPage {
             width_pt,
             height_pt,
@@ -42,11 +42,14 @@ impl TextPageExtractDevice {
         }
     }
 
-    pub(super) fn push_glyph_text(&mut self, text: String, bbox: Option<PdfRect>, x: f64, y: f64) {
+    fn push_glyph_text(&mut self, text: String, bbox: Option<PdfRect>, x: f64, y: f64) {
         if self.is_duplicate_glyph(&text, x, y) {
             return;
         }
 
+        if bbox.is_none() {
+            self.dropped_glyphs += text.chars().count();
+        }
         self.glyphs
             .extend(text.chars().map(|ch| TextGlyph { ch, bbox }));
         self.set_last_glyph(text, x, y);
@@ -103,9 +106,6 @@ impl<'a> Device<'a> for TextPageExtractDevice {
 
         let position = (transform * glyph_transform) * Point::ORIGIN;
         let bbox = glyph_bbox(glyph, transform, glyph_transform);
-        if bbox.is_none() {
-            self.dropped_glyphs += 1;
-        }
         self.push_glyph_text(bf_string_text(ch), bbox, position.x, position.y);
     }
 
@@ -142,5 +142,40 @@ fn bf_string_text(value: BfString) -> String {
     match value {
         BfString::Char(ch) => ch.to_string(),
         BfString::String(text) => text,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PdfRect, TextPageExtractDevice};
+
+    #[test]
+    fn duplicate_filter_preserves_repeated_chars_in_same_glyph_token() {
+        let mut device = TextPageExtractDevice::default();
+        let bbox = Some(PdfRect {
+            x0: 1.0,
+            y0: 2.0,
+            x1: 3.0,
+            y1: 4.0,
+        });
+
+        device.push_glyph_text("ff".to_owned(), bbox, 10.0, 20.0);
+        device.push_glyph_text("ff".to_owned(), bbox, 10.0, 20.0);
+
+        let text: String = device.glyphs.iter().map(|glyph| glyph.ch).collect();
+        assert_eq!(text, "ff");
+        assert_eq!(device.glyphs.len(), 2);
+    }
+
+    #[test]
+    fn dropped_glyph_count_matches_emitted_unbounded_glyphs() {
+        let mut device = TextPageExtractDevice::default();
+
+        device.push_glyph_text("ffi".to_owned(), None, 10.0, 20.0);
+        device.push_glyph_text("ffi".to_owned(), None, 10.0, 20.0);
+
+        let page = device.finish(100.0, 100.0);
+        assert_eq!(page.glyphs.len(), 3);
+        assert_eq!(page.dropped_glyphs, 3);
     }
 }

--- a/src/backend/traits.rs
+++ b/src/backend/traits.rs
@@ -175,63 +175,8 @@ pub struct TextPage {
 }
 
 impl TextPage {
-    pub fn extracted_text(&self) -> String {
-        let mut out = String::new();
-        let mut last_rect: Option<PdfRect> = None;
-        for glyph in &self.glyphs {
-            push_extracted_char(&mut out, glyph.ch, glyph.bbox, &mut last_rect);
-        }
-        out.trim().to_owned()
-    }
-}
-
-const LINE_BREAK_THRESHOLD: f32 = 6.0;
-
-fn push_extracted_char(
-    out: &mut String,
-    ch: char,
-    bbox: Option<PdfRect>,
-    last_rect: &mut Option<PdfRect>,
-) {
-    if ch == '\n' || ch == '\r' {
-        push_newline(out);
-        if bbox.is_some() {
-            *last_rect = bbox;
-        }
-        return;
-    }
-    if ch.is_whitespace() {
-        push_space(out);
-        if bbox.is_some() {
-            *last_rect = bbox;
-        }
-        return;
-    }
-
-    if let (Some(last), Some(bbox)) = (*last_rect, bbox)
-        && (bbox.y0 - last.y0).abs() > LINE_BREAK_THRESHOLD
-    {
-        push_newline(out);
-    }
-
-    out.push(ch);
-    if bbox.is_some() {
-        *last_rect = bbox;
-    }
-}
-
-fn push_newline(out: &mut String) {
-    while out.ends_with(' ') {
-        out.pop();
-    }
-    if !out.is_empty() && !out.ends_with('\n') {
-        out.push('\n');
-    }
-}
-
-fn push_space(out: &mut String) {
-    if !out.ends_with([' ', '\n']) {
-        out.push(' ');
+    pub fn plain_text(&self) -> String {
+        self.glyphs.iter().map(|glyph| glyph.ch).collect()
     }
 }
 
@@ -244,8 +189,7 @@ pub trait PdfBackend: Send + Sync {
     fn render_context(&self) -> Box<dyn PdfRenderContext + '_> {
         Box::new(DefaultPdfRenderContext { backend: self })
     }
-    fn extract_text(&self, page: usize) -> AppResult<String>;
-    fn extract_positioned_text(&self, page: usize) -> AppResult<TextPage>;
+    fn extract_text_page(&self, page: usize) -> AppResult<TextPage>;
     fn extract_outline(&self) -> AppResult<Vec<OutlineNode>>;
 }
 
@@ -331,47 +275,32 @@ mod tests {
     fn _assert_pdf_backend_object_safe(_: &dyn PdfBackend) {}
 
     #[test]
-    fn text_page_extracted_text_preserves_line_breaks() {
+    fn text_page_plain_text_preserves_glyph_stream_text() {
         let page = TextPage {
             width_pt: 100.0,
             height_pt: 100.0,
             glyphs: vec![
                 TextGlyph {
                     ch: 'A',
-                    bbox: Some(PdfRect {
-                        x0: 1.0,
-                        y0: 1.0,
-                        x1: 2.0,
-                        y1: 2.0,
-                    }),
+                    bbox: None,
                 },
                 TextGlyph {
                     ch: ' ',
-                    bbox: Some(PdfRect {
-                        x0: 3.0,
-                        y0: 1.0,
-                        x1: 4.0,
-                        y1: 2.0,
-                    }),
+                    bbox: None,
                 },
                 TextGlyph {
                     ch: 'B',
-                    bbox: Some(PdfRect {
-                        x0: 1.0,
-                        y0: 20.0,
-                        x1: 2.0,
-                        y1: 21.0,
-                    }),
+                    bbox: None,
                 },
             ],
             dropped_glyphs: 0,
         };
 
-        assert_eq!(page.extracted_text(), "A\nB");
+        assert_eq!(page.plain_text(), "A B");
     }
 
     #[test]
-    fn text_page_extracted_text_keeps_line_context_across_unbounded_space() {
+    fn text_page_plain_text_does_not_infer_line_breaks_from_geometry() {
         let page = TextPage {
             width_pt: 100.0,
             height_pt: 100.0,
@@ -402,6 +331,6 @@ mod tests {
             dropped_glyphs: 1,
         };
 
-        assert_eq!(page.extracted_text(), "A\nB");
+        assert_eq!(page.plain_text(), "A B");
     }
 }

--- a/src/command/catalog.rs
+++ b/src/command/catalog.rs
@@ -908,12 +908,7 @@ mod tests {
                 pixels: vec![0; 4].into(),
             })
         }
-
-        fn extract_text(&self, _page: usize) -> crate::error::AppResult<String> {
-            Ok(String::new())
-        }
-
-        fn extract_positioned_text(&self, _page: usize) -> crate::error::AppResult<TextPage> {
+        fn extract_text_page(&self, _page: usize) -> crate::error::AppResult<TextPage> {
             Ok(TextPage {
                 width_pt: 612.0,
                 height_pt: 792.0,

--- a/src/command/dispatch.rs
+++ b/src/command/dispatch.rs
@@ -315,12 +315,7 @@ mod tests {
                 pixels: vec![0; 4].into(),
             })
         }
-
-        fn extract_text(&self, _page: usize) -> crate::error::AppResult<String> {
-            Ok(String::new())
-        }
-
-        fn extract_positioned_text(&self, _page: usize) -> crate::error::AppResult<TextPage> {
+        fn extract_text_page(&self, _page: usize) -> crate::error::AppResult<TextPage> {
             Ok(TextPage {
                 width_pt: 612.0,
                 height_pt: 792.0,

--- a/src/extension/host.rs
+++ b/src/extension/host.rs
@@ -273,12 +273,7 @@ mod tests {
                 pixels: vec![0, 0, 0, 0].into(),
             })
         }
-
-        fn extract_text(&self, _page: usize) -> crate::error::AppResult<String> {
-            Ok(String::new())
-        }
-
-        fn extract_positioned_text(&self, _page: usize) -> crate::error::AppResult<TextPage> {
+        fn extract_text_page(&self, _page: usize) -> crate::error::AppResult<TextPage> {
             Ok(TextPage {
                 width_pt: 612.0,
                 height_pt: 792.0,

--- a/src/outline/state.rs
+++ b/src/outline/state.rs
@@ -134,12 +134,7 @@ mod tests {
                 pixels: vec![0, 0, 0, 0].into(),
             })
         }
-
-        fn extract_text(&self, _page: usize) -> crate::error::AppResult<String> {
-            Ok(String::new())
-        }
-
-        fn extract_positioned_text(&self, _page: usize) -> crate::error::AppResult<TextPage> {
+        fn extract_text_page(&self, _page: usize) -> crate::error::AppResult<TextPage> {
             Ok(TextPage {
                 width_pt: 1.0,
                 height_pt: 1.0,

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -37,8 +37,9 @@ pub enum SearchEvent {
         occurrences: Vec<SearchOccurrence>,
         highlight_unavailable: bool,
     },
-    Failed {
+    PageSkipped {
         generation: u64,
+        page: usize,
         message: String,
     },
 }

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -208,18 +208,6 @@ impl SearchMatcher for CancelMatcher {
         String::new()
     }
 
-    fn matches_page(&self, _page_text: &str, _prepared_query: &str) -> bool {
-        false
-    }
-
-    fn locate_text_matches(
-        &self,
-        _page_text: &str,
-        _prepared_query: &str,
-    ) -> Vec<SearchOccurrence> {
-        Vec::new()
-    }
-
     fn locate_matches(&self, _page: &TextPage, _prepared_query: &str) -> Vec<SearchOccurrence> {
         Vec::new()
     }

--- a/src/search/matcher.rs
+++ b/src/search/matcher.rs
@@ -8,8 +8,6 @@ use super::engine::SearchOccurrence;
 
 pub trait SearchMatcher: Send + Sync {
     fn prepare_query(&self, raw_query: &str) -> String;
-    fn matches_page(&self, page_text: &str, prepared_query: &str) -> bool;
-    fn locate_text_matches(&self, page_text: &str, prepared_query: &str) -> Vec<SearchOccurrence>;
     fn locate_matches(&self, page: &TextPage, prepared_query: &str) -> Vec<SearchOccurrence>;
 }
 
@@ -29,14 +27,6 @@ impl SearchMatcher for ContainsMatcher {
         prepare_contains_query(raw_query, self.case_sensitive)
     }
 
-    fn matches_page(&self, page_text: &str, prepared_query: &str) -> bool {
-        page_matches_contains(page_text, prepared_query, self.case_sensitive)
-    }
-
-    fn locate_text_matches(&self, page_text: &str, prepared_query: &str) -> Vec<SearchOccurrence> {
-        locate_text_occurrences(page_text, prepared_query, self.case_sensitive)
-    }
-
     fn locate_matches(&self, page: &TextPage, prepared_query: &str) -> Vec<SearchOccurrence> {
         locate_occurrences(&page.glyphs, prepared_query, self.case_sensitive)
     }
@@ -44,21 +34,6 @@ impl SearchMatcher for ContainsMatcher {
 
 pub(crate) fn prepare_contains_query(raw_query: &str, case_sensitive: bool) -> String {
     normalize_text_for_search(raw_query, case_sensitive, false)
-}
-
-pub(crate) fn page_matches_contains(
-    page_text: &str,
-    prepared_query: &str,
-    case_sensitive: bool,
-) -> bool {
-    let prepared_page = normalize_text_for_search(page_text, case_sensitive, false);
-    if prepared_page.contains(prepared_query) {
-        return true;
-    }
-
-    let whitespace_insensitive_page = normalize_text_for_search(page_text, case_sensitive, true);
-    let whitespace_insensitive_query = normalize_text_for_search(prepared_query, true, true);
-    whitespace_insensitive_page.contains(&whitespace_insensitive_query)
 }
 
 pub(crate) fn locate_occurrences(
@@ -73,20 +48,6 @@ pub(crate) fn locate_occurrences(
     }
 
     locate_occurrences_with_strategy(glyphs, prepared_query, case_sensitive, true)
-}
-
-pub(crate) fn locate_text_occurrences(
-    text: &str,
-    prepared_query: &str,
-    case_sensitive: bool,
-) -> Vec<SearchOccurrence> {
-    let occurrences =
-        locate_text_occurrences_with_strategy(text, prepared_query, case_sensitive, false);
-    if !occurrences.is_empty() {
-        return occurrences;
-    }
-
-    locate_text_occurrences_with_strategy(text, prepared_query, case_sensitive, true)
 }
 
 pub(crate) fn occurrence_highlight_unavailable(
@@ -163,38 +124,6 @@ fn build_hit_snippet(
     )
 }
 
-fn build_text_hit_snippet(text: &str, char_start: usize, char_end: usize) -> SnippetPresentation {
-    const CONTEXT_CHARS: usize = 16;
-
-    let chars: Vec<char> = text.chars().collect();
-    if chars.is_empty() || char_start >= chars.len() || char_end < char_start {
-        return SnippetPresentation {
-            text: String::new(),
-            match_start: None,
-            match_end: None,
-        };
-    }
-
-    let char_end = char_end.min(chars.len() - 1);
-    let context_start = char_start.saturating_sub(CONTEXT_CHARS);
-    let context_end = char_end
-        .saturating_add(CONTEXT_CHARS)
-        .saturating_add(1)
-        .min(chars.len());
-
-    let before = chars[context_start..char_start].iter().collect::<String>();
-    let matched = chars[char_start..=char_end].iter().collect::<String>();
-    let after = chars[char_end + 1..context_end].iter().collect::<String>();
-
-    build_snippet_text(
-        before,
-        matched,
-        after,
-        context_start > 0,
-        context_end < chars.len(),
-    )
-}
-
 fn build_snippet_text(
     before: String,
     matched: String,
@@ -226,86 +155,6 @@ fn build_snippet_text(
         match_start,
         match_end,
     }
-}
-
-fn locate_text_occurrences_with_strategy(
-    text: &str,
-    prepared_query: &str,
-    case_sensitive: bool,
-    ignore_whitespace: bool,
-) -> Vec<SearchOccurrence> {
-    if prepared_query.is_empty() {
-        return Vec::new();
-    }
-
-    let (search_text, char_map) =
-        normalize_text_with_char_map(text, case_sensitive, ignore_whitespace);
-    if search_text.is_empty() {
-        return Vec::new();
-    }
-
-    let query_text = normalize_text_for_search(prepared_query, true, ignore_whitespace);
-    if query_text.is_empty() || query_text.len() > search_text.len() {
-        return Vec::new();
-    }
-
-    let char_byte_offsets: Vec<usize> = search_text
-        .char_indices()
-        .map(|(offset, _)| offset)
-        .collect();
-    let query_char_len = query_text.chars().count();
-    if query_char_len == 0 || query_char_len > char_map.len() {
-        return Vec::new();
-    }
-
-    let mut occurrences = Vec::new();
-    let mut cursor_byte = 0;
-    while cursor_byte <= search_text.len() {
-        let Some(relative_match_byte) = search_text[cursor_byte..].find(&query_text) else {
-            break;
-        };
-        let match_byte = cursor_byte + relative_match_byte;
-        let match_char_start = char_byte_offsets
-            .binary_search(&match_byte)
-            .expect("str::find returned a non-character-boundary offset");
-        let char_start = char_map[match_char_start];
-        let char_end = char_map[match_char_start + query_char_len - 1];
-        let snippet = build_text_hit_snippet(text, char_start, char_end);
-        occurrences.push(SearchOccurrence {
-            match_start: char_start,
-            match_end: char_end,
-            rects: Vec::new(),
-            snippet: snippet.text,
-            snippet_match_start: snippet.match_start,
-            snippet_match_end: snippet.match_end,
-        });
-        cursor_byte = match_byte + query_text.len();
-    }
-
-    occurrences
-}
-
-fn normalize_text_with_char_map(
-    text: &str,
-    case_sensitive: bool,
-    ignore_whitespace: bool,
-) -> (String, Vec<usize>) {
-    let mut search_text = String::new();
-    let mut char_map = Vec::new();
-
-    for (char_index, ch) in text.chars().enumerate() {
-        if ignore_whitespace && ch.is_whitespace() {
-            continue;
-        }
-        push_normalized_chars(ch, case_sensitive, |normalized| {
-            if !ignore_whitespace || !normalized.is_whitespace() {
-                search_text.push(normalized);
-                char_map.push(char_index);
-            }
-        });
-    }
-
-    (search_text, char_map)
 }
 
 fn locate_occurrences_with_strategy(

--- a/src/search/state.rs
+++ b/src/search/state.rs
@@ -166,6 +166,7 @@ impl Default for SearchState {
 
 impl SearchState {
     const HIGHLIGHT_UNAVAILABLE_NOTICE: &str = "some search highlights are unavailable";
+    const PAGE_SKIPPED_NOTICE: &str = "some pages could not be searched";
 
     pub fn open_palette(&mut self) -> PaletteRequest {
         let payload = if self.query.is_empty() {
@@ -355,18 +356,15 @@ impl SearchState {
                         changed = true;
                     }
                 }
-                SearchEvent::Failed {
+                SearchEvent::PageSkipped {
                     generation,
-                    message,
+                    page: _,
+                    message: _,
                 } => {
                     if generation != self.generation {
                         continue;
                     }
-                    self.in_progress = false;
-                    self.last_error = Some(message.clone());
-                    app.apply_notice_action(NoticeAction::error(format!(
-                        "search failed: {message}"
-                    )));
+                    app.apply_notice_action(NoticeAction::warning(Self::PAGE_SKIPPED_NOTICE));
                     changed = true;
                 }
             }

--- a/src/search/state.rs
+++ b/src/search/state.rs
@@ -556,7 +556,6 @@ mod tests {
     use crate::app::{AppState, NoticeAction, NoticeLevel, PageLayoutMode, PaletteRequest};
     use crate::backend::{PdfBackend, RgbaFrame, SharedPdfBackend, TextPage};
     use crate::command::{CommandOutcome, SearchMatcherKind};
-    use crate::error::AppError;
     use crate::palette::{PaletteKind, PaletteOpenPayload};
     use crate::search::engine::{SearchEngine, SearchPageHit};
 
@@ -600,12 +599,7 @@ mod tests {
                 pixels: vec![0, 0, 0, 0].into(),
             })
         }
-
-        fn extract_text(&self, _page: usize) -> crate::error::AppResult<String> {
-            Ok(String::new())
-        }
-
-        fn extract_positioned_text(&self, _page: usize) -> crate::error::AppResult<TextPage> {
+        fn extract_text_page(&self, _page: usize) -> crate::error::AppResult<TextPage> {
             Ok(TextPage {
                 width_pt: 612.0,
                 height_pt: 792.0,
@@ -621,14 +615,22 @@ mod tests {
 
     struct HighlightUnavailableStubPdf {
         path: PathBuf,
-        text: String,
+        page: TextPage,
     }
 
     impl HighlightUnavailableStubPdf {
         fn new(text: &str) -> Self {
             Self {
                 path: PathBuf::from("highlight-unavailable.pdf"),
-                text: text.to_string(),
+                page: TextPage {
+                    width_pt: 612.0,
+                    height_pt: 792.0,
+                    glyphs: text
+                        .chars()
+                        .map(|ch| crate::backend::TextGlyph { ch, bbox: None })
+                        .collect(),
+                    dropped_glyphs: text.chars().count(),
+                },
             }
         }
     }
@@ -657,13 +659,8 @@ mod tests {
                 pixels: vec![0, 0, 0, 0].into(),
             })
         }
-
-        fn extract_text(&self, _page: usize) -> crate::error::AppResult<String> {
-            Ok(self.text.clone())
-        }
-
-        fn extract_positioned_text(&self, _page: usize) -> crate::error::AppResult<TextPage> {
-            Err(AppError::unsupported("positioned text unavailable"))
+        fn extract_text_page(&self, _page: usize) -> crate::error::AppResult<TextPage> {
+            Ok(self.page.clone())
         }
 
         fn extract_outline(&self) -> crate::error::AppResult<Vec<crate::backend::OutlineNode>> {

--- a/src/search/worker.rs
+++ b/src/search/worker.rs
@@ -82,16 +82,9 @@ struct BudgetedPageCache<V> {
     memory_bytes: usize,
 }
 
-struct SearchTextCache {
-    pages: BudgetedPageCache<Arc<str>>,
-}
-
-struct SearchGeometryCache {
+struct SearchPageCache {
     pages: BudgetedPageCache<Arc<TextPage>>,
 }
-
-#[cfg(test)]
-type SearchPageCache = SearchGeometryCache;
 
 impl<V> BudgetedPageCache<V> {
     fn with_limits(max_entries: usize, memory_budget_bytes: usize) -> Self {
@@ -173,32 +166,7 @@ impl<V> BudgetedPageCache<V> {
     }
 }
 
-impl SearchTextCache {
-    const DEFAULT_MAX_ENTRIES: usize = 16_384;
-    const DEFAULT_MEMORY_BUDGET_BYTES: usize = 48 * 1024 * 1024;
-
-    fn new() -> Self {
-        Self::with_limits(Self::DEFAULT_MAX_ENTRIES, Self::DEFAULT_MEMORY_BUDGET_BYTES)
-    }
-
-    fn with_limits(max_entries: usize, memory_budget_bytes: usize) -> Self {
-        Self {
-            pages: BudgetedPageCache::with_limits(max_entries, memory_budget_bytes),
-        }
-    }
-
-    fn get(&mut self, doc_id: u64, page: usize) -> Option<Arc<str>> {
-        self.pages.get(doc_id, page).map(Arc::clone)
-    }
-
-    fn try_insert_without_eviction(&mut self, doc_id: u64, page: usize, text: Arc<str>) -> bool {
-        let estimated_bytes = estimate_search_text_bytes(&text);
-        self.pages
-            .try_insert_without_eviction(doc_id, page, text, estimated_bytes)
-    }
-}
-
-impl SearchGeometryCache {
+impl SearchPageCache {
     const DEFAULT_MAX_ENTRIES: usize = 16_384;
     const DEFAULT_MEMORY_BUDGET_BYTES: usize = 16 * 1024 * 1024;
 
@@ -243,16 +211,6 @@ impl SearchGeometryCache {
     }
 }
 
-#[cfg(test)]
-pub(crate) fn estimate_search_text_bytes(text: &Arc<str>) -> usize {
-    size_of::<Arc<str>>() + text.len()
-}
-
-#[cfg(not(test))]
-fn estimate_search_text_bytes(text: &Arc<str>) -> usize {
-    size_of::<Arc<str>>() + text.len()
-}
-
 fn estimate_text_page_bytes(text_page: &TextPage) -> usize {
     size_of::<TextPage>() + text_page.glyphs.len() * size_of::<TextGlyph>()
 }
@@ -262,8 +220,7 @@ pub(crate) fn worker_main(
     event_tx: UnboundedSender<SearchEvent>,
 ) {
     let mut pending = PendingWorkerWork::default();
-    let mut text_cache = SearchTextCache::new();
-    let mut geometry_cache = SearchGeometryCache::new();
+    let mut page_cache = SearchPageCache::new();
     let mut prewarm_finished_doc_ids = HashSet::new();
 
     loop {
@@ -279,8 +236,7 @@ pub(crate) fn worker_main(
                     &mut request_rx,
                     &event_tx,
                     &mut pending,
-                    &mut text_cache,
-                    &mut geometry_cache,
+                    &mut page_cache,
                 ) {
                     WorkerControl::Continue => {}
                     WorkerControl::Shutdown => break,
@@ -296,8 +252,7 @@ pub(crate) fn worker_main(
                     job,
                     &mut request_rx,
                     &mut pending,
-                    &mut text_cache,
-                    &mut geometry_cache,
+                    &mut page_cache,
                     &mut prewarm_finished_doc_ids,
                 ) {
                     PrewarmControl::Finished => {}
@@ -314,8 +269,7 @@ pub(crate) fn worker_main(
                         &mut request_rx,
                         &event_tx,
                         &mut pending,
-                        &mut text_cache,
-                        &mut geometry_cache,
+                        &mut page_cache,
                     ) {
                         WorkerControl::Continue => {}
                         WorkerControl::Shutdown => break,
@@ -327,8 +281,7 @@ pub(crate) fn worker_main(
                         job,
                         &mut request_rx,
                         &mut pending,
-                        &mut text_cache,
-                        &mut geometry_cache,
+                        &mut page_cache,
                         &mut prewarm_finished_doc_ids,
                     ) {
                         PrewarmControl::Finished => {}
@@ -346,8 +299,7 @@ pub(crate) fn worker_main(
             &mut request_rx,
             &event_tx,
             &mut pending,
-            &mut text_cache,
-            &mut geometry_cache,
+            &mut page_cache,
         ) {
             WorkerControl::Continue => {}
             WorkerControl::Shutdown => break,
@@ -374,8 +326,7 @@ fn run_prewarm_job(
     job: PrewarmJob,
     request_rx: &mut UnboundedReceiver<WorkerRequest>,
     pending: &mut PendingWorkerWork,
-    text_cache: &mut SearchTextCache,
-    geometry_cache: &mut SearchGeometryCache,
+    page_cache: &mut SearchPageCache,
     prewarm_finished_doc_ids: &mut HashSet<u64>,
 ) -> PrewarmControl {
     let doc = job.pdf.clone();
@@ -403,17 +354,15 @@ fn run_prewarm_job(
             }
             WorkerControl::Shutdown => return PrewarmControl::Shutdown,
         }
-        if text_cache.get(doc_id, page).is_some() {
+        if page_cache.get(doc_id, page).is_some() {
             continue;
         }
-        if let Ok(text_page) = doc.extract_positioned_text(page) {
+        if let Ok(text_page) = doc.extract_text_page(page) {
             let text_page = Arc::new(text_page);
-            let text: Arc<str> = Arc::from(text_page.extracted_text());
-            if !text_cache.try_insert_without_eviction(doc_id, page, text) {
+            if !page_cache.try_insert_without_eviction(doc_id, page, text_page) {
                 prewarm_finished_doc_ids.insert(doc_id);
                 break;
             }
-            geometry_cache.try_insert_without_eviction(doc_id, page, text_page);
         }
     }
 
@@ -426,8 +375,7 @@ fn run_job(
     request_rx: &mut UnboundedReceiver<WorkerRequest>,
     event_tx: &UnboundedSender<SearchEvent>,
     pending: &mut PendingWorkerWork,
-    text_cache: &mut SearchTextCache,
-    geometry_cache: &mut SearchGeometryCache,
+    page_cache: &mut SearchPageCache,
 ) -> WorkerControl {
     let query = job.matcher.prepare_query(job.query.trim());
     if query.is_empty() {
@@ -463,57 +411,35 @@ fn run_job(
             WorkerControl::Shutdown => return WorkerControl::Shutdown,
         }
 
-        let page_text = match text_cache.get(doc_id, page) {
-            Some(text) => Ok(text),
-            None => doc.extract_positioned_text(page).map(|text_page| {
+        let text_page = match page_cache.get(doc_id, page) {
+            Some(text_page) => Ok(text_page),
+            None => doc.extract_text_page(page).map(|text_page| {
                 let text_page = Arc::new(text_page);
-                let text: Arc<str> = Arc::from(text_page.extracted_text());
-                text_cache.try_insert_without_eviction(doc_id, page, Arc::clone(&text));
-                geometry_cache.try_insert_without_eviction(doc_id, page, text_page);
-                text
+                page_cache.try_insert_without_eviction(doc_id, page, Arc::clone(&text_page));
+                text_page
             }),
         };
 
-        match page_text {
-            Ok(text) => {
-                let occurrences = match geometry_cache.get(doc_id, page) {
-                    Some(text_page) => {
-                        let mut occurrences =
-                            job.matcher.locate_matches(text_page.as_ref(), &query);
-                        for occurrence in &mut occurrences {
-                            if occurrence_highlight_unavailable(occurrence, &text_page.glyphs) {
-                                highlight_unavailable = true;
-                            }
-                            apply_hit_snippet(occurrence, &text_page.glyphs);
-                        }
-                        occurrences
-                    }
-                    None => job.matcher.locate_text_matches(&text, &query),
-                };
-                if !occurrences.is_empty() {
-                    hits.push(SearchPageHit { page, occurrences });
-                }
+        let text_page = match text_page {
+            Ok(text_page) => text_page,
+            Err(err) => {
+                let _ = event_tx.send(SearchEvent::Failed {
+                    generation: job.generation,
+                    message: err.to_string(),
+                });
+                return WorkerControl::Continue;
             }
-            Err(_) => {
-                let text = match doc.extract_text(page) {
-                    Ok(text) => text,
-                    Err(err) => {
-                        let _ = event_tx.send(SearchEvent::Failed {
-                            generation: job.generation,
-                            message: err.to_string(),
-                        });
-                        return WorkerControl::Continue;
-                    }
-                };
+        };
 
-                if job.matcher.matches_page(&text, &query) {
-                    hits.push(SearchPageHit {
-                        page,
-                        occurrences: Vec::new(),
-                    });
-                    highlight_unavailable = true;
-                }
+        let mut occurrences = job.matcher.locate_matches(text_page.as_ref(), &query);
+        for occurrence in &mut occurrences {
+            if occurrence_highlight_unavailable(occurrence, &text_page.glyphs) {
+                highlight_unavailable = true;
             }
+            apply_hit_snippet(occurrence, &text_page.glyphs);
+        }
+        if !occurrences.is_empty() {
+            hits.push(SearchPageHit { page, occurrences });
         }
 
         let scanned_pages = page + 1;
@@ -540,8 +466,7 @@ fn run_geometry_job(
     request_rx: &mut UnboundedReceiver<WorkerRequest>,
     event_tx: &UnboundedSender<SearchEvent>,
     pending: &mut PendingWorkerWork,
-    text_cache: &mut SearchTextCache,
-    geometry_cache: &mut SearchGeometryCache,
+    page_cache: &mut SearchPageCache,
 ) -> WorkerControl {
     let query = job.matcher.prepare_query(job.query.trim());
     if query.is_empty() {
@@ -571,20 +496,16 @@ fn run_geometry_job(
             WorkerControl::Shutdown => return WorkerControl::Shutdown,
         }
 
-        let positioned_text = match geometry_cache.get(doc_id, page) {
+        let text_page = match page_cache.get(doc_id, page) {
             Some(text_page) => Ok(text_page),
-            None => doc.extract_positioned_text(page).map(|text_page| {
+            None => doc.extract_text_page(page).map(|text_page| {
                 let text_page = Arc::new(text_page);
-                if text_cache.get(doc_id, page).is_none() {
-                    let text: Arc<str> = Arc::from(text_page.extracted_text());
-                    text_cache.try_insert_without_eviction(doc_id, page, text);
-                }
-                geometry_cache.insert(doc_id, page, Arc::clone(&text_page));
+                page_cache.insert(doc_id, page, Arc::clone(&text_page));
                 text_page
             }),
         };
 
-        let Ok(text_page) = positioned_text else {
+        let Ok(text_page) = text_page else {
             continue;
         };
 
@@ -643,8 +564,7 @@ mod tests {
     use tokio::sync::mpsc::unbounded_channel;
 
     use super::{
-        PendingWorkerWork, PrewarmControl, PrewarmJob, SearchGeometryCache, SearchJob,
-        SearchPageCache, SearchTextCache, WorkerRequest, estimate_search_text_bytes,
+        PendingWorkerWork, PrewarmControl, PrewarmJob, SearchJob, SearchPageCache, WorkerRequest,
         estimate_text_page_bytes, run_prewarm_job,
     };
     use crate::backend::{OutlineNode, PdfBackend, PdfRect, RgbaFrame, TextGlyph, TextPage};
@@ -652,33 +572,33 @@ mod tests {
     use crate::error::{AppError, AppResult};
     use crate::search::matcher::matcher_for_kind;
 
-    struct CountingPositionedStubPdf {
+    struct CountingTextPageStubPdf {
         path: PathBuf,
         doc_id: u64,
         pages: Vec<TextPage>,
-        positioned_calls: Mutex<Vec<usize>>,
+        text_page_calls: Mutex<Vec<usize>>,
     }
 
-    impl CountingPositionedStubPdf {
+    impl CountingTextPageStubPdf {
         fn new(doc_id: u64, pages: Vec<TextPage>) -> Self {
             let page_count = pages.len();
             Self {
-                path: PathBuf::from(format!("counting-positioned-{doc_id}.pdf")),
+                path: PathBuf::from(format!("counting-text-page-{doc_id}.pdf")),
                 doc_id,
                 pages,
-                positioned_calls: Mutex::new(vec![0; page_count]),
+                text_page_calls: Mutex::new(vec![0; page_count]),
             }
         }
 
-        fn positioned_calls(&self) -> Vec<usize> {
-            self.positioned_calls
+        fn text_page_calls(&self) -> Vec<usize> {
+            self.text_page_calls
                 .lock()
-                .expect("positioned calls lock should not be poisoned")
+                .expect("text page calls lock should not be poisoned")
                 .clone()
         }
     }
 
-    impl PdfBackend for CountingPositionedStubPdf {
+    impl PdfBackend for CountingTextPageStubPdf {
         fn path(&self) -> &Path {
             &self.path
         }
@@ -699,15 +619,11 @@ mod tests {
             Err(AppError::unsupported("not needed in search test"))
         }
 
-        fn extract_text(&self, page: usize) -> AppResult<String> {
-            Ok(self.pages[page].extracted_text())
-        }
-
-        fn extract_positioned_text(&self, page: usize) -> AppResult<TextPage> {
+        fn extract_text_page(&self, page: usize) -> AppResult<TextPage> {
             let mut calls = self
-                .positioned_calls
+                .text_page_calls
                 .lock()
-                .expect("positioned calls lock should not be poisoned");
+                .expect("text page calls lock should not be poisoned");
             calls[page] += 1;
             Ok(self.pages[page].clone())
         }
@@ -789,7 +705,7 @@ mod tests {
             cache
                 .get(1, 0)
                 .expect("replacement page should exist")
-                .extracted_text(),
+                .plain_text(),
             "alpha"
         );
         assert_eq!(cache.memory_bytes(), expected_bytes);
@@ -805,14 +721,14 @@ mod tests {
             cache
                 .get(1, 0)
                 .expect("doc 1 page should exist")
-                .extracted_text(),
+                .plain_text(),
             "alpha"
         );
         assert_eq!(
             cache
                 .get(2, 0)
                 .expect("doc 2 page should exist")
-                .extracted_text(),
+                .plain_text(),
             "beta"
         );
     }
@@ -848,16 +764,15 @@ mod tests {
     fn prewarm_does_not_retry_after_memory_budget_is_reached() {
         let first_page = text_page("alpha");
         let second_page = text_page("beta gamma");
-        let budget = estimate_search_text_bytes(&Arc::from(first_page.extracted_text()));
-        let pdf = Arc::new(CountingPositionedStubPdf::new(
+        let budget = estimate_text_page_bytes(&first_page);
+        let pdf = Arc::new(CountingTextPageStubPdf::new(
             302,
             vec![first_page, second_page],
         ));
         let (_request_tx, request_rx) = unbounded_channel();
         let mut request_rx = request_rx;
         let mut pending = PendingWorkerWork::default();
-        let mut text_cache = SearchTextCache::with_limits(4, budget);
-        let mut geometry_cache = SearchGeometryCache::with_limits(4, usize::MAX);
+        let mut page_cache = SearchPageCache::with_limits(4, budget);
         let mut prewarm_finished_doc_ids = HashSet::new();
 
         assert!(matches!(
@@ -865,39 +780,36 @@ mod tests {
                 PrewarmJob { pdf: pdf.clone() },
                 &mut request_rx,
                 &mut pending,
-                &mut text_cache,
-                &mut geometry_cache,
+                &mut page_cache,
                 &mut prewarm_finished_doc_ids,
             ),
             PrewarmControl::Finished
         ));
-        assert_eq!(pdf.positioned_calls(), vec![1, 1]);
+        assert_eq!(pdf.text_page_calls(), vec![1, 1]);
 
         assert!(matches!(
             run_prewarm_job(
                 PrewarmJob { pdf: pdf.clone() },
                 &mut request_rx,
                 &mut pending,
-                &mut text_cache,
-                &mut geometry_cache,
+                &mut page_cache,
                 &mut prewarm_finished_doc_ids,
             ),
             PrewarmControl::Finished
         ));
-        assert_eq!(pdf.positioned_calls(), vec![1, 1]);
+        assert_eq!(pdf.text_page_calls(), vec![1, 1]);
     }
 
     #[test]
     fn interrupted_prewarm_can_resume_after_priority_work() {
-        let pdf = Arc::new(CountingPositionedStubPdf::new(
+        let pdf = Arc::new(CountingTextPageStubPdf::new(
             303,
             vec![text_page("alpha"), text_page("beta")],
         ));
         let (request_tx, request_rx) = unbounded_channel();
         let mut request_rx = request_rx;
         let mut pending = PendingWorkerWork::default();
-        let mut text_cache = SearchTextCache::with_limits(4, usize::MAX);
-        let mut geometry_cache = SearchGeometryCache::with_limits(4, usize::MAX);
+        let mut page_cache = SearchPageCache::with_limits(4, usize::MAX);
         let mut prewarm_finished_doc_ids = HashSet::new();
 
         request_tx
@@ -913,8 +825,7 @@ mod tests {
             PrewarmJob { pdf: pdf.clone() },
             &mut request_rx,
             &mut pending,
-            &mut text_cache,
-            &mut geometry_cache,
+            &mut page_cache,
             &mut prewarm_finished_doc_ids,
         ) {
             PrewarmControl::Interrupted(job) => job,
@@ -923,7 +834,7 @@ mod tests {
         };
 
         assert!(pending.query.is_some());
-        assert_eq!(pdf.positioned_calls(), vec![0, 0]);
+        assert_eq!(pdf.text_page_calls(), vec![0, 0]);
 
         pending.query = None;
         assert!(matches!(
@@ -931,13 +842,12 @@ mod tests {
                 interrupted,
                 &mut request_rx,
                 &mut pending,
-                &mut text_cache,
-                &mut geometry_cache,
+                &mut page_cache,
                 &mut prewarm_finished_doc_ids,
             ),
             PrewarmControl::Finished
         ));
-        assert_eq!(pdf.positioned_calls(), vec![1, 1]);
+        assert_eq!(pdf.text_page_calls(), vec![1, 1]);
     }
 
     fn text_page(text: &str) -> TextPage {

--- a/src/search/worker.rs
+++ b/src/search/worker.rs
@@ -423,8 +423,9 @@ fn run_job(
         let text_page = match text_page {
             Ok(text_page) => Some(text_page),
             Err(err) => {
-                let _ = event_tx.send(SearchEvent::Failed {
+                let _ = event_tx.send(SearchEvent::PageSkipped {
                     generation: job.generation,
+                    page,
                     message: err.to_string(),
                 });
                 None
@@ -936,7 +937,8 @@ mod tests {
         }
         assert!(events.iter().any(|event| matches!(
             event,
-            SearchEvent::Failed {
+            SearchEvent::PageSkipped {
+                page: 1,
                 message,
                 ..
             } if message.contains("page text unavailable")

--- a/src/search/worker.rs
+++ b/src/search/worker.rs
@@ -212,7 +212,7 @@ impl SearchPageCache {
 }
 
 fn estimate_text_page_bytes(text_page: &TextPage) -> usize {
-    size_of::<TextPage>() + text_page.glyphs.len() * size_of::<TextGlyph>()
+    size_of::<TextPage>() + text_page.glyphs.capacity() * size_of::<TextGlyph>()
 }
 
 pub(crate) fn worker_main(
@@ -421,25 +421,27 @@ fn run_job(
         };
 
         let text_page = match text_page {
-            Ok(text_page) => text_page,
+            Ok(text_page) => Some(text_page),
             Err(err) => {
                 let _ = event_tx.send(SearchEvent::Failed {
                     generation: job.generation,
                     message: err.to_string(),
                 });
-                return WorkerControl::Continue;
+                None
             }
         };
 
-        let mut occurrences = job.matcher.locate_matches(text_page.as_ref(), &query);
-        for occurrence in &mut occurrences {
-            if occurrence_highlight_unavailable(occurrence, &text_page.glyphs) {
-                highlight_unavailable = true;
+        if let Some(text_page) = text_page {
+            let mut occurrences = job.matcher.locate_matches(text_page.as_ref(), &query);
+            for occurrence in &mut occurrences {
+                if occurrence_highlight_unavailable(occurrence, &text_page.glyphs) {
+                    highlight_unavailable = true;
+                }
+                apply_hit_snippet(occurrence, &text_page.glyphs);
             }
-            apply_hit_snippet(occurrence, &text_page.glyphs);
-        }
-        if !occurrences.is_empty() {
-            hits.push(SearchPageHit { page, occurrences });
+            if !occurrences.is_empty() {
+                hits.push(SearchPageHit { page, occurrences });
+            }
         }
 
         let scanned_pages = page + 1;
@@ -565,11 +567,14 @@ mod tests {
 
     use super::{
         PendingWorkerWork, PrewarmControl, PrewarmJob, SearchJob, SearchPageCache, WorkerRequest,
-        estimate_text_page_bytes, run_prewarm_job,
+        estimate_text_page_bytes, run_job, run_prewarm_job,
     };
-    use crate::backend::{OutlineNode, PdfBackend, PdfRect, RgbaFrame, TextGlyph, TextPage};
+    use crate::backend::{
+        OutlineNode, PdfBackend, PdfRect, RgbaFrame, SharedPdfBackend, TextGlyph, TextPage,
+    };
     use crate::command::SearchMatcherKind;
     use crate::error::{AppError, AppResult};
+    use crate::search::engine::SearchEvent;
     use crate::search::matcher::matcher_for_kind;
 
     struct CountingTextPageStubPdf {
@@ -625,6 +630,55 @@ mod tests {
                 .lock()
                 .expect("text page calls lock should not be poisoned");
             calls[page] += 1;
+            Ok(self.pages[page].clone())
+        }
+
+        fn extract_outline(&self) -> AppResult<Vec<OutlineNode>> {
+            Err(AppError::unsupported("not needed in search test"))
+        }
+    }
+
+    struct FailingPageStubPdf {
+        path: PathBuf,
+        pages: Vec<TextPage>,
+        failing_page: usize,
+    }
+
+    impl FailingPageStubPdf {
+        fn new(pages: Vec<TextPage>, failing_page: usize) -> Self {
+            Self {
+                path: PathBuf::from("failing-page.pdf"),
+                pages,
+                failing_page,
+            }
+        }
+    }
+
+    impl PdfBackend for FailingPageStubPdf {
+        fn path(&self) -> &Path {
+            &self.path
+        }
+
+        fn doc_id(&self) -> u64 {
+            404
+        }
+
+        fn page_count(&self) -> usize {
+            self.pages.len()
+        }
+
+        fn page_dimensions(&self, _page: usize) -> AppResult<(f32, f32)> {
+            Ok((100.0, 100.0))
+        }
+
+        fn render_page(&self, _page: usize, _scale: f32) -> AppResult<RgbaFrame> {
+            Err(AppError::unsupported("not needed in search test"))
+        }
+
+        fn extract_text_page(&self, page: usize) -> AppResult<TextPage> {
+            if page == self.failing_page {
+                return Err(AppError::unsupported("page text unavailable"));
+            }
             Ok(self.pages[page].clone())
         }
 
@@ -848,6 +902,54 @@ mod tests {
             PrewarmControl::Finished
         ));
         assert_eq!(pdf.text_page_calls(), vec![1, 1]);
+    }
+
+    #[test]
+    fn search_continues_after_page_text_extraction_failure() {
+        let pdf = Arc::new(FailingPageStubPdf::new(
+            vec![text_page("alpha"), text_page("broken"), text_page("beta")],
+            1,
+        )) as SharedPdfBackend;
+        let (_request_tx, request_rx) = unbounded_channel();
+        let mut request_rx = request_rx;
+        let (event_tx, mut event_rx) = unbounded_channel();
+        let mut pending = PendingWorkerWork::default();
+        let mut page_cache = SearchPageCache::with_limits(4, usize::MAX);
+
+        let control = run_job(
+            SearchJob {
+                generation: 1,
+                pdf,
+                query: "beta".to_string(),
+                matcher: matcher_for_kind(SearchMatcherKind::ContainsInsensitive),
+            },
+            &mut request_rx,
+            &event_tx,
+            &mut pending,
+            &mut page_cache,
+        );
+
+        assert!(matches!(control, super::WorkerControl::Continue));
+        let mut events = Vec::new();
+        while let Ok(event) = event_rx.try_recv() {
+            events.push(event);
+        }
+        assert!(events.iter().any(|event| matches!(
+            event,
+            SearchEvent::Failed {
+                message,
+                ..
+            } if message.contains("page text unavailable")
+        )));
+        let completed = events
+            .iter()
+            .find_map(|event| match event {
+                SearchEvent::Completed { hits, .. } => Some(hits),
+                _ => None,
+            })
+            .expect("search should complete after skipping failed page");
+        assert_eq!(completed.len(), 1);
+        assert_eq!(completed[0].page, 2);
     }
 
     fn text_page(text: &str) -> TextPage {


### PR DESCRIPTION
## Problem

Text extraction had two parallel paths: a plain string extractor and a positioned text extractor. Both interpreted the same PDF glyph stream, but each had its own text reconstruction rules. In particular, both paths inferred line breaks from physical vertical movement. That is a layout heuristic, not a text-extraction contract, and it is especially wrong for vertical writing, wrapped text, rotated text, tables, and other non-horizontal layouts.

## Approach

This PR makes `TextPage` the single internal text extraction unit. The backend now exposes `extract_text_page()` instead of maintaining separate string-only and positioned extraction APIs. Search operates directly on the glyph stream in `TextPage`, so text matching and highlight geometry come from the same source.

The old plain-text device and string fallback path are removed rather than kept as compatibility branches. `TextPage::plain_text()` now only concatenates extracted glyph characters; it no longer inserts line breaks from glyph positions. Missing glyph bounds remain searchable and only disable highlighting for affected hits.

## Impact

This may change search behavior for PDFs where previous results depended on inferred layout newlines. That is intentional: wrapped visual lines should not become semantic newlines, and v0 can favor a cleaner internal contract over preserving a horizontal-writing heuristic. Search still has whitespace-insensitive fallback matching inside the glyph matcher, so ordinary wrapped or spaced queries remain practical without inventing new text.

## Verification

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search and text extraction now operate on page-based, glyph-preserving content, improving consistency of extracted text and highlights.

* **Bug Fixes**
  * Improved match detection and snippet rendering to respect glyph boundaries, reducing issues with spacing, duplicate glyphs, and missing geometry.
  * Reduced search failures by unifying how page text is cached and reused, and by continuing searches when individual pages can’t be extracted.

* **Refactor**
  * Updated runtime/test backends and stubs to the new page-based extraction API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->