### PR TITLE
refactor(app): drive perf through loop driver

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,9 +1,9 @@
 # Architecture
 
 `pvf` is a Rust CLI/TUI PDF viewer. The runtime is organized around one
-interactive `App`, a typed event loop, static command and palette registries,
-internal extensions, asynchronous render and encode workers, and a backend
-abstraction for PDF data.
+interactive `App`, a typed event loop with driver-controlled execution,
+static command and palette registries, internal extensions, asynchronous
+render and encode workers, and a backend abstraction for PDF data.
 
 ## Runtime Flow
 
@@ -45,6 +45,10 @@ can operate on resolved policies rather than re-reading config or CLI state.
   caching, encode workers, slot drawing, and presenter feedback.
 - [src/backend/](../src/backend/) owns the PDF backend trait and default backend implementation.
 - [src/ui/](../src/ui/) owns layout, chrome, overlays, help, theme, and frame composition.
+- [src/perf/](../src/perf/) owns headless performance diagnostics, scenario
+  drivers, and JSON report construction.
+- [src/metrics.rs](../src/metrics.rs) owns low-level runtime and presenter
+  metric primitives shared by diagnostics and runtime instrumentation.
 
 ## Dependency Direction
 
@@ -67,6 +71,11 @@ data crosses from extensions to palettes through `ExtensionUiSnapshot`.
 
 Render workers and presenter encode workers communicate with the loop through
 typed request and completion values. They do not mutate app state directly.
+
+Performance diagnostics drive the same event loop through the app-owned loop
+driver contract. The `perf` subsystem owns headless scenarios and reports;
+`app` owns terminal/session coordination and does not depend on performance
+diagnostic scenario types.
 
 Rationale: the central `App` boundary keeps mutable runtime state in one place,
 while commands, palettes, extensions, and workers remain testable through typed
@@ -144,6 +153,12 @@ plugin system.
 Render and presenter:
 Raw page rasterization and terminal protocol encoding are separated because
 their cache identities, stale-result rules, and performance costs differ.
+
+Performance diagnostics:
+Headless diagnostics are modeled as loop drivers so they exercise the same
+runtime path as the interactive viewer. Low-level metrics live outside `perf`
+because render, presenter, and app instrumentation can record them without
+depending on diagnostic report ownership.
 
 Backend:
 The backend trait isolates PDF opening, rasterization, text extraction, and

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -462,7 +462,8 @@ Owned by:
 - [benches/perf.rs](../benches/perf.rs)
 - [benches/fixtures/](../benches/fixtures/)
 - [src/perf/](../src/perf/)
-- [src/app/perf_runner.rs](../src/app/perf_runner.rs)
+- [src/app/loop_driver.rs](../src/app/loop_driver.rs)
+- [src/metrics.rs](../src/metrics.rs)
 
 Test coverage:
 - [src/perf/](../src/perf/) tests for scenario parsing, validation, summary shape, and report

--- a/src/app/actors.rs
+++ b/src/app/actors.rs
@@ -5,7 +5,7 @@ use crossterm::event::{Event, KeyEventKind};
 use crate::backend::PdfBackend;
 use crate::config::RenderPolicy;
 use crate::error::AppResult;
-use crate::perf::{PerfStats, RedrawReason};
+use crate::metrics::{PerfStats, RedrawReason};
 use crate::presenter::PanOffset;
 use crate::render::worker::{RenderWorker, RenderWorkerResult};
 

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -220,6 +220,14 @@ impl App {
         self.watch_policy.enabled = watch;
     }
 
+    pub(crate) fn enable_metrics_collection(&mut self) -> AppResult<()> {
+        self.render.runtime.perf_stats.reset();
+        self.render.presenter.initialize_headless_for_perf()?;
+        self.render.runtime.perf_stats.enable_sample_collection();
+        self.render.presenter.enable_perf_sample_collection();
+        Ok(())
+    }
+
     pub(crate) fn run_options(&self) -> RunOptions {
         self.run_options
     }

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -7,22 +7,20 @@ use tokio::time::{self, MissedTickBehavior};
 use crate::backend::{PdfBackend, SharedPdfBackend};
 use crate::error::{AppError, AppResult};
 use crate::event::DomainEvent;
-use crate::perf::{PerfIterationSnapshot, PerfScenarioId, PerfScenarioParameters};
 use crate::presenter::ImagePresenter;
 use crate::render::worker::RenderWorker;
 
 use super::actors::{InputActor, RenderActor, UiActor};
 use super::core::{App, RunOptions};
 use super::event_bus::EventBusRuntime;
