### PR TITLE
refactor(cache): share budgeted LRU implementation

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,613 @@
+use std::hash::Hash;
+use std::num::NonZeroUsize;
+
+use lru::LruCache;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CacheLimits {
+    pub(crate) max_entries: usize,
+    pub(crate) memory_budget_bytes: usize,
+}
+
+impl CacheLimits {
+    pub(crate) fn new(max_entries: usize, memory_budget_bytes: usize) -> Self {
+        Self {
+            max_entries: max_entries.max(1),
+            memory_budget_bytes: memory_budget_bytes.max(1),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CacheCounters {
+    pub hits: u64,
+    pub misses: u64,
+    pub evictions: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OversizePolicy {
+    Reject,
+    Admit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EvictionPolicy<'a, K> {
+    Normal,
+    Protect(&'a [K]),
+    RejectIfEvictionRequired,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct InsertPolicy<'a, K> {
+    pub(crate) oversize: OversizePolicy,
+    pub(crate) eviction: EvictionPolicy<'a, K>,
+}
+
+impl<K> InsertPolicy<'_, K> {
+    pub(crate) const NORMAL: Self = Self {
+        oversize: OversizePolicy::Reject,
+        eviction: EvictionPolicy::Normal,
+    };
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RemovedEntry<K, V> {
+    pub(crate) key: K,
+    pub(crate) value: V,
+    pub(crate) cost_bytes: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InsertOutcome<K, V> {
+    pub(crate) inserted: bool,
+    pub(crate) replaced: Option<RemovedEntry<K, V>>,
+    pub(crate) evicted: Vec<RemovedEntry<K, V>>,
+}
+
+impl<K, V> InsertOutcome<K, V> {
+    fn rejected() -> Self {
+        Self {
+            inserted: false,
+            replaced: None,
+            evicted: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CacheEntry<V> {
+    value: V,
+    cost_bytes: usize,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BudgetedLruCache<K: Eq + Hash, V> {
+    limits: CacheLimits,
+    memory_bytes: usize,
+    entries: LruCache<K, CacheEntry<V>>,
+    counters: CacheCounters,
+}
+
+impl<K, V> BudgetedLruCache<K, V>
+where
+    K: Eq + Hash + Clone,
+{
+    pub(crate) fn new(limits: CacheLimits) -> Self {
+        let limits = CacheLimits::new(limits.max_entries, limits.memory_budget_bytes);
+        Self {
+            limits,
+            memory_bytes: 0,
+            entries: LruCache::new(
+                NonZeroUsize::new(limits.max_entries.saturating_mul(2).saturating_add(1))
+                    .expect("cache entries is non-zero"),
+            ),
+            counters: CacheCounters::default(),
+        }
+    }
+
+    pub(crate) fn get(&mut self, key: &K) -> Option<&V> {
+        if self.entries.peek(key).is_some() {
+            self.counters.hits += 1;
+            return self.entries.get(key).map(|entry| &entry.value);
+        }
+        self.counters.misses += 1;
+        None
+    }
+
+    pub(crate) fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        if self.entries.peek(key).is_some() {
+            self.counters.hits += 1;
+            return self.entries.get_mut(key).map(|entry| &mut entry.value);
+        }
+        self.counters.misses += 1;
+        None
+    }
+
+    pub(crate) fn peek(&self, key: &K) -> Option<&V> {
+        self.entries.peek(key).map(|entry| &entry.value)
+    }
+
+    pub(crate) fn peek_mut(&mut self, key: &K) -> Option<&mut V> {
+        self.entries.peek_mut(key).map(|entry| &mut entry.value)
+    }
+
+    pub(crate) fn insert(
+        &mut self,
+        key: K,
+        value: V,
+        cost_bytes: usize,
+        policy: InsertPolicy<'_, K>,
+    ) -> InsertOutcome<K, V> {
+        let cost_bytes = cost_bytes.max(1);
+        if cost_bytes > self.limits.memory_budget_bytes && policy.oversize == OversizePolicy::Reject
+        {
+            return InsertOutcome::rejected();
+        }
+        if self.eviction_required_for_insert(&key, cost_bytes, policy.oversize)
+            && policy.eviction == EvictionPolicy::RejectIfEvictionRequired
+        {
+            return InsertOutcome::rejected();
+        }
+
+        let protected = match policy.eviction {
+            EvictionPolicy::Protect(keys) => keys,
+            EvictionPolicy::Normal | EvictionPolicy::RejectIfEvictionRequired => &[],
+        };
+        if matches!(policy.eviction, EvictionPolicy::Protect(_))
+            && !self.can_admit_with_protected(&key, cost_bytes, policy.oversize, protected)
+        {
+            return InsertOutcome::rejected();
+        }
+        let replaced = self.pop_entry(&key);
+        self.memory_bytes = self.memory_bytes.saturating_add(cost_bytes);
+        let mut evicted = Vec::new();
+        let _ = self
+            .entries
+            .push(key.clone(), CacheEntry { value, cost_bytes });
+
+        let oversize_admitted = cost_bytes > self.limits.memory_budget_bytes
+            && policy.oversize == OversizePolicy::Admit;
+        let eviction_forbidden = policy.eviction == EvictionPolicy::RejectIfEvictionRequired;
+
+        if oversize_admitted && !eviction_forbidden {
+            evicted.extend(self.evict_unprotected_except(&key, protected));
+        } else if !oversize_admitted || !eviction_forbidden {
+            evicted.extend(self.evict_while_needed(protected));
+        }
+
+        InsertOutcome {
+            inserted: true,
+            replaced,
+            evicted,
+        }
+    }
+
+    pub(crate) fn remove(&mut self, key: &K) -> Option<RemovedEntry<K, V>> {
+        self.pop_entry(key)
+    }
+
+    pub(crate) fn remove_where(
+        &mut self,
+        mut should_remove: impl FnMut(&K, &V) -> bool,
+    ) -> Vec<RemovedEntry<K, V>> {
+        let keys = self
+            .entries
+            .iter()
+            .filter_map(|(key, entry)| should_remove(key, &entry.value).then_some(key.clone()))
+            .collect::<Vec<_>>();
+        keys.into_iter()
+            .filter_map(|key| self.remove(&key))
+            .collect()
+    }
+
+    pub(crate) fn clear(&mut self) -> Vec<RemovedEntry<K, V>> {
+        let keys = self
+            .entries
+            .iter()
+            .map(|(key, _)| key.clone())
+            .collect::<Vec<_>>();
+        let removed = keys
+            .into_iter()
+            .filter_map(|key| self.pop_entry(&key))
+            .collect::<Vec<_>>();
+        self.entries.clear();
+        self.memory_bytes = 0;
+        removed
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub(crate) fn max_entries(&self) -> usize {
+        self.limits.max_entries
+    }
+
+    pub(crate) fn memory_budget_bytes(&self) -> usize {
+        self.limits.memory_budget_bytes
+    }
+
+    pub(crate) fn memory_bytes(&self) -> usize {
+        self.memory_bytes
+    }
+
+    pub(crate) fn counters(&self) -> CacheCounters {
+        self.counters
+    }
+
+    pub(crate) fn add_evictions(&mut self, count: u64) {
+        self.counters.evictions = self.counters.evictions.saturating_add(count);
+    }
+
+    pub(crate) fn hit_rate(&self) -> f64 {
+        let lookups = self.counters.hits + self.counters.misses;
+        if lookups == 0 {
+            return 0.0;
+        }
+        self.counters.hits as f64 / lookups as f64
+    }
+
+    fn eviction_required_for_insert(
+        &self,
+        key: &K,
+        cost_bytes: usize,
+        oversize: OversizePolicy,
+    ) -> bool {
+        let replaced_bytes = self.entries.peek(key).map_or(0, |entry| entry.cost_bytes);
+        let projected_len = if self.entries.peek(key).is_some() {
+            self.entries.len()
+        } else {
+            self.entries.len() + 1
+        };
+        let projected_memory = self
+            .memory_bytes
+            .saturating_sub(replaced_bytes)
+            .saturating_add(cost_bytes);
+        projected_len > self.limits.max_entries
+            || (projected_memory > self.limits.memory_budget_bytes
+                && !(cost_bytes > self.limits.memory_budget_bytes
+                    && oversize == OversizePolicy::Admit))
+    }
+
+    fn can_admit_with_protected(
+        &self,
+        key: &K,
+        cost_bytes: usize,
+        oversize: OversizePolicy,
+        protected: &[K],
+    ) -> bool {
+        let replaced_bytes = self.entries.peek(key).map_or(0, |entry| entry.cost_bytes);
+        let mut projected_len = if self.entries.peek(key).is_some() {
+            self.entries.len()
+        } else {
+            self.entries.len() + 1
+        };
+        let mut projected_memory = self
+            .memory_bytes
+            .saturating_sub(replaced_bytes)
+            .saturating_add(cost_bytes);
+        for (entry_key, entry) in self.entries.iter() {
+            if self.fits_limits(projected_len, projected_memory, cost_bytes, oversize) {
+                return true;
+            }
+            if entry_key == key || protected.contains(entry_key) {
+                continue;
+            }
+            projected_len = projected_len.saturating_sub(1);
+            projected_memory = projected_memory.saturating_sub(entry.cost_bytes);
+        }
+        self.fits_limits(projected_len, projected_memory, cost_bytes, oversize)
+    }
+
+    fn fits_limits(
+        &self,
+        projected_len: usize,
+        projected_memory: usize,
+        cost_bytes: usize,
+        oversize: OversizePolicy,
+    ) -> bool {
+        projected_len <= self.limits.max_entries
+            && (projected_memory <= self.limits.memory_budget_bytes
+                || (cost_bytes > self.limits.memory_budget_bytes
+                    && oversize == OversizePolicy::Admit))
+    }
+
+    fn evict_while_needed(&mut self, protected: &[K]) -> Vec<RemovedEntry<K, V>> {
+        let mut removed = Vec::new();
+        while self.entries.len() > self.limits.max_entries
+            || self.memory_bytes > self.limits.memory_budget_bytes
+        {
+            let Some(entry) = self.pop_lru_unprotected(protected) else {
+                break;
+            };
+            self.counters.evictions += 1;
+            removed.push(entry);
+        }
+        removed
+    }
+
+    fn evict_unprotected_except(
+        &mut self,
+        inserted_key: &K,
+        protected: &[K],
+    ) -> Vec<RemovedEntry<K, V>> {
+        let keys = self
+            .entries
+            .iter()
+            .filter_map(|(key, _)| {
+                (key != inserted_key && !protected.contains(key)).then_some(key.clone())
+            })
+            .collect::<Vec<_>>();
+        let mut removed = Vec::new();
+        for key in keys {
+            if let Some(entry) = self.pop_entry(&key) {
+                self.counters.evictions += 1;
+                removed.push(entry);
+            }
+        }
+        removed
+    }
+
+    fn pop_lru_unprotected(&mut self, protected: &[K]) -> Option<RemovedEntry<K, V>> {
+        let mut protected_entries = Vec::new();
+        loop {
+            match self.entries.pop_lru() {
+                Some((key, entry)) if protected.contains(&key) => {
+                    protected_entries.push((key, entry));
+                }
+                Some((key, entry)) => {
+                    for (protected_key, protected_entry) in protected_entries.into_iter().rev() {
+                        let _ = self.entries.push(protected_key.clone(), protected_entry);
+                        let _ = self.entries.demote(&protected_key);
+                    }
+                    let removed = self.removed_entry(key, entry);
+                    self.memory_bytes = self.memory_bytes.saturating_sub(removed.cost_bytes);
+                    return Some(removed);
+                }
+                None => {
+                    for (protected_key, protected_entry) in protected_entries.into_iter().rev() {
+                        let _ = self.entries.push(protected_key.clone(), protected_entry);
+                        let _ = self.entries.demote(&protected_key);
+                    }
+                    return None;
+                }
+            }
+        }
+    }
+
+    fn pop_entry(&mut self, key: &K) -> Option<RemovedEntry<K, V>> {
+        let entry = self.entries.pop(key)?;
+        let removed = self.removed_entry(key.clone(), entry);
+        self.memory_bytes = self.memory_bytes.saturating_sub(removed.cost_bytes);
+        Some(removed)
+    }
+
+    fn removed_entry(&self, key: K, entry: CacheEntry<V>) -> RemovedEntry<K, V> {
+        RemovedEntry {
+            key,
+            value: entry.value,
+            cost_bytes: entry.cost_bytes,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BudgetedLruCache, CacheLimits, EvictionPolicy, InsertPolicy, OversizePolicy};
+
+    fn cache(max_entries: usize, memory_budget_bytes: usize) -> BudgetedLruCache<u8, &'static str> {
+        BudgetedLruCache::new(CacheLimits::new(max_entries, memory_budget_bytes))
+    }
+
+    #[test]
+    fn get_tracks_hit_rate_and_promotes_lru_order() {
+        let mut cache = cache(2, 100);
+        let _ = cache.insert(1, "one", 1, InsertPolicy::NORMAL);
+        let _ = cache.insert(2, "two", 1, InsertPolicy::NORMAL);
+
+        assert_eq!(cache.get(&1), Some(&"one"));
+        assert_eq!(cache.get(&3), None);
+        let _ = cache.insert(3, "three", 1, InsertPolicy::NORMAL);
+
+        assert_eq!(cache.peek(&1), Some(&"one"));
+        assert_eq!(cache.peek(&2), None);
+        assert_eq!(cache.hit_rate(), 0.5);
+    }
+
+    #[test]
+    fn peek_does_not_track_hits_or_promote_lru_order() {
+        let mut cache = cache(2, 100);
+        let _ = cache.insert(1, "one", 1, InsertPolicy::NORMAL);
+        let _ = cache.insert(2, "two", 1, InsertPolicy::NORMAL);
+
+        assert_eq!(cache.peek(&1), Some(&"one"));
+        let _ = cache.insert(3, "three", 1, InsertPolicy::NORMAL);
+
+        assert_eq!(cache.peek(&1), None);
+        assert_eq!(cache.peek(&2), Some(&"two"));
+        assert_eq!(cache.hit_rate(), 0.0);
+    }
+
+    #[test]
+    fn insert_evicts_lru_over_capacity_and_returns_removed_entry() {
+        let mut cache = cache(2, 100);
+        let _ = cache.insert(1, "one", 1, InsertPolicy::NORMAL);
+        let _ = cache.insert(2, "two", 1, InsertPolicy::NORMAL);
+
+        let outcome = cache.insert(3, "three", 1, InsertPolicy::NORMAL);
+
+        assert!(outcome.inserted);
+        assert_eq!(outcome.evicted.len(), 1);
+        assert_eq!(outcome.evicted[0].key, 1);
+        assert_eq!(outcome.evicted[0].value, "one");
+        assert_eq!(cache.memory_bytes(), 2);
+    }
+
+    #[test]
+    fn insert_evicts_until_memory_budget_is_satisfied() {
+        let mut cache = cache(4, 10);
+        let _ = cache.insert(1, "one", 4, InsertPolicy::NORMAL);
+        let _ = cache.insert(2, "two", 4, InsertPolicy::NORMAL);
+
+        let outcome = cache.insert(3, "three", 6, InsertPolicy::NORMAL);
+
+        assert_eq!(outcome.evicted.len(), 1);
+        assert_eq!(outcome.evicted[0].key, 1);
+        assert_eq!(cache.memory_bytes(), 10);
+    }
+
+    #[test]
+    fn reinserting_existing_key_replaces_cost_without_double_counting() {
+        let mut cache = cache(4, 100);
+        let _ = cache.insert(1, "one", 4, InsertPolicy::NORMAL);
+
+        let outcome = cache.insert(1, "uno", 7, InsertPolicy::NORMAL);
+
+        assert_eq!(
+            outcome
+                .replaced
+                .expect("old value should be returned")
+                .value,
+            "one"
+        );
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.memory_bytes(), 7);
+        assert_eq!(cache.peek(&1), Some(&"uno"));
+    }
+
+    #[test]
+    fn oversize_reject_leaves_existing_entries_untouched() {
+        let mut cache = cache(4, 5);
+        let _ = cache.insert(1, "one", 4, InsertPolicy::NORMAL);
+
+        let outcome = cache.insert(2, "two", 6, InsertPolicy::NORMAL);
+
+        assert!(!outcome.inserted);
+        assert_eq!(cache.peek(&1), Some(&"one"));
+        assert_eq!(cache.peek(&2), None);
+        assert_eq!(cache.memory_bytes(), 4);
+    }
+
+    #[test]
+    fn oversize_admit_keeps_inserted_entry_and_evicts_unprotected_entries() {
+        let mut cache = cache(4, 5);
+        let _ = cache.insert(1, "one", 4, InsertPolicy::NORMAL);
+
+        let outcome = cache.insert(
+            2,
+            "two",
+            6,
+            InsertPolicy {
+                oversize: OversizePolicy::Admit,
+                eviction: EvictionPolicy::Normal,
+            },
+        );
+
+        assert!(outcome.inserted);
+        assert_eq!(outcome.evicted[0].key, 1);
+        assert_eq!(cache.peek(&1), None);
+        assert_eq!(cache.peek(&2), Some(&"two"));
+        assert_eq!(cache.memory_bytes(), 6);
+    }
+
+    #[test]
+    fn oversize_admit_without_eviction_keeps_existing_entries() {
+        let mut cache = cache(4, 5);
+        let _ = cache.insert(1, "one", 4, InsertPolicy::NORMAL);
+
+        let outcome = cache.insert(
+            2,
+            "two",
+            6,
+            InsertPolicy {
+                oversize: OversizePolicy::Admit,
+                eviction: EvictionPolicy::RejectIfEvictionRequired,
+            },
+        );
+
+        assert!(outcome.inserted);
+        assert!(outcome.evicted.is_empty());
+        assert_eq!(cache.peek(&1), Some(&"one"));
+        assert_eq!(cache.peek(&2), Some(&"two"));
+        assert_eq!(cache.memory_bytes(), 10);
+    }
+
+    #[test]
+    fn protected_keys_are_not_evicted_when_an_unprotected_candidate_exists() {
+        let mut cache = cache(2, 100);
+        let protected = [1];
+        let _ = cache.insert(1, "one", 1, InsertPolicy::NORMAL);
+        let _ = cache.insert(2, "two", 1, InsertPolicy::NORMAL);
+
+        let outcome = cache.insert(
+            3,
+            "three",
+            1,
+            InsertPolicy {
+                oversize: OversizePolicy::Reject,
+                eviction: EvictionPolicy::Protect(&protected),
+            },
+        );
+
+        assert!(outcome.inserted);
+        assert_eq!(cache.peek(&1), Some(&"one"));
+        assert_eq!(cache.peek(&2), None);
+        assert_eq!(cache.peek(&3), Some(&"three"));
+    }
+
+    #[test]
+    fn protected_insert_rejects_when_only_inserted_entry_could_be_evicted() {
+        let mut cache = cache(2, 100);
+        let protected = [1, 2];
+        let _ = cache.insert(1, "one", 1, InsertPolicy::NORMAL);
+        let _ = cache.insert(2, "two", 1, InsertPolicy::NORMAL);
+
+        let outcome = cache.insert(
+            3,
+            "three",
+            1,
+            InsertPolicy {
+                oversize: OversizePolicy::Reject,
+                eviction: EvictionPolicy::Protect(&protected),
+            },
+        );
+
+        assert!(!outcome.inserted);
+        assert_eq!(cache.peek(&1), Some(&"one"));
+        assert_eq!(cache.peek(&2), Some(&"two"));
+        assert_eq!(cache.peek(&3), None);
+        assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn reject_if_eviction_required_rejects_capacity_or_memory_eviction() {
+        let mut cache = cache(1, 5);
+        let _ = cache.insert(1, "one", 3, InsertPolicy::NORMAL);
+        let policy = InsertPolicy {
+            oversize: OversizePolicy::Reject,
+            eviction: EvictionPolicy::RejectIfEvictionRequired,
+        };
+
+        assert!(!cache.insert(2, "two", 1, policy).inserted);
+        assert!(!cache.insert(1, "uno", 6, policy).inserted);
+        assert_eq!(cache.peek(&1), Some(&"one"));
+    }
+
+    #[test]
+    fn clear_returns_removed_entries_and_resets_memory() {
+        let mut cache = cache(2, 100);
+        let _ = cache.insert(1, "one", 3, InsertPolicy::NORMAL);
+        let _ = cache.insert(2, "two", 4, InsertPolicy::NORMAL);
+
+        let removed = cache.clear();
+
+        assert_eq!(removed.len(), 2);
+        assert!(cache.is_empty());
+        assert_eq!(cache.memory_bytes(), 0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod app;
 pub mod backend;
+pub(crate) mod cache;
 pub mod config;
 pub mod error;
 pub mod perf;

--- a/src/presenter/l2_cache.rs
+++ b/src/presenter/l2_cache.rs
@@ -1,9 +1,9 @@
-use std::num::NonZeroUsize;
-
-use lru::LruCache;
 use ratatui_image::protocol::StatefulProtocol;
 
 use crate::backend::RgbaFrame;
+use crate::cache::{
+    BudgetedLruCache, CacheLimits, EvictionPolicy, InsertPolicy, OversizePolicy, RemovedEntry,
+};
 use crate::render::cache::RenderedPageKey;
 
 use super::traits::{PanOffset, Viewport};
@@ -20,7 +20,6 @@ pub(crate) enum TerminalFrameState {
 
 pub(crate) struct TerminalFrameEntry {
     state: TerminalFrameState,
-    approx_bytes: usize,
 }
 
 impl TerminalFrameEntry {
@@ -38,19 +37,9 @@ pub(crate) struct TerminalFrameKey {
     pub(crate) overlay_stamp: u64,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-struct CacheCounters {
-    hits: u64,
-    misses: u64,
-}
-
 pub(crate) struct TerminalFrameCache {
-    max_entries: usize,
-    memory_budget_bytes: usize,
-    pub(crate) entries: LruCache<TerminalFrameKey, TerminalFrameEntry>,
-    pub(crate) memory_bytes: usize,
+    entries: BudgetedLruCache<TerminalFrameKey, TerminalFrameEntry>,
     pending_work_count: usize,
-    counters: CacheCounters,
 }
 
 impl Default for TerminalFrameCache {
@@ -61,27 +50,14 @@ impl Default for TerminalFrameCache {
 
 impl TerminalFrameCache {
     pub(crate) fn new(max_entries: usize, memory_budget_bytes: usize) -> Self {
-        let max_entries = max_entries.max(1);
         Self {
-            max_entries,
-            memory_budget_bytes: memory_budget_bytes.max(1),
-            entries: LruCache::new(
-                NonZeroUsize::new(max_entries).expect("l2 cache entries is non-zero"),
-            ),
-            memory_bytes: 0,
+            entries: BudgetedLruCache::new(CacheLimits::new(max_entries, memory_budget_bytes)),
             pending_work_count: 0,
-            counters: CacheCounters::default(),
         }
     }
 
     pub(crate) fn lookup_mut(&mut self, key: &TerminalFrameKey) -> Option<&mut TerminalFrameEntry> {
-        if self.entries.peek(key).is_some() {
-            self.counters.hits += 1;
-            return self.entries.get_mut(key);
-        }
-
-        self.counters.misses += 1;
-        None
+        self.entries.get_mut(key)
     }
 
     pub(crate) fn cached_mut(&mut self, key: &TerminalFrameKey) -> Option<&mut TerminalFrameEntry> {
@@ -120,73 +96,49 @@ impl TerminalFrameCache {
             .copied()
             .filter(|protected| *protected != key)
             .collect::<Vec<_>>();
-        if approx_bytes > self.memory_budget_bytes {
-            if !allow_single_oversize {
-                return false;
-            }
-
-            self.pop_entry(&key);
-
-            // Keep the visible ready frame resident while swapping in an oversize current
-            // entry. We allow this narrow over-budget state so the viewer never regresses
-            // from "image visible" back to blank while the replacement frame is pending.
-            // If the cache is configured for a single entry, honor that cap and fall back
-            // to the original replacement behavior.
-            let protected_keys = if self.max_entries > 1 {
-                protected_keys.as_slice()
-            } else {
-                &[]
-            };
-            self.retain_only(protected_keys, key);
-            self.memory_bytes = self.memory_bytes.saturating_add(approx_bytes);
-            self.pending_work_count += 1;
-            if let Some((_evicted_key, evicted)) = self.entries.push(
-                key,
-                TerminalFrameEntry {
-                    state: TerminalFrameState::PendingFrame(frame),
-                    approx_bytes,
-                },
-            ) {
-                self.memory_bytes = self.memory_bytes.saturating_sub(evicted.approx_bytes);
-                self.note_removed_state(&evicted.state);
-            }
-            return true;
-        }
-
-        // Preserve single-entry oversize recovery for current page:
-        // while a lone oversize entry is resident, reject unrelated
-        // non-oversize inserts (typically prefetch) that would evict it.
         if !allow_single_oversize
-            && self.memory_bytes > self.memory_budget_bytes
+            && self.entries.memory_bytes() > self.entries.memory_budget_bytes()
             && self.entries.peek(&key).is_none()
         {
             return false;
         }
 
-        self.pop_entry(&key);
-
-        self.memory_bytes += approx_bytes;
-        self.pending_work_count += 1;
-        if let Some((_evicted_key, evicted)) = self.entries.push(
+        // Keep visible ready frames resident while swapping in an oversize current
+        // entry. If the cache is configured for a single entry, honor that cap.
+        let protected_keys = if self.entries.max_entries() > 1 {
+            protected_keys.as_slice()
+        } else {
+            &[]
+        };
+        let outcome = self.entries.insert(
             key,
             TerminalFrameEntry {
                 state: TerminalFrameState::PendingFrame(frame),
-                approx_bytes,
             },
-        ) {
-            self.memory_bytes = self.memory_bytes.saturating_sub(evicted.approx_bytes);
-            self.note_removed_state(&evicted.state);
+            approx_bytes,
+            InsertPolicy {
+                oversize: if allow_single_oversize {
+                    OversizePolicy::Admit
+                } else {
+                    OversizePolicy::Reject
+                },
+                eviction: if protected_keys.is_empty() {
+                    EvictionPolicy::Normal
+                } else {
+                    EvictionPolicy::Protect(protected_keys)
+                },
+            },
+        );
+        if !outcome.inserted {
+            return false;
         }
-        self.evict_while_needed(&protected_keys);
+        self.note_removed_entries(outcome.replaced.into_iter().chain(outcome.evicted));
+        self.pending_work_count += 1;
         true
     }
 
     pub(crate) fn hit_rate(&self) -> f64 {
-        let lookups = self.counters.hits + self.counters.misses;
-        if lookups == 0 {
-            return 0.0;
-        }
-        self.counters.hits as f64 / lookups as f64
+        self.entries.hit_rate()
     }
 
     pub(crate) fn len(&self) -> usize {
@@ -195,12 +147,17 @@ impl TerminalFrameCache {
 
     #[cfg(test)]
     pub(crate) fn max_entries(&self) -> usize {
-        self.max_entries
+        self.entries.max_entries()
     }
 
     #[cfg(test)]
     pub(crate) fn memory_budget_bytes(&self) -> usize {
-        self.memory_budget_bytes
+        self.entries.memory_budget_bytes()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn memory_bytes(&self) -> usize {
+        self.entries.memory_bytes()
     }
 
     pub(crate) fn has_pending_work(&self) -> bool {
@@ -229,86 +186,30 @@ impl TerminalFrameCache {
     }
 
     pub(crate) fn clear(&mut self) {
-        self.entries.clear();
-        self.memory_bytes = 0;
+        let _ = self.entries.clear();
         self.pending_work_count = 0;
     }
 
     pub(crate) fn remove(&mut self, key: &TerminalFrameKey) -> bool {
-        self.pop_entry(key).is_some()
-    }
-
-    fn evict_while_needed(&mut self, protected_keys: &[TerminalFrameKey]) {
-        while self.entries.len() > self.max_entries || self.memory_bytes > self.memory_budget_bytes
-        {
-            if self.entries.len() == 1
-                && protected_keys
-                    .iter()
-                    .any(|key| self.entries.peek(key).is_some())
-            {
-                break;
-            }
-            let Some((_key, entry)) = self.pop_lru_unprotected(protected_keys) else {
-                break;
-            };
-            self.memory_bytes = self.memory_bytes.saturating_sub(entry.approx_bytes);
-            self.note_removed_state(&entry.state);
-        }
-    }
-
-    fn retain_only(&mut self, protected_keys: &[TerminalFrameKey], inserted_key: TerminalFrameKey) {
-        let doomed: Vec<_> = self
-            .entries
-            .iter()
-            .map(|(key, _)| *key)
-            .filter(|key| *key != inserted_key && !protected_keys.contains(key))
-            .collect();
-
-        for key in doomed {
-            let _ = self.remove(&key);
-        }
-    }
-
-    fn pop_lru_unprotected(
-        &mut self,
-        protected_keys: &[TerminalFrameKey],
-    ) -> Option<(TerminalFrameKey, TerminalFrameEntry)> {
-        let mut protected_entry = Vec::new();
-
-        loop {
-            match self.entries.pop_lru() {
-                Some((key, entry)) if protected_keys.contains(&key) => {
-                    protected_entry.push((key, entry));
-                    continue;
-                }
-                Some(pair) => {
-                    for (key, entry) in protected_entry.into_iter().rev() {
-                        let _ = self.entries.push(key, entry);
-                        let _ = self.entries.demote(&key);
-                    }
-                    return Some(pair);
-                }
-                None => {
-                    for (key, entry) in protected_entry.into_iter().rev() {
-                        let _ = self.entries.push(key, entry);
-                        let _ = self.entries.demote(&key);
-                    }
-                    return None;
-                }
-            }
-        }
-    }
-
-    fn pop_entry(&mut self, key: &TerminalFrameKey) -> Option<TerminalFrameEntry> {
-        let entry = self.entries.pop(key)?;
-        self.memory_bytes = self.memory_bytes.saturating_sub(entry.approx_bytes);
-        self.note_removed_state(&entry.state);
-        Some(entry)
+        let Some(removed) = self.entries.remove(key) else {
+            return false;
+        };
+        self.note_removed_state(&removed.value.state);
+        true
     }
 
     fn note_removed_state(&mut self, state: &TerminalFrameState) {
         if state_has_pending_work(state) {
             self.pending_work_count = self.pending_work_count.saturating_sub(1);
+        }
+    }
+
+    fn note_removed_entries(
+        &mut self,
+        entries: impl IntoIterator<Item = RemovedEntry<TerminalFrameKey, TerminalFrameEntry>>,
+    ) {
+        for entry in entries {
+            self.note_removed_state(&entry.value.state);
         }
     }
 }
@@ -318,4 +219,198 @@ fn state_has_pending_work(state: &TerminalFrameState) -> bool {
         state,
         TerminalFrameState::PendingFrame(_) | TerminalFrameState::Encoding
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::backend::RgbaFrame;
+
+    use super::*;
+
+    fn frame() -> RgbaFrame {
+        RgbaFrame {
+            width: 4,
+            height: 4,
+            pixels: vec![200; 4 * 4 * 4].into(),
+        }
+    }
+
+    fn key(page: usize) -> TerminalFrameKey {
+        TerminalFrameKey {
+            rendered_page: RenderedPageKey::new(1, page, 1.0),
+            viewport: Viewport {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
+            pan: PanOffset::default(),
+            overlay_stamp: 0,
+        }
+    }
+
+    #[test]
+    fn cached_mut_does_not_touch_lru_order() {
+        let mut cache = TerminalFrameCache::default();
+        for page in 0..L2_MAX_ENTRIES {
+            let _ = cache.insert(key(page), frame(), 1, false, None);
+        }
+
+        let oldest = key(0);
+        assert!(cache.cached_mut(&oldest).is_some());
+        let _ = cache.insert(key(L2_MAX_ENTRIES), frame(), 1, false, None);
+
+        assert!(cache.cached_mut(&oldest).is_none());
+        assert!(cache.cached_mut(&key(1)).is_some());
+    }
+
+    #[test]
+    fn insert_at_capacity_keeps_memory_accounting_consistent() {
+        let mut cache = TerminalFrameCache::default();
+        for page in 0..L2_MAX_ENTRIES {
+            let _ = cache.insert(key(page), frame(), 16, false, None);
+        }
+        let _ = cache.insert(key(L2_MAX_ENTRIES), frame(), 20, false, None);
+
+        let expected = (L2_MAX_ENTRIES - 1) * 16 + 20;
+        assert_eq!(cache.len(), L2_MAX_ENTRIES);
+        assert_eq!(cache.memory_bytes(), expected);
+    }
+
+    #[test]
+    fn insert_keeps_pending_frame_buffer_shared() {
+        let mut cache = TerminalFrameCache::default();
+        let key = key(0);
+        let source = frame();
+        let _ = cache.insert(key, source.clone(), source.byte_len(), false, None);
+
+        let stored_pixels = match cache.cached_mut(&key).map(|entry| entry.state()) {
+            Some(TerminalFrameState::PendingFrame(frame)) => &frame.pixels,
+            _ => panic!("expected pending frame"),
+        };
+        assert!(source.pixels.ptr_eq(stored_pixels));
+    }
+
+    #[test]
+    fn pending_work_tracks_state_transitions() {
+        let mut cache = TerminalFrameCache::default();
+        let key = key(0);
+        let _ = cache.insert(key, frame(), 16, false, None);
+        assert!(cache.has_pending_work());
+
+        assert!(cache.set_state(&key, TerminalFrameState::Failed));
+        assert!(!cache.has_pending_work());
+
+        assert!(cache.set_state(&key, TerminalFrameState::Encoding));
+        assert!(cache.has_pending_work());
+
+        assert!(cache.remove(&key));
+        assert!(!cache.has_pending_work());
+    }
+
+    #[test]
+    fn pending_work_tracks_eviction_and_clear() {
+        let mut cache = TerminalFrameCache::new(1, 64);
+        let first = key(0);
+        let second = key(1);
+        assert!(cache.insert(first, frame(), 16, false, None));
+        assert!(cache.insert(second, frame(), 16, false, None));
+        assert!(cache.cached_mut(&first).is_none());
+        assert!(cache.has_pending_work());
+
+        cache.clear();
+        assert!(!cache.has_pending_work());
+    }
+
+    #[test]
+    fn oversize_insert_without_override_preserves_existing_entries() {
+        let mut cache = TerminalFrameCache::new(8, 32);
+        let kept = key(0);
+        let oversize = key(1);
+        let _ = cache.insert(kept, frame(), 16, false, None);
+
+        let inserted = cache.insert(oversize, frame(), 64, false, None);
+        assert!(!inserted);
+        assert!(cache.cached_mut(&kept).is_some());
+        assert!(cache.cached_mut(&oversize).is_none());
+    }
+
+    #[test]
+    fn oversize_insert_with_override_keeps_single_entry() {
+        let mut cache = TerminalFrameCache::new(8, 32);
+        let kept = key(0);
+        let oversize = key(1);
+        let _ = cache.insert(kept, frame(), 16, false, None);
+
+        let inserted = cache.insert(oversize, frame(), 64, true, None);
+        assert!(inserted);
+        assert!(cache.cached_mut(&kept).is_none());
+        assert!(cache.cached_mut(&oversize).is_some());
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn oversize_insert_with_protected_key_keeps_visible_entry() {
+        let mut cache = TerminalFrameCache::new(8, 32);
+        let visible = key(0);
+        let oversize = key(1);
+        let _ = cache.insert(visible, frame(), 16, false, None);
+
+        let inserted = cache.insert(oversize, frame(), 64, true, Some(visible));
+        assert!(inserted);
+        assert!(cache.cached_mut(&visible).is_some());
+        assert!(cache.cached_mut(&oversize).is_some());
+        assert_eq!(cache.len(), 2);
+        assert!(cache.memory_bytes() > cache.memory_budget_bytes());
+    }
+
+    #[test]
+    fn oversize_insert_with_protected_keys_keeps_visible_entries() {
+        let mut cache = TerminalFrameCache::new(8, 32);
+        let left_visible = key(0);
+        let right_visible = key(1);
+        let oversize = key(2);
+        let _ = cache.insert(left_visible, frame(), 16, false, None);
+        let _ = cache.insert(right_visible, frame(), 16, false, None);
+
+        let inserted =
+            cache.insert_protected(oversize, frame(), 64, true, &[left_visible, right_visible]);
+        assert!(inserted);
+        assert!(cache.cached_mut(&left_visible).is_some());
+        assert!(cache.cached_mut(&right_visible).is_some());
+        assert!(cache.cached_mut(&oversize).is_some());
+        assert_eq!(cache.len(), 3);
+        assert!(cache.memory_bytes() > cache.memory_budget_bytes());
+    }
+
+    #[test]
+    fn oversize_insert_with_protected_key_respects_single_entry_limit() {
+        let mut cache = TerminalFrameCache::new(1, 32);
+        let visible = key(0);
+        let oversize = key(1);
+        let _ = cache.insert(visible, frame(), 16, false, None);
+
+        let inserted = cache.insert(oversize, frame(), 64, true, Some(visible));
+        assert!(inserted);
+        assert!(cache.cached_mut(&visible).is_none());
+        assert!(cache.cached_mut(&oversize).is_some());
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn non_oversize_insert_does_not_evict_single_oversize_entry() {
+        let mut cache = TerminalFrameCache::new(8, 32);
+        let oversize = key(1);
+        let prefetch = key(2);
+
+        assert!(cache.insert(oversize, frame(), 64, true, None));
+        assert_eq!(cache.len(), 1);
+        assert!(cache.cached_mut(&oversize).is_some());
+
+        let inserted_prefetch = cache.insert(prefetch, frame(), 16, false, None);
+        assert!(!inserted_prefetch);
+        assert_eq!(cache.len(), 1);
+        assert!(cache.cached_mut(&oversize).is_some());
+        assert!(cache.cached_mut(&prefetch).is_none());
+    }
 }

--- a/src/presenter/tests/mod.rs
+++ b/src/presenter/tests/mod.rs
@@ -15,7 +15,7 @@ use super::encode::{
     EncodeLaneKind, EncodeWorkerRequest, enqueue_encode_request, pop_next_encode_task,
 };
 use super::factory::create_presenter;
-use super::l2_cache::{L2_MAX_ENTRIES, TerminalFrameCache, TerminalFrameKey, TerminalFrameState};
+use super::l2_cache::{TerminalFrameKey, TerminalFrameState};
 use super::ratatui::RatatuiImagePresenter;
 use super::terminal_cell::cell_size_from_window_metrics;
 use super::traits::{
@@ -28,20 +28,6 @@ fn frame() -> RgbaFrame {
         width: 4,
         height: 4,
         pixels: vec![200; 4 * 4 * 4].into(),
-    }
-}
-
-fn l2_key(page: usize) -> TerminalFrameKey {
-    TerminalFrameKey {
-        rendered_page: RenderedPageKey::new(1, page, 1.0),
-        viewport: Viewport {
-            x: 0,
-            y: 0,
-            width: 80,
-            height: 24,
-        },
-        pan: PanOffset::default(),
-        overlay_stamp: 0,
     }
 }
 
@@ -277,8 +263,7 @@ fn prefetch_encode_advances_entry_to_ready() {
             presenter
                 .state
                 .l2_cache
-                .entries
-                .get(&key)
+                .cached_mut(&key)
                 .map(|entry| entry.state()),
             Some(TerminalFrameState::Ready(_))
         );
@@ -695,8 +680,7 @@ fn render_reports_failed_feedback_when_encode_worker_is_disconnected() {
         presenter
             .state
             .l2_cache
-            .entries
-            .get(&key)
+            .cached_mut(&key)
             .map(|entry| entry.state()),
         Some(TerminalFrameState::Failed)
     ));
@@ -866,171 +850,6 @@ fn current_encode_queue_cancels_stale_generation() {
     let first = pop_next_encode_task(&mut queue).expect("current should remain");
     assert_eq!(first.key.rendered_page.page, 3);
     assert!(pop_next_encode_task(&mut queue).is_none());
-}
-
-#[test]
-fn l2_cached_mut_does_not_touch_lru_order() {
-    let mut cache = TerminalFrameCache::default();
-    for page in 0..L2_MAX_ENTRIES {
-        let _ = cache.insert(l2_key(page), frame(), 1, false, None);
-    }
-
-    let oldest = l2_key(0);
-    assert!(cache.cached_mut(&oldest).is_some());
-    let _ = cache.insert(l2_key(L2_MAX_ENTRIES), frame(), 1, false, None);
-
-    assert!(cache.entries.peek(&oldest).is_none());
-    assert!(cache.entries.peek(&l2_key(1)).is_some());
-}
-
-#[test]
-fn l2_insert_at_capacity_keeps_memory_accounting_consistent() {
-    let mut cache = TerminalFrameCache::default();
-    for page in 0..L2_MAX_ENTRIES {
-        let _ = cache.insert(l2_key(page), frame(), 16, false, None);
-    }
-    let _ = cache.insert(l2_key(L2_MAX_ENTRIES), frame(), 20, false, None);
-
-    let expected = (L2_MAX_ENTRIES - 1) * 16 + 20;
-    assert_eq!(cache.len(), L2_MAX_ENTRIES);
-    assert_eq!(cache.memory_bytes, expected);
-}
-
-#[test]
-fn l2_insert_keeps_pending_frame_buffer_shared() {
-    let mut cache = TerminalFrameCache::default();
-    let key = l2_key(0);
-    let source = frame();
-    let _ = cache.insert(key, source.clone(), source.byte_len(), false, None);
-
-    let stored_pixels = match cache.cached_mut(&key).map(|entry| entry.state()) {
-        Some(TerminalFrameState::PendingFrame(frame)) => &frame.pixels,
-        _ => panic!("expected pending frame"),
-    };
-    assert!(source.pixels.ptr_eq(stored_pixels));
-}
-
-#[test]
-fn l2_pending_work_tracks_state_transitions() {
-    let mut cache = TerminalFrameCache::default();
-    let key = l2_key(0);
-    let _ = cache.insert(key, frame(), 16, false, None);
-    assert!(cache.has_pending_work());
-
-    assert!(cache.set_state(&key, TerminalFrameState::Failed));
-    assert!(!cache.has_pending_work());
-
-    assert!(cache.set_state(&key, TerminalFrameState::Encoding));
-    assert!(cache.has_pending_work());
-
-    assert!(cache.remove(&key));
-    assert!(!cache.has_pending_work());
-}
-
-#[test]
-fn l2_pending_work_tracks_eviction_and_clear() {
-    let mut cache = TerminalFrameCache::new(1, 64);
-    let first = l2_key(0);
-    let second = l2_key(1);
-    assert!(cache.insert(first, frame(), 16, false, None));
-    assert!(cache.insert(second, frame(), 16, false, None));
-    assert!(cache.cached_mut(&first).is_none());
-    assert!(cache.has_pending_work());
-
-    cache.clear();
-    assert!(!cache.has_pending_work());
-}
-
-#[test]
-fn l2_oversize_insert_without_override_preserves_existing_entries() {
-    let mut cache = TerminalFrameCache::new(8, 32);
-    let kept = l2_key(0);
-    let oversize = l2_key(1);
-    let _ = cache.insert(kept, frame(), 16, false, None);
-
-    let inserted = cache.insert(oversize, frame(), 64, false, None);
-    assert!(!inserted);
-    assert!(cache.cached_mut(&kept).is_some());
-    assert!(cache.cached_mut(&oversize).is_none());
-}
-
-#[test]
-fn l2_oversize_insert_with_override_keeps_single_entry() {
-    let mut cache = TerminalFrameCache::new(8, 32);
-    let kept = l2_key(0);
-    let oversize = l2_key(1);
-    let _ = cache.insert(kept, frame(), 16, false, None);
-
-    let inserted = cache.insert(oversize, frame(), 64, true, None);
-    assert!(inserted);
-    assert!(cache.cached_mut(&kept).is_none());
-    assert!(cache.cached_mut(&oversize).is_some());
-    assert_eq!(cache.len(), 1);
-}
-
-#[test]
-fn l2_oversize_insert_with_protected_key_keeps_visible_entry() {
-    let mut cache = TerminalFrameCache::new(8, 32);
-    let visible = l2_key(0);
-    let oversize = l2_key(1);
-    let _ = cache.insert(visible, frame(), 16, false, None);
-
-    let inserted = cache.insert(oversize, frame(), 64, true, Some(visible));
-    assert!(inserted);
-    assert!(cache.cached_mut(&visible).is_some());
-    assert!(cache.cached_mut(&oversize).is_some());
-    assert_eq!(cache.len(), 2);
-    assert!(cache.memory_bytes > cache.memory_budget_bytes());
-}
-
-#[test]
-fn l2_oversize_insert_with_protected_keys_keeps_visible_entries() {
-    let mut cache = TerminalFrameCache::new(8, 32);
-    let left_visible = l2_key(0);
-    let right_visible = l2_key(1);
-    let oversize = l2_key(2);
-    let _ = cache.insert(left_visible, frame(), 16, false, None);
-    let _ = cache.insert(right_visible, frame(), 16, false, None);
-
-    let inserted =
-        cache.insert_protected(oversize, frame(), 64, true, &[left_visible, right_visible]);
-    assert!(inserted);
-    assert!(cache.cached_mut(&left_visible).is_some());
-    assert!(cache.cached_mut(&right_visible).is_some());
-    assert!(cache.cached_mut(&oversize).is_some());
-    assert_eq!(cache.len(), 3);
-    assert!(cache.memory_bytes > cache.memory_budget_bytes());
-}
-
-#[test]
-fn l2_oversize_insert_with_protected_key_respects_single_entry_limit() {
-    let mut cache = TerminalFrameCache::new(1, 32);
-    let visible = l2_key(0);
-    let oversize = l2_key(1);
-    let _ = cache.insert(visible, frame(), 16, false, None);
-
-    let inserted = cache.insert(oversize, frame(), 64, true, Some(visible));
-    assert!(inserted);
-    assert!(cache.cached_mut(&visible).is_none());
-    assert!(cache.cached_mut(&oversize).is_some());
-    assert_eq!(cache.len(), 1);
-}
-
-#[test]
-fn l2_non_oversize_insert_does_not_evict_single_oversize_entry() {
-    let mut cache = TerminalFrameCache::new(8, 32);
-    let oversize = l2_key(1);
-    let prefetch = l2_key(2);
-
-    assert!(cache.insert(oversize, frame(), 64, true, None));
-    assert_eq!(cache.len(), 1);
-    assert!(cache.cached_mut(&oversize).is_some());
-
-    let inserted_prefetch = cache.insert(prefetch, frame(), 16, false, None);
-    assert!(!inserted_prefetch);
-    assert_eq!(cache.len(), 1);
-    assert!(cache.cached_mut(&oversize).is_some());
-    assert!(cache.cached_mut(&prefetch).is_none());
 }
 
 #[test]

--- a/src/render/cache.rs
+++ b/src/render/cache.rs
@@ -1,8 +1,7 @@
-use std::num::NonZeroUsize;
-
-use lru::LruCache;
-
 use crate::backend::RgbaFrame;
+use crate::cache::{
+    BudgetedLruCache, CacheCounters, CacheLimits, EvictionPolicy, InsertPolicy, OversizePolicy,
+};
 
 const DEFAULT_MEMORY_BUDGET_BYTES: usize = 512 * 1024 * 1024;
 const DEFAULT_MAX_ENTRIES: usize = 128;
@@ -31,20 +30,9 @@ impl RenderedPageKey {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct CacheCounters {
-    pub hits: u64,
-    pub misses: u64,
-    pub evictions: u64,
-}
-
 #[derive(Debug, Clone)]
 pub struct RenderedPageCache {
-    max_entries: usize,
-    memory_budget_bytes: usize,
-    memory_bytes: usize,
-    entries: LruCache<RenderedPageKey, RgbaFrame>,
-    counters: CacheCounters,
+    entries: BudgetedLruCache<RenderedPageKey, RgbaFrame>,
 }
 
 impl Default for RenderedPageCache {
@@ -55,26 +43,13 @@ impl Default for RenderedPageCache {
 
 impl RenderedPageCache {
     pub fn new(max_entries: usize, memory_budget_bytes: usize) -> Self {
-        let max_entries = max_entries.max(1);
         Self {
-            max_entries,
-            memory_budget_bytes: memory_budget_bytes.max(1),
-            memory_bytes: 0,
-            entries: LruCache::new(
-                NonZeroUsize::new(max_entries).expect("max entries is non-zero"),
-            ),
-            counters: CacheCounters::default(),
+            entries: BudgetedLruCache::new(CacheLimits::new(max_entries, memory_budget_bytes)),
         }
     }
 
     pub fn get(&mut self, key: &RenderedPageKey) -> Option<&RgbaFrame> {
-        if self.entries.peek(key).is_some() {
-            self.counters.hits += 1;
-            return self.entries.get(key);
-        }
-
-        self.counters.misses += 1;
-        None
+        self.entries.get(key)
     }
 
     pub fn get_cloned(&mut self, key: &RenderedPageKey) -> Option<RgbaFrame> {
@@ -88,76 +63,44 @@ impl RenderedPageCache {
         allow_single_oversize: bool,
     ) -> bool {
         let frame_bytes = frame.byte_len();
-        if frame_bytes > self.memory_budget_bytes {
-            if !allow_single_oversize {
-                return false;
-            }
-            self.clear();
-            self.memory_bytes = frame_bytes;
-            self.entries.put(key, frame);
-            return true;
-        }
-
-        // Keep the single-entry oversize recovery path stable:
-        // reject unrelated non-oversize inserts while a lone oversize
-        // frame is intentionally resident.
         if !allow_single_oversize
-            && self.memory_bytes > self.memory_budget_bytes
-            && self.entries.len() == 1
+            && self.entries.memory_bytes() > self.entries.memory_budget_bytes()
             && self.entries.peek(&key).is_none()
-            && self
-                .entries
-                .peek_lru()
-                .is_some_and(|(_cached_key, cached)| cached.byte_len() > self.memory_budget_bytes)
         {
             return false;
         }
-
-        if let Some(prev) = self.entries.pop(&key) {
-            self.memory_bytes = self.memory_bytes.saturating_sub(prev.byte_len());
-        }
-
-        let implicit_evicted_bytes =
-            if self.entries.len() >= self.max_entries && self.entries.peek(&key).is_none() {
-                self.entries
-                    .peek_lru()
-                    .map(|(_key, frame)| frame.byte_len())
-            } else {
-                None
-            };
-
-        self.memory_bytes += frame_bytes;
-        self.entries.put(key, frame);
-        if let Some(evicted_bytes) = implicit_evicted_bytes {
-            self.memory_bytes = self.memory_bytes.saturating_sub(evicted_bytes);
-            self.counters.evictions += 1;
-        }
-        self.evict_while_needed();
-        true
+        self.entries
+            .insert(
+                key,
+                frame,
+                frame_bytes,
+                InsertPolicy {
+                    oversize: if allow_single_oversize {
+                        OversizePolicy::Admit
+                    } else {
+                        OversizePolicy::Reject
+                    },
+                    eviction: EvictionPolicy::Normal,
+                },
+            )
+            .inserted
     }
 
     pub fn remove_doc(&mut self, doc_id: u64) {
-        let doomed: Vec<_> = self
+        let removed = self
             .entries
-            .iter()
-            .filter_map(|(key, _)| (key.doc_id == doc_id).then_some(*key))
-            .collect();
-
-        for key in doomed {
-            self.remove(&key);
-        }
+            .remove_where(|key, _frame| key.doc_id == doc_id);
+        self.entries.add_evictions(removed.len() as u64);
     }
 
     pub fn remove(&mut self, key: &RenderedPageKey) {
-        if let Some(frame) = self.entries.pop(key) {
-            self.memory_bytes = self.memory_bytes.saturating_sub(frame.byte_len());
-            self.counters.evictions += 1;
+        if self.entries.remove(key).is_some() {
+            self.entries.add_evictions(1);
         }
     }
 
     pub fn clear(&mut self) {
-        self.entries.clear();
-        self.memory_bytes = 0;
+        let _ = self.entries.clear();
     }
 
     pub fn len(&self) -> usize {
@@ -165,11 +108,11 @@ impl RenderedPageCache {
     }
 
     pub fn max_entries(&self) -> usize {
-        self.max_entries
+        self.entries.max_entries()
     }
 
     pub fn memory_budget_bytes(&self) -> usize {
-        self.memory_budget_bytes
+        self.entries.memory_budget_bytes()
     }
 
     pub fn contains(&self, key: &RenderedPageKey) -> bool {
@@ -181,33 +124,15 @@ impl RenderedPageCache {
     }
 
     pub fn memory_bytes(&self) -> usize {
-        self.memory_bytes
+        self.entries.memory_bytes()
     }
 
     pub fn counters(&self) -> CacheCounters {
-        self.counters
+        self.entries.counters()
     }
 
     pub fn hit_rate(&self) -> f64 {
-        let lookups = self.counters.hits + self.counters.misses;
-        if lookups == 0 {
-            return 0.0;
-        }
-        self.counters.hits as f64 / lookups as f64
-    }
-
-    fn evict_while_needed(&mut self) {
-        while self.entries.len() > self.max_entries || self.memory_bytes > self.memory_budget_bytes
-        {
-            if self.entries.len() == 1 {
-                break;
-            }
-            let Some((_key, frame)) = self.entries.pop_lru() else {
-                break;
-            };
-            self.memory_bytes = self.memory_bytes.saturating_sub(frame.byte_len());
-            self.counters.evictions += 1;
-        }
+        self.entries.hit_rate()
     }
 }
 

--- a/src/search/worker.rs
+++ b/src/search/worker.rs
@@ -1,12 +1,11 @@
 use std::collections::HashSet;
 use std::mem::size_of;
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 
-use lru::LruCache;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, error::TryRecvError};
 
 use crate::backend::{SharedPdfBackend, TextGlyph, TextPage};
+use crate::cache::{BudgetedLruCache, CacheLimits, EvictionPolicy, InsertPolicy, OversizePolicy};
 
 use super::engine::{SearchEvent, SearchPageHit, SearchSnapshot};
 use super::matcher::{SearchMatcher, apply_hit_snippet, occurrence_highlight_unavailable};
@@ -71,99 +70,8 @@ struct SearchPageCacheKey {
     page: usize,
 }
 
-struct BudgetedPageCacheEntry<V> {
-    value: V,
-    estimated_bytes: usize,
-}
-
-struct BudgetedPageCache<V> {
-    pages: LruCache<SearchPageCacheKey, BudgetedPageCacheEntry<V>>,
-    memory_budget_bytes: usize,
-    memory_bytes: usize,
-}
-
 struct SearchPageCache {
-    pages: BudgetedPageCache<Arc<TextPage>>,
-}
-
-impl<V> BudgetedPageCache<V> {
-    fn with_limits(max_entries: usize, memory_budget_bytes: usize) -> Self {
-        let max_entries =
-            NonZeroUsize::new(max_entries).expect("search cache entries must be non-zero");
-        Self {
-            pages: LruCache::new(max_entries),
-            memory_budget_bytes,
-            memory_bytes: 0,
-        }
-    }
-
-    fn get(&mut self, doc_id: u64, page: usize) -> Option<&V> {
-        self.pages
-            .get(&SearchPageCacheKey { doc_id, page })
-            .map(|cached| &cached.value)
-    }
-
-    fn insert(&mut self, doc_id: u64, page: usize, value: V, estimated_bytes: usize) {
-        let key = SearchPageCacheKey { doc_id, page };
-        if let Some(replaced) = self.pages.pop(&key) {
-            self.memory_bytes = self.memory_bytes.saturating_sub(replaced.estimated_bytes);
-        }
-        if let Some((_key, removed)) = self.pages.push(
-            key,
-            BudgetedPageCacheEntry {
-                value,
-                estimated_bytes,
-            },
-        ) {
-            self.memory_bytes = self.memory_bytes.saturating_sub(removed.estimated_bytes);
-        }
-        self.memory_bytes = self.memory_bytes.saturating_add(estimated_bytes);
-        self.enforce_memory_budget();
-    }
-
-    fn try_insert_without_eviction(
-        &mut self,
-        doc_id: u64,
-        page: usize,
-        value: V,
-        estimated_bytes: usize,
-    ) -> bool {
-        let key = SearchPageCacheKey { doc_id, page };
-        let replaced_bytes = self
-            .pages
-            .peek(&key)
-            .map_or(0, |cached| cached.estimated_bytes);
-        let projected_memory_bytes = self
-            .memory_bytes
-            .saturating_sub(replaced_bytes)
-            .saturating_add(estimated_bytes);
-        if projected_memory_bytes > self.memory_budget_bytes {
-            return false;
-        }
-
-        self.insert(doc_id, page, value, estimated_bytes);
-        true
-    }
-
-    fn enforce_memory_budget(&mut self) {
-        while self.memory_bytes > self.memory_budget_bytes {
-            let Some((_key, evicted)) = self.pages.pop_lru() else {
-                self.memory_bytes = 0;
-                break;
-            };
-            self.memory_bytes = self.memory_bytes.saturating_sub(evicted.estimated_bytes);
-        }
-    }
-
-    #[cfg(test)]
-    fn len(&self) -> usize {
-        self.pages.len()
-    }
-
-    #[cfg(test)]
-    fn memory_bytes(&self) -> usize {
-        self.memory_bytes
-    }
+    pages: BudgetedLruCache<SearchPageCacheKey, Arc<TextPage>>,
 }
 
 impl SearchPageCache {
@@ -176,17 +84,24 @@ impl SearchPageCache {
 
     fn with_limits(max_entries: usize, memory_budget_bytes: usize) -> Self {
         Self {
-            pages: BudgetedPageCache::with_limits(max_entries, memory_budget_bytes),
+            pages: BudgetedLruCache::new(CacheLimits::new(max_entries, memory_budget_bytes)),
         }
     }
 
     fn get(&mut self, doc_id: u64, page: usize) -> Option<Arc<TextPage>> {
-        self.pages.get(doc_id, page).map(Arc::clone)
+        self.pages
+            .get(&SearchPageCacheKey { doc_id, page })
+            .map(Arc::clone)
     }
 
     fn insert(&mut self, doc_id: u64, page: usize, text_page: Arc<TextPage>) {
         let estimated_bytes = estimate_text_page_bytes(&text_page);
-        self.pages.insert(doc_id, page, text_page, estimated_bytes);
+        let _ = self.pages.insert(
+            SearchPageCacheKey { doc_id, page },
+            text_page,
+            estimated_bytes,
+            InsertPolicy::NORMAL,
+        );
     }
 
     fn try_insert_without_eviction(
@@ -197,7 +112,16 @@ impl SearchPageCache {
     ) -> bool {
         let estimated_bytes = estimate_text_page_bytes(&text_page);
         self.pages
-            .try_insert_without_eviction(doc_id, page, text_page, estimated_bytes)
+            .insert(
+                SearchPageCacheKey { doc_id, page },
+                text_page,
+                estimated_bytes,
+                InsertPolicy {
+                    oversize: OversizePolicy::Reject,
+                    eviction: EvictionPolicy::RejectIfEvictionRequired,
+                },
+            )
+            .inserted
     }
 
     #[cfg(test)]


### PR DESCRIPTION
## Problem

The L1 render cache, L2 terminal frame cache, and search page cache each had their own LRU and memory-budget accounting. That duplicated eviction logic and made protected-entry and oversize behavior harder to reason about consistently.

## Solution

- Add a shared `BudgetedLruCache` for size-aware LRU storage, hit/miss counters, protected eviction, oversize admission, and removed-entry outcomes.
- Rework the render, presenter, and search caches into thin domain wrappers over the shared cache.
- Keep L2-specific pending-work accounting in the presenter wrapper by consuming removed-entry outcomes.
- Add cache contract tests, including protected insertion behavior where the new item must not be reported as inserted if it cannot remain cached.

## Verification

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared, budget-aware caching system that tracks entry count, memory use, hits, misses, and evictions.
  * Improved cache behavior with configurable oversize handling and protected-entry eviction rules.

* **Bug Fixes**
  * Reduced inconsistent cache accounting by centralizing memory and counter updates.
  * Preserved cached-item ordering and retrieval behavior across cache operations.

* **Refactor**
  * Updated page, render, search, and presenter caching to use the new shared cache foundation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->