-use super::loop_runtime::{
-    ActiveDocument, LoopControl, LoopRuntime, LoopStep, SessionRestore, WaitEvent,
+use super::loop_driver::{
+    InteractiveLoopDriver, LoopDriver, LoopDriverDecision, LoopDriverHandle, LoopEventMode,
+    LoopMetricsSnapshot, LoopObservation,
 };
-use super::perf_runner::{
-    HeadlessTerminalSession, PERF_HEADLESS_HEIGHT, PERF_HEADLESS_WIDTH, PerfLoopDriver,
-};
+use super::loop_runtime::{ActiveDocument, LoopControl, LoopRuntime, LoopStep, WaitEvent};
 use super::render_ops::PrefetchDispatchPlan;
 use super::scale::select_input_poll_timeout;
-use super::terminal_session::{InteractiveTerminalSession, TerminalSurface};
+use super::terminal_session::{InteractiveTerminalSession, TerminalSession, TerminalSurface};
 
 impl App {
     pub async fn run(&mut self, pdf: SharedPdfBackend) -> AppResult<()> {
@@ -34,15 +32,39 @@ impl App {
         pdf: SharedPdfBackend,
         options: RunOptions,
     ) -> AppResult<()> {
+        let session = InteractiveTerminalSession::enter()?;
+        self.run_loop(
+            pdf,
+            session,
+            LoopEventMode::Interactive {
+                watch: options.watch,
+            },
+            InteractiveLoopDriver,
+        )
+        .await
+    }
+
+    pub(crate) async fn run_loop<S, D>(
+        &mut self,
+        pdf: SharedPdfBackend,
+        session: S,
+        event_mode: LoopEventMode,
+        mut driver: D,
+    ) -> AppResult<D::Output>
+    where
+        S: TerminalSession,
+        D: LoopDriver,
+    {
         let page_count = pdf.page_count();
         if page_count == 0 {
             return Err(AppError::invalid_argument("pdf has no pages"));
         }
 
         let mut document = ActiveDocument::new(pdf);
-        let session = InteractiveTerminalSession::enter()?;
-        let (loop_event_tx, loop_event_rx, loop_event_runtime) =
-            EventBusRuntime::spawn_interactive();
+        let (loop_event_tx, loop_event_rx, loop_event_runtime) = match event_mode {
+            LoopEventMode::Interactive { .. } => EventBusRuntime::spawn_interactive(),
+            LoopEventMode::Headless => EventBusRuntime::spawn_headless(),
+        };
         let mut runtime = self.initialize_loop_runtime(
             Arc::clone(&document.pdf),
             page_count,
@@ -51,61 +73,33 @@ impl App {
             loop_event_rx,
             loop_event_runtime,
         )?;
-        runtime
-            .loop_event_runtime
-            .start_input(runtime.loop_event_tx.clone());
-        if options.watch {
-            runtime.loop_event_runtime.start_file_watch(
-                document.path.clone(),
-                self.watch_policy.poll_interval,
-                self.watch_policy.settle_delay,
-                runtime.loop_event_tx.clone(),
-            );
-        }
-        let result = self.run_interactive_loop(&mut runtime, &mut document).await;
-        runtime.loop_event_runtime.shutdown();
-        let restore_result = runtime.session.restore();
-        result?;
-        restore_result
-            .map_err(|source| AppError::io_with_context(source, "restoring terminal session"))?;
-        Ok(())
-    }
-
-    pub async fn run_perf(
-        &mut self,
-        pdf: SharedPdfBackend,
-        scenario: PerfScenarioId,
-        parameters: PerfScenarioParameters,
-        cold_started_at: Instant,
-    ) -> AppResult<PerfIterationSnapshot> {
-        let page_count = pdf.page_count();
-        if page_count == 0 {
-            return Err(AppError::invalid_argument("pdf has no pages"));
+        if let LoopEventMode::Interactive { watch } = event_mode {
+            runtime
+                .loop_event_runtime
+                .start_input(runtime.loop_event_tx.clone());
+            if watch {
+                runtime.loop_event_runtime.start_file_watch(
+                    document.path.clone(),
+                    self.watch_policy.poll_interval,
+                    self.watch_policy.settle_delay,
+                    runtime.loop_event_tx.clone(),
+                );
+            }
         }
 
-        self.render.runtime.perf_stats.reset();
-        self.render.presenter.initialize_headless_for_perf()?;
-        self.render.runtime.perf_stats.enable_sample_collection();
-        self.render.presenter.enable_perf_sample_collection();
-        let session = HeadlessTerminalSession::new(PERF_HEADLESS_WIDTH, PERF_HEADLESS_HEIGHT)?;
-        let (loop_event_tx, loop_event_rx, loop_event_runtime) = EventBusRuntime::spawn_headless();
-        let mut runtime = self.initialize_loop_runtime(
-            Arc::clone(&pdf),
-            page_count,
-            session,
-            loop_event_tx,
-            loop_event_rx,
-            loop_event_runtime,
-        )?;
         let result = self
-            .run_perf_loop(&mut runtime, pdf, scenario, parameters, cold_started_at)
+            .run_driver_loop(&mut runtime, &mut document, &mut driver)
             .await;
         runtime.loop_event_runtime.shutdown();
         let restore_result = runtime.session.restore();
-        let snapshot = result?;
-        restore_result
-            .map_err(|source| AppError::io_with_context(source, "restoring terminal session"))?;
-        Ok(snapshot)
+        match (result, restore_result) {
+            (Ok(output), Ok(())) => Ok(output),
+            (Ok(_), Err(source)) => Err(AppError::io_with_context(
+                source,
+                "restoring terminal session",
+            )),
+            (Err(err), _) => Err(err),
+        }
     }
 
     fn initialize_loop_runtime<S>(
@@ -175,67 +169,62 @@ impl App {
         })
     }
 
-    async fn run_interactive_loop(
+    async fn run_driver_loop<S, D>(
         &mut self,
-        runtime: &mut LoopRuntime<InteractiveTerminalSession>,
+        runtime: &mut LoopRuntime<S>,
         document: &mut ActiveDocument,
-    ) -> AppResult<()> {
+        driver: &mut D,
+    ) -> AppResult<D::Output>
+    where
+        S: TerminalSession,
+        D: LoopDriver,
+    {
         loop {
             let step = self.process_loop_iteration(runtime, document.pdf.as_ref())?;
+            let observation = self.loop_observation(runtime, &step);
+            let mut handle = LoopDriverHandle::new(&runtime.loop_event_tx);
+            match driver.on_iteration(observation, &mut handle)? {
+                LoopDriverDecision::Continue => {}
+                LoopDriverDecision::Finish => {
+                    return driver.on_finish(observation, self.loop_metrics_snapshot());
+                }
+            }
+
             match self
                 .wait_and_handle_next_event(runtime, &step, document)
                 .await?
             {
                 LoopControl::Continue => {}
-                LoopControl::Break => return Ok(()),
+                LoopControl::Break => return driver.on_loop_break(),
             }
         }
     }
 
-    async fn run_perf_loop(
-        &mut self,
-        runtime: &mut LoopRuntime<HeadlessTerminalSession>,
-        pdf: SharedPdfBackend,
-        scenario: PerfScenarioId,
-        parameters: PerfScenarioParameters,
-        cold_started_at: Instant,
-    ) -> AppResult<PerfIterationSnapshot> {
-        let mut perf_driver = PerfLoopDriver::new(scenario, parameters, cold_started_at);
-        let mut document = ActiveDocument::new(pdf);
+    fn loop_observation<S>(&self, runtime: &LoopRuntime<S>, step: &LoopStep) -> LoopObservation {
+        let render_in_flight = runtime.render_worker.in_flight_len();
+        let presenter_pending = self.render.presenter.has_pending_work();
+        let redraw_pending = runtime.ui_actor.needs_redraw();
+        let event_queue_empty = runtime.loop_event_rx.is_empty();
+        LoopObservation {
+            page_count: runtime.page_count,
+            current_page: self.state.current_page,
+            current_cached: step.current_cached,
+            render_in_flight,
+            presenter_pending,
+            redraw_pending,
+            event_queue_empty,
+            system_idle: step.current_cached
+                && render_in_flight == 0
+                && !presenter_pending
+                && !redraw_pending
+                && event_queue_empty,
+        }
+    }
 
-        loop {
-            let step = self.process_loop_iteration(runtime, document.pdf.as_ref())?;
-            let system_idle = step.current_cached
-                && runtime.render_worker.in_flight_len() == 0
-                && !self.render.presenter.has_pending_work()
-                && !runtime.ui_actor.needs_redraw()
-                && runtime.loop_event_rx.is_empty();
-            if perf_driver.advance(
-                &self.state,
-                runtime.page_count,
-                system_idle,
-                &runtime.loop_event_tx,
-            ) {
-                return Ok(PerfIterationSnapshot {
-                    runtime: self.render.runtime.perf_stats.clone(),
-                    presenter: self.render.presenter.perf_snapshot().unwrap_or_default(),
-                    wall_time: perf_driver.measured_elapsed(),
-                    final_page: self.state.current_page,
-                    visited_steps: perf_driver.visited_steps(),
-                });
-            }
-
-            match self
-                .wait_and_handle_next_event(runtime, &step, &mut document)
-                .await?
-            {
-                LoopControl::Continue => {}
-                LoopControl::Break => {
-                    return Err(AppError::unsupported(
-                        "perf run ended before producing a report",
-                    ));
-                }
-            }
+    fn loop_metrics_snapshot(&self) -> LoopMetricsSnapshot {
+        LoopMetricsSnapshot {
+            runtime: self.render.runtime.perf_stats.clone(),
+            presenter: self.render.presenter.perf_snapshot().unwrap_or_default(),
         }
     }
 
@@ -292,7 +281,7 @@ impl App {
         document: &mut ActiveDocument,
     ) -> AppResult<LoopControl>
     where
-        S: TerminalSurface + SessionRestore,
+        S: TerminalSession,
     {
         let render_busy = runtime.render_worker.in_flight_len() > 0;
         let presenter_busy = self.render.presenter.has_pending_work();
@@ -490,7 +479,7 @@ mod tests {
     use crate::app::App;
     use crate::app::core::InteractionSubsystem;
     use crate::app::loop_runtime::ActiveDocument;
-    use crate::app::terminal_session::TerminalSurface;
+    use crate::app::terminal_session::{TerminalSession, TerminalSurface};
     use crate::backend::test_support::{build_pdf, unique_temp_path};
     use crate::backend::{PdfDoc, SharedPdfBackend};
     use crate::command::{
@@ -594,7 +583,7 @@ mod tests {
         }
     }
 
-    impl super::SessionRestore for StubSession {
+    impl TerminalSession for StubSession {
         fn restore(&mut self) -> io::Result<()> {
             Ok(())
         }

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -55,6 +55,7 @@ impl App {
         S: TerminalSession,
         D: LoopDriver,
     {
+        let session = RestoringSession::new(session);
         let page_count = pdf.page_count();
         if page_count == 0 {
             return Err(AppError::invalid_argument("pdf has no pages"));
@@ -460,14 +461,60 @@ async fn wait_next_event(
     }
 }
 
+struct RestoringSession<S: TerminalSession> {
+    session: S,
+    active: bool,
+}
+
+impl<S: TerminalSession> RestoringSession<S> {
+    fn new(session: S) -> Self {
+        Self {
+            session,
+            active: true,
+        }
+    }
+}
+
+impl<S: TerminalSession> TerminalSurface for RestoringSession<S> {
+    fn size(&self) -> std::io::Result<ratatui::layout::Size> {
+        self.session.size()
+    }
+
+    fn draw<F>(&mut self, render: F) -> std::io::Result<()>
+    where
+        F: FnOnce(&mut ratatui::Frame<'_>),
+    {
+        self.session.draw(render)
+    }
+}
+
+impl<S: TerminalSession> TerminalSession for RestoringSession<S> {
+    fn restore(&mut self) -> std::io::Result<()> {
+        if !self.active {
+            return Ok(());
+        }
+        self.session.restore()?;
+        self.active = false;
+        Ok(())
+    }
+}
+
+impl<S: TerminalSession> Drop for RestoringSession<S> {
+    fn drop(&mut self) {
+        let _ = self.restore();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
     use std::fs;
     use std::future::Future;
     use std::io;
+    use std::path::{Path, PathBuf};
     use std::pin::Pin;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
@@ -480,13 +527,17 @@ mod tests {
     use crate::app::core::InteractionSubsystem;
     use crate::app::loop_runtime::ActiveDocument;
     use crate::app::terminal_session::{TerminalSession, TerminalSurface};
+    use crate::app::{
+        LoopDriver, LoopDriverDecision, LoopDriverHandle, LoopMetricsSnapshot, LoopObservation,
+    };
     use crate::backend::test_support::{build_pdf, unique_temp_path};
-    use crate::backend::{PdfDoc, SharedPdfBackend};
+    use crate::backend::{OutlineNode, PdfBackend, PdfDoc, RgbaFrame, SharedPdfBackend, TextPage};
     use crate::command::{
         Command, CommandInvocationSource, CommandRequest, PanAmount, PanDirection,
     };
     use crate::condition::ConditionExpr;
     use crate::config::Config;
+    use crate::error::{AppError, AppResult};
     use crate::event::{
         DocumentReloadReason, DocumentReloadRequest, DocumentReloadResult, DomainEvent,
     };
@@ -560,12 +611,21 @@ mod tests {
 
     struct StubSession {
         size: Size,
+        restore_count: Option<Arc<AtomicUsize>>,
     }
 
     impl StubSession {
         fn new(width: u16, height: u16) -> Self {
             Self {
                 size: Size::new(width, height),
+                restore_count: None,
+            }
+        }
+
+        fn with_restore_count(width: u16, height: u16, restore_count: Arc<AtomicUsize>) -> Self {
+            Self {
+                size: Size::new(width, height),
+                restore_count: Some(restore_count),
             }
         }
     }
@@ -585,7 +645,79 @@ mod tests {
 
     impl TerminalSession for StubSession {
         fn restore(&mut self) -> io::Result<()> {
+            if let Some(count) = &self.restore_count {
+                count.fetch_add(1, Ordering::Relaxed);
+            }
             Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct RestoreProbeDriver;
+
+    impl LoopDriver for RestoreProbeDriver {
+        type Output = ();
+
+        fn on_iteration(
+            &mut self,
+            _observation: LoopObservation,
+            _handle: &mut LoopDriverHandle<'_>,
+        ) -> AppResult<LoopDriverDecision> {
+            Ok(LoopDriverDecision::Finish)
+        }
+
+        fn on_finish(
+            &mut self,
+            _observation: LoopObservation,
+            _metrics: LoopMetricsSnapshot,
+        ) -> AppResult<Self::Output> {
+            Ok(())
+        }
+
+        fn on_loop_break(&mut self) -> AppResult<Self::Output> {
+            Ok(())
+        }
+    }
+
+    struct EmptyPdfBackend {
+        path: PathBuf,
+    }
+
+    impl EmptyPdfBackend {
+        fn new() -> Self {
+            Self {
+                path: PathBuf::from("empty.pdf"),
+            }
+        }
+    }
+
+    impl PdfBackend for EmptyPdfBackend {
+        fn path(&self) -> &Path {
+            &self.path
+        }
+
+        fn doc_id(&self) -> u64 {
+            0
+        }
+
+        fn page_count(&self) -> usize {
+            0
+        }
+
+        fn page_dimensions(&self, _page: usize) -> AppResult<(f32, f32)> {
+            Err(AppError::invalid_argument("empty pdf"))
+        }
+
+        fn render_page(&self, _page: usize, _scale: f32) -> AppResult<RgbaFrame> {
+            Err(AppError::invalid_argument("empty pdf"))
+        }
+
+        fn extract_text_page(&self, _page: usize) -> AppResult<TextPage> {
+            Err(AppError::invalid_argument("empty pdf"))
+        }
+
+        fn extract_outline(&self) -> AppResult<Vec<OutlineNode>> {
+            Ok(Vec::new())
         }
     }
 
@@ -604,6 +736,27 @@ mod tests {
         let doc = PdfDoc::open(&file).expect("pdf should open");
         fs::remove_file(&file).expect("test pdf should be removed");
         Arc::new(doc)
+    }
+
+    #[test]
+    fn run_loop_restores_session_when_pdf_has_no_pages() {
+        let tokio_runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should build");
+        let restore_count = Arc::new(AtomicUsize::new(0));
+        let mut app =
+            App::new_with_config(PresenterKind::RatatuiImage, Config::default()).expect("app init");
+        let session = StubSession::with_restore_count(80, 24, Arc::clone(&restore_count));
+        let pdf: SharedPdfBackend = Arc::new(EmptyPdfBackend::new());
+        let driver = RestoreProbeDriver;
+
+        let err = tokio_runtime
+            .block_on(app.run_loop(pdf, session, super::LoopEventMode::Headless, driver))
+            .expect_err("empty pdf should fail before the loop starts");
+
+        assert!(err.to_string().contains("pdf has no pages"));
+        assert_eq!(restore_count.load(Ordering::Relaxed), 1);
     }
 
     fn failed_render_result(

--- a/src/app/loop_driver.rs
+++ b/src/app/loop_driver.rs
@@ -1,0 +1,111 @@
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::command::{CommandInvocationSource, CommandRequest};
+use crate::error::{AppError, AppResult};
+use crate::event::DomainEvent;
+use crate::metrics::PerfStats;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LoopEventMode {
+    Interactive { watch: bool },
+    Headless,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LoopObservation {
+    pub(crate) page_count: usize,
+    pub(crate) current_page: usize,
+    pub(crate) current_cached: bool,
+    pub(crate) render_in_flight: usize,
+    pub(crate) presenter_pending: bool,
+    pub(crate) redraw_pending: bool,
+    pub(crate) event_queue_empty: bool,
+    pub(crate) system_idle: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum LoopDriverDecision {
+    Continue,
+    Finish,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct LoopMetricsSnapshot {
+    pub(crate) runtime: PerfStats,
+    pub(crate) presenter: PerfStats,
+}
+
+pub(crate) trait LoopDriver {
+    type Output;
+
+    fn on_iteration(
+        &mut self,
+        observation: LoopObservation,
+        handle: &mut LoopDriverHandle<'_>,
+    ) -> AppResult<LoopDriverDecision>;
+
+    fn on_finish(
+        &mut self,
+        observation: LoopObservation,
+        metrics: LoopMetricsSnapshot,
+    ) -> AppResult<Self::Output>;
+
+    fn on_loop_break(&mut self) -> AppResult<Self::Output>;
+}
+
+pub(crate) struct LoopDriverHandle<'a> {
+    loop_event_tx: &'a UnboundedSender<DomainEvent>,
+}
+
+impl<'a> LoopDriverHandle<'a> {
+    pub(crate) fn new(loop_event_tx: &'a UnboundedSender<DomainEvent>) -> Self {
+        Self { loop_event_tx }
+    }
+
+    pub(crate) fn enqueue_command(&mut self, request: CommandRequest) -> AppResult<()> {
+        self.loop_event_tx
+            .send(DomainEvent::Command(request))
+            .map_err(|_| AppError::unsupported("event loop command channel closed"))
+    }
+
+    pub(crate) fn enqueue_commands(
+        &mut self,
+        requests: impl IntoIterator<Item = CommandRequest>,
+    ) -> AppResult<()> {
+        for request in requests {
+            self.enqueue_command(request)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct InteractiveLoopDriver;
+
+impl LoopDriver for InteractiveLoopDriver {
+    type Output = ();
+
+    fn on_iteration(
+        &mut self,
+        _observation: LoopObservation,
+        _handle: &mut LoopDriverHandle<'_>,
+    ) -> AppResult<LoopDriverDecision> {
+        Ok(LoopDriverDecision::Continue)
+    }
+
+    fn on_finish(
+        &mut self,
+        _observation: LoopObservation,
+        _metrics: LoopMetricsSnapshot,
+    ) -> AppResult<Self::Output> {
+        Ok(())
+    }
+
+    fn on_loop_break(&mut self) -> AppResult<Self::Output> {
+        Ok(())
+    }
+}
+
+pub(crate) fn binding_request(command: crate::command::Command) -> CommandRequest {
+    CommandRequest::new(command, CommandInvocationSource::Binding)
+}

--- a/src/app/loop_effects.rs
+++ b/src/app/loop_effects.rs
@@ -1,6 +1,6 @@
 use crate::command::CommandRequest;
 use crate::event::DomainEvent;
-use crate::perf::RedrawReason;
+use crate::metrics::RedrawReason;
 
 #[derive(Default)]
 pub(super) struct LoopEffects {

--- a/src/app/loop_router.rs
+++ b/src/app/loop_router.rs
@@ -7,8 +7,8 @@ use crate::error::{AppError, AppResult};
 use crate::event::{
     AppEvent, DocumentReloadReason, DocumentReloadRequest, DocumentReloadResult, DomainEvent,
 };
+use crate::metrics::RedrawReason;
 use crate::palette::PaletteKind;
-use crate::perf::RedrawReason;
 use crate::presenter::PresenterBackgroundEvent;
 use crate::render::worker::RenderWorker;
 
@@ -16,10 +16,10 @@ use super::actors::RenderCompleteContext;
 use super::core::App;
 use super::loop_effects::LoopEffects;
 use super::loop_runtime::{
-    ActiveDocument, LoopControl, LoopRuntime, SessionRestore, WaitEvent, terminate_process_now,
+    ActiveDocument, LoopControl, LoopRuntime, WaitEvent, terminate_process_now,
 };
 use super::state::{Mode, notice_action_for_error};
-use super::terminal_session::TerminalSurface;
+use super::terminal_session::{TerminalSession, TerminalSurface};
 
 const FILE_RELOAD_RETRY_DELAYS: [Duration; 5] = [
     Duration::from_millis(250),
@@ -66,7 +66,7 @@ impl App {
         document: &mut ActiveDocument,
     ) -> AppResult<LoopControl>
     where
-        S: TerminalSurface + SessionRestore,
+        S: TerminalSession,
     {
         // Wake events are not guaranteed to arrive before the next input event, so the
         // loop checks for timed-out sequences at the start of every iteration as well.
@@ -176,7 +176,7 @@ impl App {
         effects: LoopEffects,
     ) -> AppResult<LoopControl>
     where
-        S: TerminalSurface + SessionRestore,
+        S: TerminalSession,
     {
         let (commands, events, redraws) = effects.into_parts();
         for reason in redraws {
@@ -241,7 +241,7 @@ impl App {
         document: &mut ActiveDocument,
     ) -> AppResult<LoopControl>
     where
-        S: TerminalSurface + SessionRestore,
+        S: TerminalSession,
     {
         let request = self.resolve_command_request(&runtime.session, request);
         if matches!(request.command, Command::ReloadDocument) {

--- a/src/app/loop_runtime.rs
+++ b/src/app/loop_runtime.rs
@@ -13,9 +13,8 @@ use crate::render::worker::RenderWorker;
 
 use super::actors::{InputActor, RenderActor, UiActor};
 use super::event_bus::EventBusRuntime;
-use super::perf_runner::HeadlessTerminalSession;
 use super::render_ops::{CurrentInterestKeys, PrefetchDispatchContext, RequiredRenderPages};
-use super::terminal_session::InteractiveTerminalSession;
+use super::terminal_session::TerminalSession;
 use super::view_ops::InitialPreviewPlan;
 
 pub(super) struct LoopRuntime<S> {
@@ -78,25 +77,9 @@ pub(super) enum LoopControl {
     Break,
 }
 
-pub(super) trait SessionRestore {
-    fn restore(&mut self) -> std::io::Result<()>;
-}
-
-impl SessionRestore for InteractiveTerminalSession {
-    fn restore(&mut self) -> std::io::Result<()> {
-        InteractiveTerminalSession::restore(self)
-    }
-}
-
-impl SessionRestore for HeadlessTerminalSession {
-    fn restore(&mut self) -> std::io::Result<()> {
-        HeadlessTerminalSession::restore(self)
-    }
-}
-
 pub(super) fn terminate_process_now<S>(runtime: &mut LoopRuntime<S>) -> !
 where
-    S: super::terminal_session::TerminalSurface + SessionRestore,
+    S: TerminalSession,
 {
     runtime.loop_event_runtime.shutdown();
     if let Err(err) = runtime.session.restore() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5,11 +5,11 @@ mod event_bus;
 mod event_loop;
 mod frame_ops;
 mod input_ops;
+mod loop_driver;
 mod loop_effects;
 mod loop_router;
 mod loop_runtime;
 mod nav;
-mod perf_runner;
 mod render_ops;
 mod runtime;
 pub(crate) mod scale;
@@ -26,3 +26,9 @@ pub use state::{
     AppState, CacheHandle, CacheRefs, Mode, Notice, NoticeAction, NoticeLevel, PageLayoutMode,
     PaletteRequest, SpreadCoverPolicy, SpreadDirection, VisiblePageSlots, notice_action_for_error,
 };
+
+pub(crate) use loop_driver::{
+    LoopDriver, LoopDriverDecision, LoopDriverHandle, LoopEventMode, LoopMetricsSnapshot,
+    LoopObservation, binding_request,
+};
+pub(crate) use terminal_session::{TerminalSession, TerminalSurface};

--- a/src/app/render_ops.rs
+++ b/src/app/render_ops.rs
@@ -471,7 +471,7 @@ mod tests {
     use crate::app::{NoticeLevel, RenderRuntime};
     use crate::backend::RgbaFrame;
     use crate::error::{AppError, AppResult};
-    use crate::perf::PerfStats;
+    use crate::metrics::PerfStats;
     use crate::presenter::{
         ImagePresenter, PanOffset, PresenterCaps, PresenterFeedback, PresenterRenderOutcome,
         PresenterRenderSlot, PresenterSlot,

--- a/src/app/runtime/mod.rs
+++ b/src/app/runtime/mod.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use crate::backend::{PdfBackend, RgbaFrame};
 use crate::error::{AppError, AppResult};
-use crate::perf::PerfStats;
+use crate::metrics::PerfStats;
 use crate::presenter::ImagePresenter;
 use crate::render::cache::{RenderedPageCache, RenderedPageKey};
 use crate::render::scheduler::{

--- a/src/app/terminal_session.rs
+++ b/src/app/terminal_session.rs
@@ -18,6 +18,10 @@ pub(crate) trait TerminalSurface {
         F: FnOnce(&mut Frame<'_>);
 }
 
+pub(crate) trait TerminalSession: TerminalSurface {
+    fn restore(&mut self) -> io::Result<()>;
+}
+
 pub(crate) struct InteractiveTerminalSession {
     terminal: Terminal<CrosstermBackend<Stdout>>,
     active: bool,
@@ -84,6 +88,12 @@ impl TerminalSurface for InteractiveTerminalSession {
         F: FnOnce(&mut Frame<'_>),
     {
         self.terminal.draw(render).map(|_| ())
+    }
+}
+
+impl TerminalSession for InteractiveTerminalSession {
+    fn restore(&mut self) -> io::Result<()> {
+        InteractiveTerminalSession::restore(self)
     }
 }
 

--- a/src/app/tests/runtime_worker.rs
+++ b/src/app/tests/runtime_worker.rs
@@ -14,7 +14,7 @@ use crate::backend::test_support::{build_pdf, unique_temp_path};
 use crate::backend::{OutlineNode, PdfBackend, PdfDoc, PdfRect, RgbaFrame, SharedPdfBackend};
 use crate::error::{AppError, AppResult};
 use crate::highlight::{HighlightOverlaySnapshot, HighlightSource, HighlightSpan, HighlightStyle};
-use crate::perf::PerfStats;
+use crate::metrics::PerfStats;
 use crate::presenter::{
     ImagePresenter, PanOffset, PresenterCaps, PresenterFeedback, PresenterRenderOptions,
     PresenterRenderOutcome, PresenterRenderSlot, PresenterSlot, Viewport,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod app;
 pub mod backend;
 pub mod config;
 pub mod error;
+pub mod metrics;
 pub mod perf;
 pub mod presenter;
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -162,6 +162,7 @@ impl PerfStats {
     }
 
     pub fn add_encode_canceled_tasks(&mut self, canceled: usize) {
+        self.canceled_tasks += canceled;
         self.encode_canceled_tasks += canceled;
     }
 
@@ -179,6 +180,7 @@ impl PerfStats {
         self.encode_queue_depth = presenter.encode_queue_depth;
         self.encode_in_flight = presenter.encode_in_flight;
         self.encode_canceled_tasks = presenter.encode_canceled_tasks;
+        self.canceled_tasks = self.render_canceled_tasks + self.encode_canceled_tasks;
         self.encode_samples_ms = presenter.encode_samples_ms.clone();
         self.blit_samples_ms = presenter.blit_samples_ms.clone();
         self.encode_queue_wait_samples_ms = presenter.encode_queue_wait_samples_ms.clone();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,266 @@
+use std::time::Duration;
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RedrawReason {
+    Input,
+    Command,
+    AppEvent,
+    RenderComplete,
+    PendingWork,
+    Timer,
+    InputError,
+    StateChanged,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
+pub struct RedrawReasonCounts {
+    pub input: u64,
+    pub command: u64,
+    pub app_event: u64,
+    pub render_complete: u64,
+    pub pending_work: u64,
+    pub timer: u64,
+    pub input_error: u64,
+    pub state_changed: u64,
+}
+
+impl RedrawReasonCounts {
+    fn record(&mut self, reason: RedrawReason) {
+        match reason {
+            RedrawReason::Input => self.input += 1,
+            RedrawReason::Command => self.command += 1,
+            RedrawReason::AppEvent => self.app_event += 1,
+            RedrawReason::RenderComplete => self.render_complete += 1,
+            RedrawReason::PendingWork => self.pending_work += 1,
+            RedrawReason::Timer => self.timer += 1,
+            RedrawReason::InputError => self.input_error += 1,
+            RedrawReason::StateChanged => self.state_changed += 1,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct PerfStats {
+    pub render_ms: f64,
+    pub convert_ms: f64,
+    pub blit_ms: f64,
+    pub cache_hit_rate_l1: f64,
+    pub cache_hit_rate_l2: f64,
+    pub queue_depth: usize,
+    pub canceled_tasks: usize,
+    pub render_samples: u64,
+    pub convert_samples: u64,
+    pub blit_samples: u64,
+    pub render_in_flight: usize,
+    pub encode_queue_depth: usize,
+    pub encode_in_flight: usize,
+    pub render_canceled_tasks: usize,
+    pub encode_canceled_tasks: usize,
+    pub redraw_requests_total: u64,
+    pub redraw_by_reason: RedrawReasonCounts,
+    collect_samples: bool,
+    render_samples_ms: Vec<f64>,
+    encode_samples_ms: Vec<f64>,
+    blit_samples_ms: Vec<f64>,
+    render_queue_wait_samples_ms: Vec<f64>,
+    encode_queue_wait_samples_ms: Vec<f64>,
+    render_queue_depth_samples: Vec<usize>,
+    render_in_flight_samples: Vec<usize>,
+    encode_queue_depth_samples: Vec<usize>,
+    encode_in_flight_samples: Vec<usize>,
+}
+
+impl PerfStats {
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    pub fn enable_sample_collection(&mut self) {
+        self.collect_samples = true;
+    }
+
+    pub fn record_render(&mut self, elapsed: Duration) {
+        self.render_ms = elapsed.as_secs_f64() * 1000.0;
+        self.render_samples += 1;
+        if self.collect_samples {
+            self.render_samples_ms.push(self.render_ms);
+        }
+    }
+
+    pub fn record_convert(&mut self, elapsed: Duration) {
+        self.convert_ms = elapsed.as_secs_f64() * 1000.0;
+        self.convert_samples += 1;
+        if self.collect_samples {
+            self.encode_samples_ms.push(self.convert_ms);
+        }
+    }
+
+    pub fn record_blit(&mut self, elapsed: Duration) {
+        self.blit_ms = elapsed.as_secs_f64() * 1000.0;
+        self.blit_samples += 1;
+        if self.collect_samples {
+            self.blit_samples_ms.push(self.blit_ms);
+        }
+    }
+
+    pub fn record_render_queue_wait(&mut self, elapsed: Duration) {
+        if self.collect_samples {
+            self.render_queue_wait_samples_ms
+                .push(elapsed.as_secs_f64() * 1000.0);
+        }
+    }
+
+    pub fn record_encode_queue_wait(&mut self, elapsed: Duration) {
+        if self.collect_samples {
+            self.encode_queue_wait_samples_ms
+                .push(elapsed.as_secs_f64() * 1000.0);
+        }
+    }
+
+    pub fn set_l1_hit_rate(&mut self, rate: f64) {
+        self.cache_hit_rate_l1 = rate.clamp(0.0, 1.0);
+    }
+
+    pub fn set_l2_hit_rate(&mut self, rate: f64) {
+        self.cache_hit_rate_l2 = rate.clamp(0.0, 1.0);
+    }
+
+    pub fn set_queue_depth(&mut self, depth: usize) {
+        self.queue_depth = depth;
+        if self.collect_samples {
+            self.render_queue_depth_samples.push(depth);
+        }
+    }
+
+    pub fn set_render_in_flight(&mut self, inflight: usize) {
+        self.render_in_flight = inflight;
+        if self.collect_samples {
+            self.render_in_flight_samples.push(inflight);
+        }
+    }
+
+    pub fn set_encode_queue_depth(&mut self, depth: usize) {
+        self.encode_queue_depth = depth;
+        if self.collect_samples {
+            self.encode_queue_depth_samples.push(depth);
+        }
+    }
+
+    pub fn set_encode_in_flight(&mut self, inflight: usize) {
+        self.encode_in_flight = inflight;
+        if self.collect_samples {
+            self.encode_in_flight_samples.push(inflight);
+        }
+    }
+
+    pub fn add_canceled_tasks(&mut self, canceled: usize) {
+        self.canceled_tasks += canceled;
+        self.render_canceled_tasks += canceled;
+    }
+
+    pub fn add_encode_canceled_tasks(&mut self, canceled: usize) {
+        self.encode_canceled_tasks += canceled;
+    }
+
+    pub fn record_redraw(&mut self, reason: RedrawReason) {
+        self.redraw_requests_total += 1;
+        self.redraw_by_reason.record(reason);
+    }
+
+    pub fn absorb_presenter_metrics(&mut self, presenter: &PerfStats) {
+        self.convert_ms = presenter.convert_ms;
+        self.blit_ms = presenter.blit_ms;
+        self.cache_hit_rate_l2 = presenter.cache_hit_rate_l2;
+        self.convert_samples = presenter.convert_samples;
+        self.blit_samples = presenter.blit_samples;
+        self.encode_queue_depth = presenter.encode_queue_depth;
+        self.encode_in_flight = presenter.encode_in_flight;
+        self.encode_canceled_tasks = presenter.encode_canceled_tasks;
+        self.encode_samples_ms = presenter.encode_samples_ms.clone();
+        self.blit_samples_ms = presenter.blit_samples_ms.clone();
+        self.encode_queue_wait_samples_ms = presenter.encode_queue_wait_samples_ms.clone();
+        self.encode_queue_depth_samples = presenter.encode_queue_depth_samples.clone();
+        self.encode_in_flight_samples = presenter.encode_in_flight_samples.clone();
+    }
+
+    pub fn clear_blit_metrics(&mut self) {
+        self.blit_ms = 0.0;
+        self.blit_samples = 0;
+        self.blit_samples_ms.clear();
+    }
+
+    pub(crate) fn render_samples_ms(&self) -> &[f64] {
+        &self.render_samples_ms
+    }
+
+    pub(crate) fn encode_samples_ms(&self) -> &[f64] {
+        &self.encode_samples_ms
+    }
+
+    pub(crate) fn blit_samples_ms(&self) -> &[f64] {
+        &self.blit_samples_ms
+    }
+
+    pub(crate) fn render_queue_wait_samples_ms(&self) -> &[f64] {
+        &self.render_queue_wait_samples_ms
+    }
+
+    pub(crate) fn encode_queue_wait_samples_ms(&self) -> &[f64] {
+        &self.encode_queue_wait_samples_ms
+    }
+
+    pub(crate) fn render_queue_depth_samples(&self) -> &[usize] {
+        &self.render_queue_depth_samples
+    }
+
+    pub(crate) fn render_in_flight_samples(&self) -> &[usize] {
+        &self.render_in_flight_samples
+    }
+
+    pub(crate) fn encode_queue_depth_samples(&self) -> &[usize] {
+        &self.encode_queue_depth_samples
+    }
+
+    pub(crate) fn encode_in_flight_samples(&self) -> &[usize] {
+        &self.encode_in_flight_samples
+    }
+
+    pub(crate) fn extend_render_samples_ms(&mut self, samples: &[f64]) {
+        self.render_samples_ms.extend_from_slice(samples);
+    }
+
+    pub(crate) fn extend_encode_samples_ms(&mut self, samples: &[f64]) {
+        self.encode_samples_ms.extend_from_slice(samples);
+    }
+
+    pub(crate) fn extend_blit_samples_ms(&mut self, samples: &[f64]) {
+        self.blit_samples_ms.extend_from_slice(samples);
+    }
+
+    pub(crate) fn extend_render_queue_wait_samples_ms(&mut self, samples: &[f64]) {
+        self.render_queue_wait_samples_ms.extend_from_slice(samples);
+    }
+
+    pub(crate) fn extend_encode_queue_wait_samples_ms(&mut self, samples: &[f64]) {
+        self.encode_queue_wait_samples_ms.extend_from_slice(samples);
+    }
+
+    pub(crate) fn extend_render_queue_depth_samples(&mut self, samples: &[usize]) {
+        self.render_queue_depth_samples.extend_from_slice(samples);
+    }
+
+    pub(crate) fn extend_render_in_flight_samples(&mut self, samples: &[usize]) {
+        self.render_in_flight_samples.extend_from_slice(samples);
+    }
+
+    pub(crate) fn extend_encode_queue_depth_samples(&mut self, samples: &[usize]) {
+        self.encode_queue_depth_samples.extend_from_slice(samples);
+    }
+
+    pub(crate) fn extend_encode_in_flight_samples(&mut self, samples: &[usize]) {
+        self.encode_in_flight_samples.extend_from_slice(samples);
+    }
+}

--- a/src/perf/driver.rs
+++ b/src/perf/driver.rs
@@ -5,14 +5,14 @@ use std::time::{Duration, Instant};
 use ratatui::backend::TestBackend;
 use ratatui::layout::Size;
 use ratatui::{Frame, Terminal};
-use tokio::sync::mpsc::UnboundedSender;
 
-use crate::command::{Command, CommandInvocationSource, CommandRequest};
-use crate::event::DomainEvent;
-use crate::perf::{PerfScenarioId, PerfScenarioParameters};
-
-use super::state::AppState;
-use super::terminal_session::TerminalSurface;
+use crate::app::{
+    LoopDriver, LoopDriverDecision, LoopDriverHandle, LoopMetricsSnapshot, LoopObservation,
+    TerminalSession, TerminalSurface, binding_request,
+};
+use crate::command::Command;
+use crate::error::{AppError, AppResult};
+use crate::perf::{PerfIterationSnapshot, PerfScenarioId, PerfScenarioParameters};
 
 pub(crate) const PERF_HEADLESS_WIDTH: u16 = 120;
 pub(crate) const PERF_HEADLESS_HEIGHT: u16 = 40;
@@ -29,6 +29,12 @@ impl HeadlessTerminalSession {
 
     pub(crate) fn restore(&mut self) -> io::Result<()> {
         Ok(())
+    }
+}
+
+impl TerminalSession for HeadlessTerminalSession {
+    fn restore(&mut self) -> io::Result<()> {
+        HeadlessTerminalSession::restore(self)
     }
 }
 
@@ -91,121 +97,145 @@ impl PerfLoopDriver {
             .unwrap_or_default()
     }
 
-    pub(crate) fn advance(
+    fn start_measured_window(&mut self) {
+        self.measured_started_at.get_or_insert_with(Instant::now);
+    }
+}
+
+impl LoopDriver for PerfLoopDriver {
+    type Output = PerfIterationSnapshot;
+
+    fn on_iteration(
         &mut self,
-        state: &AppState,
-        page_count: usize,
-        system_idle: bool,
-        loop_event_tx: &UnboundedSender<DomainEvent>,
-    ) -> bool {
-        if !system_idle {
+        observation: LoopObservation,
+        handle: &mut LoopDriverHandle<'_>,
+    ) -> AppResult<LoopDriverDecision> {
+        if !observation.system_idle {
             self.idle_started_at = None;
-            return false;
+            return Ok(LoopDriverDecision::Continue);
         }
 
         match self.scenario {
-            PerfScenarioId::ColdFirstPage => true,
+            PerfScenarioId::ColdFirstPage => Ok(LoopDriverDecision::Finish),
             PerfScenarioId::SteadyNextPage => {
-                let last_page = page_count.saturating_sub(1);
-                if state.current_page >= last_page
+                let last_page = observation.page_count.saturating_sub(1);
+                if observation.current_page >= last_page
                     || self.command_count >= self.parameters.page_steps
                 {
                     self.start_measured_window();
-                    return true;
+                    return Ok(LoopDriverDecision::Finish);
                 }
                 self.start_measured_window();
-                let _ = loop_event_tx.send(DomainEvent::Command(CommandRequest::new(
-                    Command::NextPage,
-                    CommandInvocationSource::Binding,
-                )));
+                handle.enqueue_command(binding_request(Command::NextPage))?;
                 self.command_count += 1;
-                false
+                Ok(LoopDriverDecision::Continue)
             }
             PerfScenarioId::SteadyPrevPage => {
-                let last_page = page_count.saturating_sub(1);
+                let last_page = observation.page_count.saturating_sub(1);
                 if !self.positioned_backward_start {
-                    if state.current_page < last_page {
-                        let _ = loop_event_tx.send(DomainEvent::Command(CommandRequest::new(
-                            Command::LastPage,
-                            CommandInvocationSource::Binding,
-                        )));
+                    if observation.current_page < last_page {
+                        handle.enqueue_command(binding_request(Command::LastPage))?;
                         self.positioned_backward_start = true;
-                        return false;
+                        return Ok(LoopDriverDecision::Continue);
                     }
                     self.positioned_backward_start = true;
                 }
 
-                if state.current_page == 0 || self.command_count >= self.parameters.page_steps {
+                if observation.current_page == 0 || self.command_count >= self.parameters.page_steps
+                {
                     self.start_measured_window();
-                    return true;
+                    return Ok(LoopDriverDecision::Finish);
                 }
 
                 self.start_measured_window();
-                let _ = loop_event_tx.send(DomainEvent::Command(CommandRequest::new(
-                    Command::PrevPage,
-                    CommandInvocationSource::Binding,
-                )));
+                handle.enqueue_command(binding_request(Command::PrevPage))?;
                 self.command_count += 1;
-                false
+                Ok(LoopDriverDecision::Continue)
             }
             PerfScenarioId::RapidNextPage => {
                 if !self.initial_idle_seen {
                     self.initial_idle_seen = true;
                     self.start_measured_window();
-                    let last_page = page_count.saturating_sub(1);
+                    let last_page = observation.page_count.saturating_sub(1);
                     let steps = self
                         .parameters
                         .page_steps
-                        .min(last_page.saturating_sub(state.current_page));
-                    for _ in 0..steps {
-                        let _ = loop_event_tx.send(DomainEvent::Command(CommandRequest::new(
-                            Command::NextPage,
-                            CommandInvocationSource::Binding,
-                        )));
-                    }
+                        .min(last_page.saturating_sub(observation.current_page));
+                    handle
+                        .enqueue_commands((0..steps).map(|_| binding_request(Command::NextPage)))?;
                     self.command_count += steps;
                     self.rapid_commands_sent = true;
-                    return steps == 0;
+                    return Ok(if steps == 0 {
+                        LoopDriverDecision::Finish
+                    } else {
+                        LoopDriverDecision::Continue
+                    });
                 }
-                self.rapid_commands_sent
+                Ok(if self.rapid_commands_sent {
+                    LoopDriverDecision::Finish
+                } else {
+                    LoopDriverDecision::Continue
+                })
             }
             PerfScenarioId::ZoomStep => {
                 if !self.initial_idle_seen {
                     self.initial_idle_seen = true;
                     self.start_measured_window();
-                    let _ = loop_event_tx.send(DomainEvent::Command(CommandRequest::new(
-                        Command::ZoomIn,
-                        CommandInvocationSource::Binding,
-                    )));
+                    handle.enqueue_command(binding_request(Command::ZoomIn))?;
                     self.command_count += 1;
                     self.zoomed_in = true;
-                    return false;
+                    return Ok(LoopDriverDecision::Continue);
                 }
                 if self.zoomed_in && !self.zoomed_out {
-                    let _ = loop_event_tx.send(DomainEvent::Command(CommandRequest::new(
-                        Command::ZoomOut,
-                        CommandInvocationSource::Binding,
-                    )));
+                    handle.enqueue_command(binding_request(Command::ZoomOut))?;
                     self.command_count += 1;
                     self.zoomed_out = true;
-                    return false;
+                    return Ok(LoopDriverDecision::Continue);
                 }
-                self.zoomed_out
+                Ok(if self.zoomed_out {
+                    LoopDriverDecision::Finish
+                } else {
+                    LoopDriverDecision::Continue
+                })
             }
             PerfScenarioId::IdleSettledRedraw => {
                 let Some(started_at) = self.idle_started_at else {
                     let started_at = Instant::now();
                     self.idle_started_at = Some(started_at);
                     self.measured_started_at = Some(started_at);
-                    return false;
+                    return Ok(LoopDriverDecision::Continue);
                 };
-                started_at.elapsed().as_millis() >= u128::from(self.parameters.idle_duration_ms)
+                Ok(
+                    if started_at.elapsed().as_millis()
+                        >= u128::from(self.parameters.idle_duration_ms)
+                    {
+                        LoopDriverDecision::Finish
+                    } else {
+                        LoopDriverDecision::Continue
+                    },
+                )
             }
         }
     }
 
-    fn start_measured_window(&mut self) {
-        self.measured_started_at.get_or_insert_with(Instant::now);
+    fn on_finish(
+        &mut self,
+        observation: LoopObservation,
+        metrics: LoopMetricsSnapshot,
+    ) -> AppResult<Self::Output> {
+        Ok(PerfIterationSnapshot {
+            runtime: metrics.runtime,
+            presenter: metrics.presenter,
+            wall_time: self.measured_elapsed(),
+            final_page: observation.current_page,
+            visited_steps: self.visited_steps(),
+        })
+    }
+
+    fn on_loop_break(&mut self) -> AppResult<Self::Output> {
+        Err(AppError::unsupported(
+            "perf run ended before producing a report",
+        ))
     }
 }
 
@@ -222,9 +252,26 @@ mod tests {
     use ratatui::widgets::Paragraph;
     use tokio::sync::mpsc::unbounded_channel;
 
+    use crate::app::{
+        LoopDriver, LoopDriverDecision, LoopDriverHandle, LoopObservation, TerminalSurface,
+    };
+    use crate::event::DomainEvent;
     use crate::perf::{PerfScenarioId, PerfScenarioParameters};
 
-    use super::{HeadlessTerminalSession, PerfLoopDriver, TerminalSurface};
+    use super::{HeadlessTerminalSession, PerfLoopDriver};
+
+    fn observation(current_page: usize, page_count: usize, system_idle: bool) -> LoopObservation {
+        LoopObservation {
+            page_count,
+            current_page,
+            current_cached: system_idle,
+            render_in_flight: 0,
+            presenter_pending: false,
+            redraw_pending: false,
+            event_queue_empty: true,
+            system_idle,
+        }
+    }
 
     #[test]
     fn headless_terminal_session_supports_terminal_surface_contract() {
@@ -251,20 +298,30 @@ mod tests {
             },
             std::time::Instant::now(),
         );
-        let state = crate::app::state::AppState::default();
 
         assert!(driver.measured_started_at.is_none());
-        assert!(!driver.advance(&state, 3, false, &tx));
+        let mut handle = LoopDriverHandle::new(&tx);
+        assert!(matches!(
+            driver
+                .on_iteration(observation(0, 3, false), &mut handle)
+                .expect("driver should advance"),
+            LoopDriverDecision::Continue
+        ));
         assert!(driver.measured_started_at.is_none());
 
-        assert!(!driver.advance(&state, 3, true, &tx));
+        assert!(matches!(
+            driver
+                .on_iteration(observation(0, 3, true), &mut handle)
+                .expect("driver should advance"),
+            LoopDriverDecision::Continue
+        ));
         assert!(driver.measured_started_at.is_some());
         assert_eq!(driver.visited_steps(), 2);
     }
 
     #[test]
     fn steady_prev_starts_measured_window_after_last_page_positioning() {
-        let (tx, _rx) = unbounded_channel();
+        let (tx, mut rx) = unbounded_channel();
         let mut driver = PerfLoopDriver::new(
             PerfScenarioId::SteadyPrevPage,
             PerfScenarioParameters {
@@ -273,13 +330,26 @@ mod tests {
             },
             std::time::Instant::now(),
         );
-        let mut state = crate::app::state::AppState::default();
+        let mut handle = LoopDriverHandle::new(&tx);
 
-        assert!(!driver.advance(&state, 3, true, &tx));
+        assert!(matches!(
+            driver
+                .on_iteration(observation(0, 3, true), &mut handle)
+                .expect("driver should advance"),
+            LoopDriverDecision::Continue
+        ));
         assert!(driver.measured_started_at.is_none());
+        assert!(matches!(
+            rx.try_recv().expect("last page command should be queued"),
+            DomainEvent::Command(_)
+        ));
 
-        state.current_page = 2;
-        assert!(!driver.advance(&state, 3, true, &tx));
+        assert!(matches!(
+            driver
+                .on_iteration(observation(2, 3, true), &mut handle)
+                .expect("driver should advance"),
+            LoopDriverDecision::Continue
+        ));
         assert!(driver.measured_started_at.is_some());
         assert_eq!(driver.visited_steps(), 1);
     }

--- a/src/perf/mod.rs
+++ b/src/perf/mod.rs
@@ -3,243 +3,20 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::{Duration, Instant};
 
+mod driver;
 mod summary;
 
 use summary::{build_aggregate_report, build_iteration_report, merge_stats};
 
 use serde::Serialize;
 
-use crate::app::App;
+use crate::app::{App, LoopEventMode};
 use crate::backend::open_default_backend;
 use crate::error::{AppError, AppResult};
+use crate::metrics::{PerfStats, RedrawReasonCounts};
 use crate::presenter::PresenterKind;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum RedrawReason {
-    Input,
-    Command,
-    AppEvent,
-    RenderComplete,
-    PendingWork,
-    Timer,
-    InputError,
-    StateChanged,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
-pub struct RedrawReasonCounts {
-    pub input: u64,
-    pub command: u64,
-    pub app_event: u64,
-    pub render_complete: u64,
-    pub pending_work: u64,
-    pub timer: u64,
-    pub input_error: u64,
-    pub state_changed: u64,
-}
-
-impl RedrawReasonCounts {
-    fn record(&mut self, reason: RedrawReason) {
-        match reason {
-            RedrawReason::Input => self.input += 1,
-            RedrawReason::Command => self.command += 1,
-            RedrawReason::AppEvent => self.app_event += 1,
-            RedrawReason::RenderComplete => self.render_complete += 1,
-            RedrawReason::PendingWork => self.pending_work += 1,
-            RedrawReason::Timer => self.timer += 1,
-            RedrawReason::InputError => self.input_error += 1,
-            RedrawReason::StateChanged => self.state_changed += 1,
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Default)]
-pub struct PerfStats {
-    pub render_ms: f64,
-    pub convert_ms: f64,
-    pub blit_ms: f64,
-    pub cache_hit_rate_l1: f64,
-    pub cache_hit_rate_l2: f64,
-    pub queue_depth: usize,
-    pub canceled_tasks: usize,
-    pub render_samples: u64,
-    pub convert_samples: u64,
-    pub blit_samples: u64,
-    pub render_in_flight: usize,
-    pub encode_queue_depth: usize,
-    pub encode_in_flight: usize,
-    pub render_canceled_tasks: usize,
-    pub encode_canceled_tasks: usize,
-    pub redraw_requests_total: u64,
-    pub redraw_by_reason: RedrawReasonCounts,
-    collect_samples: bool,
-    render_samples_ms: Vec<f64>,
-    encode_samples_ms: Vec<f64>,
-    blit_samples_ms: Vec<f64>,
-    render_queue_wait_samples_ms: Vec<f64>,
-    encode_queue_wait_samples_ms: Vec<f64>,
-    render_queue_depth_samples: Vec<usize>,
-    render_in_flight_samples: Vec<usize>,
-    encode_queue_depth_samples: Vec<usize>,
-    encode_in_flight_samples: Vec<usize>,
-}
-
-impl PerfStats {
-    pub fn reset(&mut self) {
-        *self = Self::default();
-    }
-
-    pub fn enable_sample_collection(&mut self) {
-        self.collect_samples = true;
-    }
-
-    pub fn record_render(&mut self, elapsed: Duration) {
-        self.render_ms = elapsed.as_secs_f64() * 1000.0;
-        self.render_samples += 1;
-        if self.collect_samples {
-            self.render_samples_ms.push(self.render_ms);
-        }
-    }
-
-    pub fn record_convert(&mut self, elapsed: Duration) {
-        self.convert_ms = elapsed.as_secs_f64() * 1000.0;
-        self.convert_samples += 1;
-        if self.collect_samples {
-            self.encode_samples_ms.push(self.convert_ms);
-        }
-    }
-
-    pub fn record_blit(&mut self, elapsed: Duration) {
-        self.blit_ms = elapsed.as_secs_f64() * 1000.0;
-        self.blit_samples += 1;
-        if self.collect_samples {
-            self.blit_samples_ms.push(self.blit_ms);
-        }
-    }
-
-    pub fn record_render_queue_wait(&mut self, elapsed: Duration) {
-        if self.collect_samples {
-            self.render_queue_wait_samples_ms
-                .push(elapsed.as_secs_f64() * 1000.0);
-        }
-    }
-
-    pub fn record_encode_queue_wait(&mut self, elapsed: Duration) {
-        if self.collect_samples {
-            self.encode_queue_wait_samples_ms
-                .push(elapsed.as_secs_f64() * 1000.0);
-        }
-    }
-
-    pub fn set_l1_hit_rate(&mut self, rate: f64) {
-        self.cache_hit_rate_l1 = rate.clamp(0.0, 1.0);
-    }
-
-    pub fn set_l2_hit_rate(&mut self, rate: f64) {
-        self.cache_hit_rate_l2 = rate.clamp(0.0, 1.0);
-    }
-
-    pub fn set_queue_depth(&mut self, depth: usize) {
-        self.queue_depth = depth;
-        if self.collect_samples {
-            self.render_queue_depth_samples.push(depth);
-        }
-    }
-
-    pub fn set_render_in_flight(&mut self, inflight: usize) {
-        self.render_in_flight = inflight;
-        if self.collect_samples {
-            self.render_in_flight_samples.push(inflight);
-        }
-    }
-
-    pub fn set_encode_queue_depth(&mut self, depth: usize) {
-        self.encode_queue_depth = depth;
-        if self.collect_samples {
-            self.encode_queue_depth_samples.push(depth);
-        }
-    }
-
-    pub fn set_encode_in_flight(&mut self, inflight: usize) {
-        self.encode_in_flight = inflight;
-        if self.collect_samples {
-            self.encode_in_flight_samples.push(inflight);
-        }
-    }
-
-    pub fn add_canceled_tasks(&mut self, canceled: usize) {
-        self.canceled_tasks += canceled;
-        self.render_canceled_tasks += canceled;
-    }
-
-    pub fn add_encode_canceled_tasks(&mut self, canceled: usize) {
-        self.encode_canceled_tasks += canceled;
-    }
-
-    pub fn record_redraw(&mut self, reason: RedrawReason) {
-        self.redraw_requests_total += 1;
-        self.redraw_by_reason.record(reason);
-    }
-
-    pub fn absorb_presenter_metrics(&mut self, presenter: &PerfStats) {
-        self.convert_ms = presenter.convert_ms;
-        self.blit_ms = presenter.blit_ms;
-        self.cache_hit_rate_l2 = presenter.cache_hit_rate_l2;
-        self.convert_samples = presenter.convert_samples;
-        self.blit_samples = presenter.blit_samples;
-        self.encode_queue_depth = presenter.encode_queue_depth;
-        self.encode_in_flight = presenter.encode_in_flight;
-        self.encode_canceled_tasks = presenter.encode_canceled_tasks;
-        self.encode_samples_ms = presenter.encode_samples_ms.clone();
-        self.blit_samples_ms = presenter.blit_samples_ms.clone();
-        self.encode_queue_wait_samples_ms = presenter.encode_queue_wait_samples_ms.clone();
-        self.encode_queue_depth_samples = presenter.encode_queue_depth_samples.clone();
-        self.encode_in_flight_samples = presenter.encode_in_flight_samples.clone();
-    }
-
-    pub fn clear_blit_metrics(&mut self) {
-        self.blit_ms = 0.0;
-        self.blit_samples = 0;
-        self.blit_samples_ms.clear();
-    }
-
-    fn render_samples_ms(&self) -> &[f64] {
-        &self.render_samples_ms
-    }
-
-    fn encode_samples_ms(&self) -> &[f64] {
-        &self.encode_samples_ms
-    }
-
-    fn blit_samples_ms(&self) -> &[f64] {
-        &self.blit_samples_ms
-    }
-
-    fn render_queue_wait_samples_ms(&self) -> &[f64] {
-        &self.render_queue_wait_samples_ms
-    }
-
-    fn encode_queue_wait_samples_ms(&self) -> &[f64] {
-        &self.encode_queue_wait_samples_ms
-    }
-
-    fn render_queue_depth_samples(&self) -> &[usize] {
-        &self.render_queue_depth_samples
-    }
-
-    fn render_in_flight_samples(&self) -> &[usize] {
-        &self.render_in_flight_samples
-    }
-
-    fn encode_queue_depth_samples(&self) -> &[usize] {
-        &self.encode_queue_depth_samples
-    }
-
-    fn encode_in_flight_samples(&self) -> &[usize] {
-        &self.encode_in_flight_samples
-    }
-}
+use driver::{HeadlessTerminalSession, PERF_HEADLESS_HEIGHT, PERF_HEADLESS_WIDTH, PerfLoopDriver};
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct MetricSummary {
@@ -585,8 +362,11 @@ pub async fn run_suite(config: PerfSuiteConfig) -> AppResult<PerfSuiteReport> {
             let pdf = open_default_backend(&config.pdf_path)?;
             doc_id.get_or_insert(pdf.doc_id());
             let mut app = App::new(PresenterKind::RatatuiImage)?;
+            app.enable_metrics_collection()?;
+            let session = HeadlessTerminalSession::new(PERF_HEADLESS_WIDTH, PERF_HEADLESS_HEIGHT)?;
+            let driver = PerfLoopDriver::new(scenario, parameters.clone(), iteration_started_at);
             let snapshot = app
-                .run_perf(pdf, scenario, parameters.clone(), iteration_started_at)
+                .run_loop(pdf, session, LoopEventMode::Headless, driver)
                 .await?;
             if iteration >= config.warmup_iterations {
                 measured.push(snapshot);
@@ -654,6 +434,7 @@ mod tests {
 
     use super::summary::{summarize_metric, summarize_scalar};
     use crate::backend::test_support::{build_pdf, unique_temp_path};
+    use crate::metrics::RedrawReason;
 
     #[test]
     fn records_milliseconds_and_clamped_rates() {

--- a/src/perf/mod.rs
+++ b/src/perf/mod.rs
@@ -465,7 +465,7 @@ mod tests {
         assert_eq!(stats.render_in_flight, 2);
         assert_eq!(stats.encode_queue_depth, 3);
         assert_eq!(stats.encode_in_flight, 1);
-        assert_eq!(stats.canceled_tasks, 2);
+        assert_eq!(stats.canceled_tasks, 3);
         assert_eq!(stats.render_canceled_tasks, 2);
         assert_eq!(stats.encode_canceled_tasks, 1);
         assert_eq!(stats.redraw_requests_total, 2);
@@ -495,6 +495,7 @@ mod tests {
         assert_eq!(runtime.cache_hit_rate_l2, 0.8);
         assert_eq!(runtime.encode_queue_depth, 4);
         assert_eq!(runtime.encode_in_flight, 1);
+        assert_eq!(runtime.canceled_tasks, 3);
         assert_eq!(runtime.encode_canceled_tasks, 3);
         assert_eq!(runtime.encode_samples_ms(), &[5.0]);
         assert_eq!(runtime.blit_samples_ms(), &[2.0]);

--- a/src/perf/summary.rs
+++ b/src/perf/summary.rs
@@ -1,9 +1,10 @@
 use std::time::Duration;
 
 use super::{
-    CacheSummary, MetricSummary, PerfAggregateReport, PerfIterationReport, PerfStats,
-    PhaseMetricsSummary, QueueSummary, RedrawSummary, ScalarSummary,
+    CacheSummary, MetricSummary, PerfAggregateReport, PerfIterationReport, PhaseMetricsSummary,
+    QueueSummary, RedrawSummary, ScalarSummary,
 };
+use crate::metrics::PerfStats;
 
 pub(super) fn merge_stats<'a>(stats: impl Iterator<Item = &'a PerfStats>) -> PerfStats {
     let mut merged = PerfStats::default();
@@ -34,33 +35,15 @@ pub(super) fn merge_stats<'a>(stats: impl Iterator<Item = &'a PerfStats>) -> Per
         merged.redraw_by_reason.timer += stat.redraw_by_reason.timer;
         merged.redraw_by_reason.input_error += stat.redraw_by_reason.input_error;
         merged.redraw_by_reason.state_changed += stat.redraw_by_reason.state_changed;
-        merged
-            .render_samples_ms
-            .extend_from_slice(stat.render_samples_ms());
-        merged
-            .encode_samples_ms
-            .extend_from_slice(stat.encode_samples_ms());
-        merged
-            .blit_samples_ms
-            .extend_from_slice(stat.blit_samples_ms());
-        merged
-            .render_queue_wait_samples_ms
-            .extend_from_slice(stat.render_queue_wait_samples_ms());
-        merged
-            .encode_queue_wait_samples_ms
-            .extend_from_slice(stat.encode_queue_wait_samples_ms());
-        merged
-            .render_queue_depth_samples
-            .extend_from_slice(stat.render_queue_depth_samples());
-        merged
-            .render_in_flight_samples
-            .extend_from_slice(stat.render_in_flight_samples());
-        merged
-            .encode_queue_depth_samples
-            .extend_from_slice(stat.encode_queue_depth_samples());
-        merged
-            .encode_in_flight_samples
-            .extend_from_slice(stat.encode_in_flight_samples());
+        merged.extend_render_samples_ms(stat.render_samples_ms());
+        merged.extend_encode_samples_ms(stat.encode_samples_ms());
+        merged.extend_blit_samples_ms(stat.blit_samples_ms());
+        merged.extend_render_queue_wait_samples_ms(stat.render_queue_wait_samples_ms());
+        merged.extend_encode_queue_wait_samples_ms(stat.encode_queue_wait_samples_ms());
+        merged.extend_render_queue_depth_samples(stat.render_queue_depth_samples());
+        merged.extend_render_in_flight_samples(stat.render_in_flight_samples());
+        merged.extend_encode_queue_depth_samples(stat.encode_queue_depth_samples());
+        merged.extend_encode_in_flight_samples(stat.encode_in_flight_samples());
     }
     if stat_count > 0 {
         merged.cache_hit_rate_l1 /= stat_count as f64;
@@ -234,7 +217,7 @@ mod tests {
     use super::*;
     use std::time::Duration;
 
-    use crate::perf::{PerfStats, RedrawReason};
+    use crate::metrics::{PerfStats, RedrawReason};
 
     #[test]
     fn summarizes_metrics_and_scalars() {

--- a/src/presenter/ratatui/mod.rs
+++ b/src/presenter/ratatui/mod.rs
@@ -11,7 +11,7 @@ use tokio::task::JoinHandle;
 
 use crate::backend::RgbaFrame;
 use crate::error::AppResult;
-use crate::perf::PerfStats;
+use crate::metrics::PerfStats;
 use crate::render::cache::RenderedPageKey;
 use crate::work::WorkClass;
 

--- a/src/presenter/traits.rs
+++ b/src/presenter/traits.rs
@@ -6,7 +6,7 @@ use ratatui::layout::Rect;
 
 use crate::backend::RgbaFrame;
 use crate::error::AppResult;
-use crate::perf::PerfStats;
+use crate::metrics::PerfStats;
 use crate::render::cache::RenderedPageKey;
 use crate::work::WorkClass;
 


### PR DESCRIPTION
## Summary
- route headless perf runs through the shared app loop driver contract
- move headless perf driver/session ownership into src/perf and low-level metrics into src/metrics.rs
- update architecture/reference docs for the new dependency direction

## Rationale
Perf diagnostics were previously a special App execution path. This keeps App responsible for the runtime loop while making perf a driver of that loop, so app and presenter code no longer depend on perf scenario/report types.

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified loop-driving system for both interactive and headless runs, improving consistency across app execution modes.
  * Introduced richer metrics tracking, including redraw reasons, timing samples, queue depth, in-flight work, and cache hit rates.
  * Performance runs now collect metrics through the app’s main execution path and produce structured iteration results.

* **Bug Fixes**
  * Updated terminal session handling to restore state more reliably after loop execution.
  * Improved runtime coordination between interactive viewing and performance diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->