### PR TITLE
refactor(extension): split host feature operations into ports

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,8 +62,10 @@ request behavior by returning typed effects or commands instead of taking
 selection, palette input editing, palette input history recall, and help
 scrolling enter the same command dispatch path as normal-mode keymap entries.
 
-Extensions own extension-local state and observe `AppEvent` values. Shared UI
-data crosses from extensions to palettes through `ExtensionUiSnapshot`.
+Extensions own extension-local state and observe `AppEvent` values.
+`ExtensionHost` owns concrete extension state, hook routing, and shared
+snapshots. Feature behavior stays with the feature modules. Shared UI data
+crosses from extensions to palettes through `ExtensionUiSnapshot`.
 
 Render workers and presenter encode workers communicate with the loop through
 typed request and completion values. They do not mutate app state directly.
@@ -137,9 +139,10 @@ operation methods. Key routing remains outside providers and produces commands;
 the active palette is the command target for palette operations.
 
 Extensions:
-Built-in features that need background state, event observation, or status-bar
-segments live behind `ExtensionHost`. They are internal modules, not a dynamic
-plugin system.
+Built-in features that need background state, event observation, status-bar
+segments, palette-facing snapshots, or render projections live behind
+`ExtensionHost`. The host owns hook order and snapshot composition. They are
+internal modules, not a dynamic plugin system.
 
 Render and presenter:
 Raw page rasterization and terminal protocol encoding are separated because

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -340,12 +340,17 @@ Orientation:
 Contract:
 - Extensions are internal modules composed statically by `ExtensionHost`.
 - Extension state remains concrete and owned by the host.
+- `ExtensionHost` owns lifecycle routing, hook ordering, and shared snapshots.
+- Feature operations are owned by feature runtime or state types.
 - Extension hooks operate on extension-owned state plus shared app state.
 - Input hooks return ignored when they do not claim an input.
 - The first claimed input hook result wins.
 - Event hooks observe typed `AppEvent` values emitted by command dispatch and
   runtime flow.
 - Background hooks report whether visible or behavioral state changed.
+- Document reload behavior is handled through extension lifecycle hooks. Each
+  extension explicitly decides whether to reset, preserve, or rehydrate its
+  state for the new document.
 - Extension UI data exposed to palettes crosses through `ExtensionUiSnapshot`.
 
 Compatibility:

--- a/src/app/actors.rs
+++ b/src/app/actors.rs
@@ -350,7 +350,8 @@ impl UiActor {
                     highlight_overlay: interaction
                         .extensions
                         .host
-                        .highlight_overlay_for(step.visible_pages.existing_pages()),
+                        .render_snapshot(step.visible_pages.existing_pages())
+                        .highlight_overlay,
                     generation: render_generation,
                     nav_streak,
                 },

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -151,7 +151,8 @@ impl App {
             render_actor.nav_mut().intent(),
             tracked_scale,
         );
-        self.interaction.prewarm_search_text(Arc::clone(&pdf));
+        self.interaction
+            .prepare_extensions_for_document(Arc::clone(&pdf));
 
         Ok(LoopRuntime {
             page_count,
@@ -346,7 +347,8 @@ impl App {
             .interaction
             .extensions
             .host
-            .highlight_overlay_for(current_view.visible_pages.existing_pages())
+            .render_snapshot(current_view.visible_pages.existing_pages())
+            .highlight_overlay
             .stamp;
         let base_pan = self.current_pan();
         let interactive = input_actor.is_interactive(prefetch_pause_after_input);

--- a/src/app/input_ops.rs
+++ b/src/app/input_ops.rs
@@ -85,8 +85,8 @@ impl InteractionSubsystem {
         drain_background_events(state, &mut self.extensions.host)
     }
 
-    pub(crate) fn prewarm_search_text(&mut self, pdf: SharedPdfBackend) {
-        self.extensions.host.prewarm_search_text(pdf);
+    pub(crate) fn prepare_extensions_for_document(&mut self, pdf: SharedPdfBackend) {
+        self.extensions.host.on_document_opened(pdf);
     }
 
     pub(crate) fn reset_extensions_for_document_reload(
@@ -94,18 +94,17 @@ impl InteractionSubsystem {
         state: &mut AppState,
         pdf: SharedPdfBackend,
     ) {
-        self.extensions.host.reset_for_document_reload(state, pdf);
+        self.extensions.host.on_document_reloaded(state, pdf);
     }
 
-    pub(crate) fn sync_search_after_page_change(
+    pub(crate) fn sync_extensions_after_page_change(
         &mut self,
         pdf: SharedPdfBackend,
         current_page: usize,
     ) {
-        self.extensions.host.prewarm_search_text(pdf.clone());
         self.extensions
             .host
-            .resolve_search_priority_geometry(pdf, [Some(current_page), None]);
+            .on_visible_pages_changed(pdf, [Some(current_page), None]);
     }
 
     pub(crate) fn palette_view(&self) -> Option<PaletteView> {

--- a/src/app/input_ops.rs
+++ b/src/app/input_ops.rs
@@ -100,11 +100,11 @@ impl InteractionSubsystem {
     pub(crate) fn sync_extensions_after_page_change(
         &mut self,
         pdf: SharedPdfBackend,
-        current_page: usize,
+        visible_pages: [Option<usize>; 2],
     ) {
         self.extensions
             .host
-            .on_visible_pages_changed(pdf, [Some(current_page), None]);
+            .on_visible_pages_changed(pdf, visible_pages);
     }
 
     pub(crate) fn palette_view(&self) -> Option<PaletteView> {

--- a/src/app/loop_router.rs
+++ b/src/app/loop_router.rs
@@ -263,7 +263,10 @@ impl App {
             return Ok(LoopControl::Continue);
         }
         let state_before_command = self.state.clone();
-        let previous_page = self.state.current_page;
+        let previous_visible_pages = self
+            .state
+            .visible_page_slots(runtime.page_count)
+            .existing_pages();
         let view_policy = self.view_policy;
         let dispatch = match self.interaction.dispatch_command(
             &mut self.state,
@@ -292,11 +295,14 @@ impl App {
         if palette_changed {
             self.request_redraw(runtime, RedrawReason::StateChanged);
         }
-        if self.state.current_page != previous_page {
-            let visible_pages = self.state.visible_page_slots(runtime.page_count);
+        let current_visible_pages = self
+            .state
+            .visible_page_slots(runtime.page_count)
+            .existing_pages();
+        if current_visible_pages != previous_visible_pages {
             self.interaction.sync_extensions_after_page_change(
                 Arc::clone(&document.pdf),
-                visible_pages.existing_pages(),
+                current_visible_pages,
             );
         }
         if dispatch.lifecycle == CommandLifecycleEffect::Quit {

--- a/src/app/loop_router.rs
+++ b/src/app/loop_router.rs
@@ -293,9 +293,10 @@ impl App {
             self.request_redraw(runtime, RedrawReason::StateChanged);
         }
         if self.state.current_page != previous_page {
+            let visible_pages = self.state.visible_page_slots(runtime.page_count);
             self.interaction.sync_extensions_after_page_change(
                 Arc::clone(&document.pdf),
-                self.state.current_page,
+                visible_pages.existing_pages(),
             );
         }
         if dispatch.lifecycle == CommandLifecycleEffect::Quit {

--- a/src/app/loop_router.rs
+++ b/src/app/loop_router.rs
@@ -293,8 +293,10 @@ impl App {
             self.request_redraw(runtime, RedrawReason::StateChanged);
         }
         if self.state.current_page != previous_page {
-            self.interaction
-                .sync_search_after_page_change(Arc::clone(&document.pdf), self.state.current_page);
+            self.interaction.sync_extensions_after_page_change(
+                Arc::clone(&document.pdf),
+                self.state.current_page,
+            );
         }
         if dispatch.lifecycle == CommandLifecycleEffect::Quit {
             terminate_process_now(runtime);

--- a/src/command/dispatch.rs
+++ b/src/command/dispatch.rs
@@ -193,7 +193,7 @@ fn derive_nav_reason(command: &Command, extension_host: &ExtensionHost) -> Optio
         }
         Command::SearchResultGoto { .. } | Command::NextSearchHit | Command::PrevSearchHit => {
             Some(NavReason::Search {
-                query: extension_host.search_query().to_string(),
+                query: extension_host.search().query().to_string(),
             })
         }
         Command::HistoryBack => Some(NavReason::History(HistoryOp::Back)),
@@ -1020,14 +1020,16 @@ mod tests {
         let mut host = ExtensionHost::default();
         let mut palette_requests = VecDeque::new();
 
-        host.submit_search(
-            &mut app,
-            Arc::clone(&pdf),
-            "needle".to_string(),
-            SearchMatcherKind::ContainsInsensitive,
-        )
-        .expect("submit-search should succeed");
-        assert!(host.ui_snapshot().search_active);
+        host.command_ports()
+            .search
+            .submit(
+                &mut app,
+                Arc::clone(&pdf),
+                "needle".to_string(),
+                SearchMatcherKind::ContainsInsensitive,
+            )
+            .expect("submit-search should succeed");
+        assert!(host.ui_snapshot().search.active);
 
         let result = dispatch(
             &mut app,
@@ -1041,7 +1043,7 @@ mod tests {
 
         assert_eq!(result.outcome, CommandOutcome::Applied);
         assert_eq!(result.emitted_events.len(), 1);
-        assert!(!host.ui_snapshot().search_active);
+        assert!(!host.ui_snapshot().search.active);
         assert_eq!(app.notice, None);
         assert!(palette_requests.is_empty());
     }
@@ -1051,13 +1053,15 @@ mod tests {
         let mut app = AppState::default();
         let pdf = Arc::new(StubPdf::new(3)) as SharedPdfBackend;
         let mut host = ExtensionHost::default();
-        host.submit_search(
-            &mut app,
-            pdf,
-            "needle".to_string(),
-            SearchMatcherKind::ContainsInsensitive,
-        )
-        .expect("submit-search should succeed");
+        host.command_ports()
+            .search
+            .submit(
+                &mut app,
+                pdf,
+                "needle".to_string(),
+                SearchMatcherKind::ContainsInsensitive,
+            )
+            .expect("submit-search should succeed");
 
         let prev_page = app.current_page;
         let prev_mode = app.mode;

--- a/src/command/handlers/control.rs
+++ b/src/command/handlers/control.rs
@@ -8,7 +8,8 @@ use super::super::effects::{CommandExecution, CommandLifecycleEffect};
 pub(in crate::command) fn cancel_search(
     ctx: &mut CommandExecContext<'_>,
 ) -> AppResult<CommandExecution> {
-    let _ = ctx.extension_host.cancel_search(Arc::clone(&ctx.pdf))?;
+    let pdf = Arc::clone(&ctx.pdf);
+    let _ = ctx.extension_host.command_ports().search.cancel(pdf)?;
     Ok(CommandExecution::applied())
 }
 

--- a/src/command/handlers/history.rs
+++ b/src/command/handlers/history.rs
@@ -6,16 +6,24 @@ use super::super::effects::CommandExecution;
 pub(in crate::command) fn history_back(
     ctx: &mut CommandExecContext<'_>,
 ) -> AppResult<CommandExecution> {
-    let result = ctx.extension_host.history_back(ctx.app, ctx.page_count());
+    let page_count = ctx.page_count();
+    let result = ctx
+        .extension_host
+        .command_ports()
+        .history
+        .back(ctx.app, page_count);
     Ok(CommandExecution::from_notice_result(result))
 }
 
 pub(in crate::command) fn history_forward(
     ctx: &mut CommandExecContext<'_>,
 ) -> AppResult<CommandExecution> {
+    let page_count = ctx.page_count();
     let result = ctx
         .extension_host
-        .history_forward(ctx.app, ctx.page_count());
+        .command_ports()
+        .history
+        .forward(ctx.app, page_count);
     Ok(CommandExecution::from_notice_result(result))
 }
 
@@ -23,15 +31,22 @@ pub(in crate::command) fn history_goto(
     ctx: &mut CommandExecContext<'_>,
     page: usize,
 ) -> AppResult<CommandExecution> {
+    let page_count = ctx.page_count();
     let result = ctx
         .extension_host
-        .history_goto(ctx.app, ctx.page_count(), page)?;
+        .command_ports()
+        .history
+        .goto(ctx.app, page_count, page)?;
     Ok(CommandExecution::from_notice_result(result))
 }
 
 pub(in crate::command) fn open_history(
     ctx: &mut CommandExecContext<'_>,
 ) -> AppResult<CommandExecution> {
-    Ok(CommandExecution::applied()
-        .with_palette_request(ctx.extension_host.open_history_palette(ctx.app)))
+    let request = ctx
+        .extension_host
+        .command_ports()
+        .history
+        .open_palette(ctx.app);
+    Ok(CommandExecution::applied().with_palette_request(request))
 }

--- a/src/command/handlers/outline.rs
+++ b/src/command/handlers/outline.rs
@@ -8,9 +8,12 @@ use super::super::effects::CommandExecution;
 pub(in crate::command) fn open_outline(
     ctx: &mut CommandExecContext<'_>,
 ) -> AppResult<CommandExecution> {
+    let pdf = Arc::clone(&ctx.pdf);
     let request = ctx
         .extension_host
-        .open_outline_palette(Arc::clone(&ctx.pdf))?;
+        .command_ports()
+        .outline
+        .open_palette(pdf)?;
     Ok(CommandExecution::applied().with_palette_request(request))
 }
 
@@ -19,8 +22,11 @@ pub(in crate::command) fn outline_goto(
     page: usize,
     _title: String,
 ) -> AppResult<CommandExecution> {
+    let page_count = ctx.page_count();
     let result = ctx
         .extension_host
-        .outline_goto(ctx.app, ctx.page_count(), page)?;
+        .command_ports()
+        .outline
+        .goto(ctx.app, page_count, page)?;
     Ok(CommandExecution::from_notice_result(result))
 }

--- a/src/command/handlers/search.rs
+++ b/src/command/handlers/search.rs
@@ -9,13 +9,19 @@ use super::super::types::SearchMatcherKind;
 pub(in crate::command) fn open_search(
     ctx: &mut CommandExecContext<'_>,
 ) -> AppResult<CommandExecution> {
-    Ok(CommandExecution::applied().with_palette_request(ctx.extension_host.open_search_palette()))
+    let request = ctx.extension_host.command_ports().search.open_palette();
+    Ok(CommandExecution::applied().with_palette_request(request))
 }
 
 pub(in crate::command) fn open_search_results(
     ctx: &mut CommandExecContext<'_>,
 ) -> AppResult<CommandExecution> {
-    let Some(request) = ctx.extension_host.open_search_results_palette() else {
+    let Some(request) = ctx
+        .extension_host
+        .command_ports()
+        .search
+        .open_results_palette()
+    else {
         return Ok(CommandExecution::noop());
     };
     Ok(CommandExecution::applied().with_palette_request(request))
@@ -26,9 +32,12 @@ pub(in crate::command) fn submit_search(
     query: String,
     matcher: SearchMatcherKind,
 ) -> AppResult<CommandExecution> {
+    let pdf = Arc::clone(&ctx.pdf);
     let result = ctx
         .extension_host
-        .submit_search(ctx.app, Arc::clone(&ctx.pdf), query, matcher)?;
+        .command_ports()
+        .search
+        .submit(ctx.app, pdf, query, matcher)?;
     Ok(CommandExecution::from_notice_result(result))
 }
 
@@ -36,22 +45,25 @@ pub(in crate::command) fn search_result_goto(
     ctx: &mut CommandExecContext<'_>,
     page: usize,
 ) -> AppResult<CommandExecution> {
+    let page_count = ctx.page_count();
     let result = ctx
         .extension_host
-        .search_result_goto(ctx.app, ctx.page_count(), page)?;
+        .command_ports()
+        .search
+        .goto_result(ctx.app, page_count, page)?;
     Ok(CommandExecution::from_notice_result(result))
 }
 
 pub(in crate::command) fn next_search_hit(
     ctx: &mut CommandExecContext<'_>,
 ) -> AppResult<CommandExecution> {
-    let result = ctx.extension_host.next_search_hit(ctx.app);
+    let result = ctx.extension_host.command_ports().search.next_hit(ctx.app);
     Ok(CommandExecution::from_notice_result(result))
 }
 
 pub(in crate::command) fn prev_search_hit(
     ctx: &mut CommandExecContext<'_>,
 ) -> AppResult<CommandExecution> {
-    let result = ctx.extension_host.prev_search_hit(ctx.app);
+    let result = ctx.extension_host.command_ports().search.prev_hit(ctx.app);
     Ok(CommandExecution::from_notice_result(result))
 }

--- a/src/command/tests/mod.rs
+++ b/src/command/tests/mod.rs
@@ -9,6 +9,16 @@ use crate::palette::PaletteKind;
 
 use super::spec::validate_command_id_for_policy;
 
+fn extension_snapshot(search_active: bool) -> ExtensionUiSnapshot {
+    ExtensionUiSnapshot {
+        search: crate::search::SearchUiSnapshot {
+            active: search_active,
+            ..Default::default()
+        },
+        ..ExtensionUiSnapshot::default()
+    }
+}
+
 #[test]
 fn default_registry_bindings_reference_commands_invocable_when_enabled() {
     let registry = build_default_sequence_registry();
@@ -67,10 +77,7 @@ fn default_registry_bindings_reference_commands_invocable_when_enabled() {
 }
 
 fn assert_binding_is_invocable(command_id: &str, enabled_when: ConditionExpr, label: String) {
-    let extension_states = [
-        ExtensionUiSnapshot::with_search_active(false),
-        ExtensionUiSnapshot::with_search_active(true),
-    ];
+    let extension_states = [extension_snapshot(false), extension_snapshot(true)];
     let contexts = extension_states.iter().flat_map(|extensions| {
         [
             RuntimeConditionContext::new(Mode::Normal, None, extensions),

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -203,8 +203,8 @@ pub fn runtime_condition_is_met(
     match condition {
         RuntimeCondition::ModeIs(mode) => ctx.mode == mode,
         RuntimeCondition::ModeIsNot(mode) => ctx.mode != mode,
-        RuntimeCondition::SearchIsActive => ctx.extensions.search_active,
-        RuntimeCondition::SearchIsInactive => !ctx.extensions.search_active,
+        RuntimeCondition::SearchIsActive => ctx.extensions.search.active,
+        RuntimeCondition::SearchIsInactive => !ctx.extensions.search.active,
         RuntimeCondition::PaletteIsOpen => ctx.active_palette.is_some(),
         RuntimeCondition::PaletteIsClosed => ctx.active_palette.is_none(),
         RuntimeCondition::PaletteKindIs(kind) => ctx.active_palette == Some(kind),

--- a/src/extension/host.rs
+++ b/src/extension/host.rs
@@ -143,7 +143,8 @@ mod tests {
     use std::sync::Arc;
 
     use crate::backend::{PdfBackend, RgbaFrame, SharedPdfBackend, TextPage};
-    use crate::command::SearchMatcherKind;
+    use crate::command::{CommandOutcome, SearchMatcherKind};
+    use crate::event::{AppEvent, NavReason, PageGotoKind};
 
     use super::ExtensionHost;
 
@@ -279,5 +280,29 @@ mod tests {
             SearchMatcherKind::ContainsSensitive
         );
         assert_eq!(host.status_bar_segments(&app), vec!["SEARCH 0 hits"]);
+    }
+
+    #[test]
+    fn document_reload_resets_history_navigation() {
+        let mut host = ExtensionHost::default();
+        let mut app = crate::app::AppState {
+            current_page: 3,
+            ..crate::app::AppState::default()
+        };
+        host.handle_event(
+            &AppEvent::PageChanged {
+                from: 0,
+                to: 3,
+                reason: NavReason::PageGoto(PageGotoKind::Specific),
+            },
+            &mut app,
+        );
+
+        host.on_document_reloaded(&mut app, Arc::new(StubPdf::new(4)) as SharedPdfBackend);
+        let (outcome, notice) = host.command_ports().history.back(&mut app, 4);
+
+        assert_eq!(outcome, CommandOutcome::Noop);
+        assert_eq!(notice, crate::app::NoticeAction::Clear);
+        assert_eq!(app.current_page, 3);
     }
 }

--- a/src/extension/host.rs
+++ b/src/extension/host.rs
@@ -1,33 +1,31 @@
 use std::sync::Arc;
 
-use crate::app::{AppState, NoticeAction, PaletteRequest};
+use crate::app::AppState;
 use crate::backend::SharedPdfBackend;
-use crate::command::{CommandOutcome, SearchMatcherKind};
-use crate::error::AppResult;
 use crate::event::AppEvent;
 use crate::highlight::HighlightOverlaySnapshot;
-use crate::history::{HistoryExtension, HistoryState};
+use crate::history::{HistoryCommandPort, HistoryExtension, HistoryState};
 use crate::input::{AppInputEvent, InputHookResult};
-use crate::outline::{OutlineExtension, OutlinePaletteEntry, OutlineState};
-use crate::search::{SearchExtension, SearchPaletteEntry, SearchRuntime};
+use crate::outline::{OutlineCommandPort, OutlineExtension, OutlineState, OutlineUiSnapshot};
+use crate::search::{SearchCommandPort, SearchExtension, SearchRuntime, SearchUiSnapshot};
 
 use super::traits::Extension;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ExtensionUiSnapshot {
-    pub search_active: bool,
-    pub search_results_entries: Arc<[SearchPaletteEntry]>,
-    pub outline_entries: Arc<[OutlinePaletteEntry]>,
+    pub search: SearchUiSnapshot,
+    pub outline: OutlineUiSnapshot,
 }
 
-impl ExtensionUiSnapshot {
-    pub fn with_search_active(search_active: bool) -> Self {
-        Self {
-            search_active,
-            search_results_entries: Arc::from([]),
-            outline_entries: Arc::from([]),
-        }
-    }
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ExtensionRenderSnapshot {
+    pub highlight_overlay: HighlightOverlaySnapshot,
+}
+
+pub(crate) struct ExtensionCommandPorts<'a> {
+    pub search: SearchCommandPort<'a>,
+    pub history: HistoryCommandPort<'a>,
+    pub outline: OutlineCommandPort<'a>,
 }
 
 pub struct ExtensionHost {
@@ -43,6 +41,18 @@ impl ExtensionHost {
             history: HistoryExtension::init_state(),
             outline: OutlineExtension::init_state(),
         }
+    }
+
+    pub(crate) fn command_ports(&mut self) -> ExtensionCommandPorts<'_> {
+        ExtensionCommandPorts {
+            search: SearchCommandPort::new(&mut self.search),
+            history: HistoryCommandPort::new(&mut self.history),
+            outline: OutlineCommandPort::new(&mut self.outline),
+        }
+    }
+
+    pub(crate) fn search(&self) -> &SearchRuntime {
+        &self.search
     }
 
     pub fn handle_input(&mut self, event: AppInputEvent, app: &mut AppState) -> InputHookResult {
@@ -71,120 +81,23 @@ impl ExtensionHost {
         search_changed || history_changed
     }
 
-    pub fn open_search_palette(&mut self) -> PaletteRequest {
-        self.search.open_palette()
-    }
-
-    pub fn submit_search(
-        &mut self,
-        app: &mut AppState,
-        pdf: SharedPdfBackend,
-        query: String,
-        matcher: SearchMatcherKind,
-    ) -> AppResult<(CommandOutcome, NoticeAction)> {
-        self.search.submit(app, pdf, query, matcher)
-    }
-
-    pub fn prewarm_search_text(&mut self, pdf: SharedPdfBackend) {
+    pub fn on_document_opened(&mut self, pdf: SharedPdfBackend) {
         self.search.prewarm(pdf);
     }
 
-    pub fn reset_for_document_reload(&mut self, app: &mut AppState, pdf: SharedPdfBackend) {
-        let active_search = self
-            .search
-            .is_active()
-            .then(|| (self.search.query().to_string(), self.search.matcher()));
-        self.search = SearchExtension::init_state();
-        self.outline = OutlineExtension::init_state();
-        self.search.prewarm(Arc::clone(&pdf));
-        if let Some((query, matcher)) = active_search
-            && let Err(err) = self.search.submit(app, pdf, query, matcher)
-        {
-            app.set_warning_notice(format!("Could not restore search after reload: {err}"));
-        }
+    pub fn on_document_reloaded(&mut self, app: &mut AppState, pdf: SharedPdfBackend) {
+        SearchExtension::on_document_reloaded(&mut self.search, app, Arc::clone(&pdf));
+        HistoryExtension::on_document_reloaded(&mut self.history, app, Arc::clone(&pdf));
+        OutlineExtension::on_document_reloaded(&mut self.outline, app, pdf);
     }
 
-    pub fn resolve_search_priority_geometry(
+    pub fn on_visible_pages_changed(
         &mut self,
         pdf: SharedPdfBackend,
         visible_pages: [Option<usize>; 2],
     ) {
+        self.search.prewarm(Arc::clone(&pdf));
         self.search.resolve_priority_geometry(pdf, visible_pages);
-    }
-
-    pub fn open_search_results_palette(&mut self) -> Option<PaletteRequest> {
-        self.search.open_results_palette()
-    }
-
-    pub fn search_result_goto(
-        &mut self,
-        app: &mut AppState,
-        page_count: usize,
-        page: usize,
-    ) -> AppResult<(CommandOutcome, NoticeAction)> {
-        self.search.goto_result(app, page_count, page)
-    }
-
-    pub fn cancel_search(&mut self, pdf: SharedPdfBackend) -> AppResult<bool> {
-        self.search.cancel(pdf)
-    }
-
-    pub fn next_search_hit(&mut self, app: &mut AppState) -> (CommandOutcome, NoticeAction) {
-        self.search.next_hit(app)
-    }
-
-    pub fn prev_search_hit(&mut self, app: &mut AppState) -> (CommandOutcome, NoticeAction) {
-        self.search.prev_hit(app)
-    }
-
-    pub fn history_back(
-        &mut self,
-        app: &mut AppState,
-        page_count: usize,
-    ) -> (CommandOutcome, NoticeAction) {
-        self.history.back(app, page_count)
-    }
-
-    pub fn history_forward(
-        &mut self,
-        app: &mut AppState,
-        page_count: usize,
-    ) -> (CommandOutcome, NoticeAction) {
-        self.history.forward(app, page_count)
-    }
-
-    pub fn history_goto(
-        &mut self,
-        app: &mut AppState,
-        page_count: usize,
-        page: usize,
-    ) -> AppResult<(CommandOutcome, NoticeAction)> {
-        self.history.goto(app, page_count, page)
-    }
-
-    pub fn open_history_palette(&self, app: &AppState) -> PaletteRequest {
-        self.history.open_palette(app)
-    }
-
-    pub fn open_outline_palette(&mut self, pdf: SharedPdfBackend) -> AppResult<PaletteRequest> {
-        self.outline.open_palette(pdf)
-    }
-
-    pub fn outline_goto(
-        &mut self,
-        app: &mut AppState,
-        page_count: usize,
-        page: usize,
-    ) -> AppResult<(CommandOutcome, NoticeAction)> {
-        self.outline.goto(app, page_count, page)
-    }
-
-    pub fn search_query(&self) -> &str {
-        self.search.query()
-    }
-
-    pub fn search_matcher(&self) -> SearchMatcherKind {
-        self.search.matcher()
     }
 
     pub fn status_bar_segments(&self, app: &AppState) -> Vec<String> {
@@ -204,18 +117,17 @@ impl ExtensionHost {
 
     pub fn ui_snapshot(&self) -> ExtensionUiSnapshot {
         ExtensionUiSnapshot {
-            search_active: self.search.is_active(),
-            search_results_entries: self.search.palette_entries(),
-            outline_entries: self.outline.palette_entries(),
+            search: self.search.ui_snapshot(),
+            outline: self.outline.ui_snapshot(),
         }
     }
 
-    pub fn highlight_overlay_for(
-        &self,
-        visible_pages: [Option<usize>; 2],
-    ) -> HighlightOverlaySnapshot {
-        self.search
-            .highlight_overlay_for_visible_pages(visible_pages)
+    pub fn render_snapshot(&self, visible_pages: [Option<usize>; 2]) -> ExtensionRenderSnapshot {
+        ExtensionRenderSnapshot {
+            highlight_overlay: self
+                .search
+                .highlight_overlay_for_visible_pages(visible_pages),
+        }
     }
 }
 
@@ -300,13 +212,15 @@ mod tests {
         let mut app = crate::app::AppState::default();
         let pdf = StubPdf::new(4);
 
-        host.submit_search(
-            &mut app,
-            Arc::new(pdf) as SharedPdfBackend,
-            "needle".to_string(),
-            SearchMatcherKind::ContainsInsensitive,
-        )
-        .expect("submit-search should succeed");
+        host.command_ports()
+            .search
+            .submit(
+                &mut app,
+                Arc::new(pdf) as SharedPdfBackend,
+                "needle".to_string(),
+                SearchMatcherKind::ContainsInsensitive,
+            )
+            .expect("submit-search should succeed");
 
         let segments = host.status_bar_segments(&app);
         assert_eq!(segments.len(), 1);
@@ -319,18 +233,24 @@ mod tests {
         let mut app = crate::app::AppState::default();
         let pdf = Arc::new(StubPdf::new(4)) as SharedPdfBackend;
 
-        host.submit_search(
-            &mut app,
-            Arc::clone(&pdf),
-            "needle".to_string(),
-            SearchMatcherKind::ContainsInsensitive,
-        )
-        .expect("submit-search should succeed");
-        assert!(host.ui_snapshot().search_active);
+        host.command_ports()
+            .search
+            .submit(
+                &mut app,
+                Arc::clone(&pdf),
+                "needle".to_string(),
+                SearchMatcherKind::ContainsInsensitive,
+            )
+            .expect("submit-search should succeed");
+        assert!(host.ui_snapshot().search.active);
 
-        let canceled = host.cancel_search(pdf).expect("cancel should succeed");
+        let canceled = host
+            .command_ports()
+            .search
+            .cancel(pdf)
+            .expect("cancel should succeed");
         assert!(canceled);
-        assert!(!host.ui_snapshot().search_active);
+        assert!(!host.ui_snapshot().search.active);
     }
 
     #[test]
@@ -340,19 +260,24 @@ mod tests {
         let first = Arc::new(StubPdf::new(4)) as SharedPdfBackend;
         let second = Arc::new(StubPdf::new(2)) as SharedPdfBackend;
 
-        host.submit_search(
-            &mut app,
-            first,
-            "needle".to_string(),
-            SearchMatcherKind::ContainsSensitive,
-        )
-        .expect("submit-search should succeed");
+        host.command_ports()
+            .search
+            .submit(
+                &mut app,
+                first,
+                "needle".to_string(),
+                SearchMatcherKind::ContainsSensitive,
+            )
+            .expect("submit-search should succeed");
 
-        host.reset_for_document_reload(&mut app, second);
+        host.on_document_reloaded(&mut app, second);
 
-        assert!(host.ui_snapshot().search_active);
-        assert_eq!(host.search_query(), "needle");
-        assert_eq!(host.search_matcher(), SearchMatcherKind::ContainsSensitive);
+        assert!(host.ui_snapshot().search.active);
+        assert_eq!(host.search().query(), "needle");
+        assert_eq!(
+            host.search().matcher(),
+            SearchMatcherKind::ContainsSensitive
+        );
         assert_eq!(host.status_bar_segments(&app), vec!["SEARCH 0 hits"]);
     }
 }

--- a/src/extension/traits.rs
+++ b/src/extension/traits.rs
@@ -1,4 +1,5 @@
 use crate::app::AppState;
+use crate::backend::SharedPdfBackend;
 use crate::event::AppEvent;
 use crate::input::{AppInputEvent, InputHookResult};
 
@@ -23,6 +24,10 @@ pub trait Extension {
     fn on_background(state: &mut Self::State, app: &mut AppState) -> bool {
         let _ = (state, app);
         false
+    }
+
+    fn on_document_reloaded(state: &mut Self::State, app: &mut AppState, pdf: SharedPdfBackend) {
+        let _ = (state, app, pdf);
     }
 
     fn status_bar_segment(state: &Self::State, app: &AppState) -> Option<String> {

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -6,7 +6,7 @@ use crate::event::AppEvent;
 use crate::extension::Extension;
 use crate::input::{AppInputEvent, InputHookResult};
 pub use palette::HistoryPaletteProvider;
-pub use state::HistoryState;
+pub use state::{HistoryCommandPort, HistoryState};
 
 pub struct HistoryExtension;
 

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -2,6 +2,7 @@ pub mod palette;
 pub mod state;
 
 use crate::app::AppState;
+use crate::backend::SharedPdfBackend;
 use crate::event::AppEvent;
 use crate::extension::Extension;
 use crate::input::{AppInputEvent, InputHookResult};
@@ -29,5 +30,9 @@ impl Extension for HistoryExtension {
     fn handle_event(state: &mut Self::State, event: &AppEvent, app: &mut AppState) {
         let _ = app;
         state.on_event(event);
+    }
+
+    fn on_document_reloaded(state: &mut Self::State, _app: &mut AppState, _pdf: SharedPdfBackend) {
+        *state = HistoryState::default();
     }
 }

--- a/src/history/state.rs
+++ b/src/history/state.rs
@@ -22,6 +22,45 @@ pub struct HistoryState {
     suppress_next_record: bool,
 }
 
+pub struct HistoryCommandPort<'a> {
+    state: &'a mut HistoryState,
+}
+
+impl<'a> HistoryCommandPort<'a> {
+    pub(crate) fn new(state: &'a mut HistoryState) -> Self {
+        Self { state }
+    }
+
+    pub(crate) fn back(
+        &mut self,
+        app: &mut AppState,
+        page_count: usize,
+    ) -> (CommandOutcome, NoticeAction) {
+        self.state.back(app, page_count)
+    }
+
+    pub(crate) fn forward(
+        &mut self,
+        app: &mut AppState,
+        page_count: usize,
+    ) -> (CommandOutcome, NoticeAction) {
+        self.state.forward(app, page_count)
+    }
+
+    pub(crate) fn goto(
+        &mut self,
+        app: &mut AppState,
+        page_count: usize,
+        page: usize,
+    ) -> AppResult<(CommandOutcome, NoticeAction)> {
+        self.state.goto(app, page_count, page)
+    }
+
+    pub(crate) fn open_palette(&self, app: &AppState) -> PaletteRequest {
+        self.state.open_palette(app)
+    }
+}
+
 impl HistoryState {
     pub fn back(
         &mut self,

--- a/src/input/sequence.rs
+++ b/src/input/sequence.rs
@@ -870,6 +870,16 @@ mod tests {
         resolver.handle_key_in_context(KeyBindingContext::normal(&extensions), key)
     }
 
+    fn extension_snapshot(search_active: bool) -> ExtensionUiSnapshot {
+        ExtensionUiSnapshot {
+            search: crate::search::SearchUiSnapshot {
+                active: search_active,
+                ..Default::default()
+            },
+            ..ExtensionUiSnapshot::default()
+        }
+    }
+
     #[test]
     fn exact_single_key_dispatches_immediately() {
         let mut registry = SequenceRegistry::new();
@@ -1028,7 +1038,7 @@ mod tests {
             )
             .expect("later binding should register");
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
-        let extensions = ExtensionUiSnapshot::with_search_active(true);
+        let extensions = extension_snapshot(true);
 
         assert_eq!(
             resolver.handle_key_in_context(
@@ -1363,7 +1373,7 @@ mod tests {
             )
             .expect("multi-key binding should register");
         let mut resolver = SequenceResolver::new(registry, Duration::ZERO);
-        let extensions = ExtensionUiSnapshot::with_search_active(true);
+        let extensions = extension_snapshot(true);
 
         assert_eq!(
             resolver.handle_key_in_context(
@@ -1406,7 +1416,7 @@ mod tests {
             )
             .expect("single-key binding should register");
         let mut resolver = SequenceResolver::new(registry, Duration::ZERO);
-        let active_extensions = ExtensionUiSnapshot::with_search_active(true);
+        let active_extensions = extension_snapshot(true);
         let inactive_extensions = ExtensionUiSnapshot::default();
 
         assert_eq!(
@@ -1439,7 +1449,7 @@ mod tests {
             )
             .expect("conditional binding should register");
         let mut resolver = SequenceResolver::new(registry, DEFAULT_SEQUENCE_TIMEOUT);
-        let active_extensions = ExtensionUiSnapshot::with_search_active(true);
+        let active_extensions = extension_snapshot(true);
         let inactive_extensions = ExtensionUiSnapshot::default();
 
         assert_eq!(

--- a/src/outline/mod.rs
+++ b/src/outline/mod.rs
@@ -4,8 +4,8 @@ pub mod state;
 use crate::app::AppState;
 use crate::event::AppEvent;
 use crate::extension::Extension;
-pub use palette::{OutlinePaletteEntry, OutlinePaletteProvider};
-pub use state::OutlineState;
+pub use palette::OutlinePaletteProvider;
+pub use state::{OutlineCommandPort, OutlineState, OutlineUiSnapshot};
 
 pub struct OutlineExtension;
 
@@ -18,5 +18,14 @@ impl Extension for OutlineExtension {
 
     fn handle_event(state: &mut Self::State, event: &AppEvent, app: &mut AppState) {
         let _ = (state, event, app);
+    }
+
+    fn on_document_reloaded(
+        state: &mut Self::State,
+        app: &mut AppState,
+        pdf: crate::backend::SharedPdfBackend,
+    ) {
+        let _ = (app, pdf);
+        state.on_document_reloaded();
     }
 }

--- a/src/outline/palette.rs
+++ b/src/outline/palette.rs
@@ -41,7 +41,7 @@ impl PaletteProvider for OutlinePaletteProvider {
         let mut page_text_matches = Vec::new();
         let mut unfiltered = Vec::new();
 
-        for (index, entry) in ctx.extensions.outline_entries.iter().enumerate() {
+        for (index, entry) in ctx.extensions.outline.entries.iter().enumerate() {
             let candidate = outline_candidate(index, entry);
             if query.is_empty() {
                 unfiltered.push(candidate);
@@ -101,7 +101,7 @@ impl PaletteProvider for OutlinePaletteProvider {
         ctx: &PaletteContext<'_>,
         _selected: Option<&PaletteCandidate>,
     ) -> Option<String> {
-        if ctx.extensions.outline_entries.is_empty() {
+        if ctx.extensions.outline.entries.is_empty() {
             Some("No outline entries in this document".to_string())
         } else {
             let enter = format_shortcut_key(crate::input::shortcut::ShortcutKey::key(
@@ -197,7 +197,9 @@ mod tests {
             depth: 0,
         }];
         let extensions = ExtensionUiSnapshot {
-            outline_entries: entries.into(),
+            outline: crate::outline::OutlineUiSnapshot {
+                entries: entries.into(),
+            },
             ..ExtensionUiSnapshot::default()
         };
         let ctx = PaletteContext {
@@ -235,7 +237,9 @@ mod tests {
             },
         ];
         let extensions = ExtensionUiSnapshot {
-            outline_entries: entries.into(),
+            outline: crate::outline::OutlineUiSnapshot {
+                entries: entries.into(),
+            },
             ..ExtensionUiSnapshot::default()
         };
         let ctx = PaletteContext {
@@ -274,7 +278,9 @@ mod tests {
             },
         ];
         let extensions = ExtensionUiSnapshot {
-            outline_entries: entries.into(),
+            outline: crate::outline::OutlineUiSnapshot {
+                entries: entries.into(),
+            },
             ..ExtensionUiSnapshot::default()
         };
         let ctx = PaletteContext {
@@ -306,7 +312,9 @@ mod tests {
             depth: 0,
         }];
         let extensions = ExtensionUiSnapshot {
-            outline_entries: entries.into(),
+            outline: crate::outline::OutlineUiSnapshot {
+                entries: entries.into(),
+            },
             ..ExtensionUiSnapshot::default()
         };
         let ctx = PaletteContext {

--- a/src/outline/state.rs
+++ b/src/outline/state.rs
@@ -18,6 +18,34 @@ pub struct OutlineState {
     cache: Option<OutlineCache>,
 }
 
+pub struct OutlineCommandPort<'a> {
+    state: &'a mut OutlineState,
+}
+
+impl<'a> OutlineCommandPort<'a> {
+    pub(crate) fn new(state: &'a mut OutlineState) -> Self {
+        Self { state }
+    }
+
+    pub(crate) fn open_palette(&mut self, pdf: SharedPdfBackend) -> AppResult<PaletteRequest> {
+        self.state.open_palette(pdf)
+    }
+
+    pub(crate) fn goto(
+        &mut self,
+        app: &mut AppState,
+        page_count: usize,
+        page: usize,
+    ) -> AppResult<(CommandOutcome, NoticeAction)> {
+        self.state.goto(app, page_count, page)
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OutlineUiSnapshot {
+    pub entries: Arc<[OutlinePaletteEntry]>,
+}
+
 impl OutlineState {
     pub fn open_palette(&mut self, pdf: SharedPdfBackend) -> AppResult<PaletteRequest> {
         self.ensure_loaded(pdf.as_ref())?;
@@ -50,6 +78,16 @@ impl OutlineState {
             .as_ref()
             .map(|cache| Arc::clone(&cache.entries))
             .unwrap_or_else(|| Arc::from([]))
+    }
+
+    pub fn ui_snapshot(&self) -> OutlineUiSnapshot {
+        OutlineUiSnapshot {
+            entries: self.palette_entries(),
+        }
+    }
+
+    pub fn on_document_reloaded(&mut self) {
+        *self = Self::default();
     }
 
     fn ensure_loaded(&mut self, pdf: &dyn PdfBackend) -> AppResult<()> {

--- a/src/palette/providers/command.rs
+++ b/src/palette/providers/command.rs
@@ -603,13 +603,23 @@ mod tests {
         list.iter().map(|candidate| candidate.id.clone()).collect()
     }
 
+    fn extension_snapshot(search_active: bool) -> ExtensionUiSnapshot {
+        ExtensionUiSnapshot {
+            search: crate::search::SearchUiSnapshot {
+                active: search_active,
+                ..Default::default()
+            },
+            ..ExtensionUiSnapshot::default()
+        }
+    }
+
     fn command_list_for_input(
         input: &str,
         search_active: bool,
     ) -> Vec<crate::palette::PaletteCandidate> {
         let provider = CommandPaletteProvider;
         let app = PaletteAppSnapshot::default();
-        let extensions = ExtensionUiSnapshot::with_search_active(search_active);
+        let extensions = extension_snapshot(search_active);
         let ctx = PaletteContext {
             app,
             extensions: &extensions,
@@ -647,7 +657,7 @@ mod tests {
     ) -> PaletteSubmitEffect {
         let provider = CommandPaletteProvider;
         let app = PaletteAppSnapshot::default();
-        let extensions = ExtensionUiSnapshot::with_search_active(search_active);
+        let extensions = extension_snapshot(search_active);
         let ctx = PaletteContext {
             app,
             extensions: &extensions,
@@ -668,7 +678,7 @@ mod tests {
     fn command_tab_effect(input: &str, selected_id: &str, search_active: bool) -> PaletteTabEffect {
         let provider = CommandPaletteProvider;
         let app = PaletteAppSnapshot::default();
-        let extensions = ExtensionUiSnapshot::with_search_active(search_active);
+        let extensions = extension_snapshot(search_active);
         let ctx = PaletteContext {
             app,
             extensions: &extensions,
@@ -689,7 +699,7 @@ mod tests {
     fn assistive_text_for_input(input: &str, search_active: bool) -> Option<String> {
         let provider = CommandPaletteProvider;
         let app = PaletteAppSnapshot::default();
-        let extensions = ExtensionUiSnapshot::with_search_active(search_active);
+        let extensions = extension_snapshot(search_active);
         let ctx = PaletteContext {
             app,
             extensions: &extensions,
@@ -739,7 +749,7 @@ mod tests {
     fn list_shows_search_hit_navigation_when_search_is_active() {
         let provider = CommandPaletteProvider;
         let app = PaletteAppSnapshot::default();
-        let extensions = ExtensionUiSnapshot::with_search_active(true);
+        let extensions = extension_snapshot(true);
         let ctx = PaletteContext {
             app,
             extensions: &extensions,
@@ -1108,7 +1118,7 @@ mod tests {
     fn submit_reopens_when_input_targets_internal_command() {
         let provider = CommandPaletteProvider;
         let app = PaletteAppSnapshot::default();
-        let extensions = ExtensionUiSnapshot::with_search_active(true);
+        let extensions = extension_snapshot(true);
         let ctx = PaletteContext {
             app,
             extensions: &extensions,

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -9,7 +9,7 @@ use crate::event::AppEvent;
 use crate::extension::Extension;
 pub use palette::SearchPaletteProvider;
 pub use palette::SearchResultsPaletteProvider;
-pub use state::{SearchPaletteEntry, SearchRuntime};
+pub use state::{SearchCommandPort, SearchRuntime, SearchUiSnapshot};
 
 pub struct SearchExtension;
 
@@ -28,6 +28,14 @@ impl Extension for SearchExtension {
 
     fn handle_event(state: &mut Self::State, event: &AppEvent, app: &mut AppState) {
         let _ = (state, event, app);
+    }
+
+    fn on_document_reloaded(
+        state: &mut Self::State,
+        app: &mut AppState,
+        pdf: crate::backend::SharedPdfBackend,
+    ) {
+        state.on_document_reloaded(app, pdf);
     }
 
     fn status_bar_segment(state: &Self::State, _app: &AppState) -> Option<String> {

--- a/src/search/palette.rs
+++ b/src/search/palette.rs
@@ -172,7 +172,7 @@ impl PaletteProvider for SearchResultsPaletteProvider {
     }
 
     fn list(&self, ctx: &PaletteContext<'_>) -> AppResult<Vec<PaletteCandidate>> {
-        let entries = ctx.extensions.search_results_entries.as_ref();
+        let entries = ctx.extensions.search.results_entries.as_ref();
         let query = ctx.input.trim().to_ascii_lowercase();
         if query.is_empty() {
             return Ok(build_result_candidates(entries));
@@ -226,7 +226,7 @@ impl PaletteProvider for SearchResultsPaletteProvider {
         ctx: &PaletteContext<'_>,
         _selected: Option<&PaletteCandidate>,
     ) -> Option<String> {
-        if ctx.extensions.search_results_entries.is_empty() {
+        if ctx.extensions.search.results_entries.is_empty() {
             return Some("0 hits".to_string());
         }
 
@@ -330,7 +330,7 @@ mod tests {
         palette::{
             PaletteAppSnapshot, PaletteContext, PaletteKind, PaletteOpenPayload, PaletteProvider,
         },
-        search::SearchPaletteEntry,
+        search::state::SearchPaletteEntry,
     };
 
     use super::{SearchPaletteProvider, SearchResultsPaletteProvider};
@@ -393,14 +393,17 @@ mod tests {
         let provider = SearchResultsPaletteProvider;
         let app = PaletteAppSnapshot::default();
         let extensions = ExtensionUiSnapshot {
-            search_results_entries: vec![SearchPaletteEntry {
-                index: 1,
-                page: 4,
-                snippet: "…foo needle bar…".to_string(),
-                snippet_match_start: Some(7),
-                snippet_match_end: Some(13),
-            }]
-            .into(),
+            search: crate::search::SearchUiSnapshot {
+                results_entries: vec![SearchPaletteEntry {
+                    index: 1,
+                    page: 4,
+                    snippet: "…foo needle bar…".to_string(),
+                    snippet_match_start: Some(7),
+                    snippet_match_end: Some(13),
+                }]
+                .into(),
+                ..Default::default()
+            },
             ..ExtensionUiSnapshot::default()
         };
         let ctx = PaletteContext {
@@ -430,23 +433,26 @@ mod tests {
             ..PaletteAppSnapshot::default()
         };
         let extensions = ExtensionUiSnapshot {
-            search_results_entries: vec![
-                SearchPaletteEntry {
-                    index: 1,
-                    page: 8,
-                    snippet: "other".to_string(),
-                    snippet_match_start: None,
-                    snippet_match_end: None,
-                },
-                SearchPaletteEntry {
-                    index: 2,
-                    page: 5,
-                    snippet: "right".to_string(),
-                    snippet_match_start: None,
-                    snippet_match_end: None,
-                },
-            ]
-            .into(),
+            search: crate::search::SearchUiSnapshot {
+                results_entries: vec![
+                    SearchPaletteEntry {
+                        index: 1,
+                        page: 8,
+                        snippet: "other".to_string(),
+                        snippet_match_start: None,
+                        snippet_match_end: None,
+                    },
+                    SearchPaletteEntry {
+                        index: 2,
+                        page: 5,
+                        snippet: "right".to_string(),
+                        snippet_match_start: None,
+                        snippet_match_end: None,
+                    },
+                ]
+                .into(),
+                ..Default::default()
+            },
             ..ExtensionUiSnapshot::default()
         };
         let ctx = PaletteContext {
@@ -474,23 +480,26 @@ mod tests {
             ..PaletteAppSnapshot::default()
         };
         let extensions = ExtensionUiSnapshot {
-            search_results_entries: vec![
-                SearchPaletteEntry {
-                    index: 1,
-                    page: 0,
-                    snippet: "cover".to_string(),
-                    snippet_match_start: None,
-                    snippet_match_end: None,
-                },
-                SearchPaletteEntry {
-                    index: 2,
-                    page: 1,
-                    snippet: "next".to_string(),
-                    snippet_match_start: None,
-                    snippet_match_end: None,
-                },
-            ]
-            .into(),
+            search: crate::search::SearchUiSnapshot {
+                results_entries: vec![
+                    SearchPaletteEntry {
+                        index: 1,
+                        page: 0,
+                        snippet: "cover".to_string(),
+                        snippet_match_start: None,
+                        snippet_match_end: None,
+                    },
+                    SearchPaletteEntry {
+                        index: 2,
+                        page: 1,
+                        snippet: "next".to_string(),
+                        snippet_match_start: None,
+                        snippet_match_end: None,
+                    },
+                ]
+                .into(),
+                ..Default::default()
+            },
             ..ExtensionUiSnapshot::default()
         };
         let ctx = PaletteContext {

--- a/src/search/state.rs
+++ b/src/search/state.rs
@@ -182,8 +182,10 @@ impl SearchRuntime {
         *self = Self::default();
         self.prewarm(Arc::clone(&pdf));
         if let Some((query, matcher)) = active_search
-            && let Err(err) = self.submit(app, pdf, query, matcher)
+            && let Err(err) = self.submit(app, Arc::clone(&pdf), query, matcher)
         {
+            *self = Self::default();
+            self.prewarm(pdf);
             app.set_warning_notice(format!("Could not restore search after reload: {err}"));
         }
     }
@@ -276,21 +278,20 @@ impl SearchState {
         query: String,
         matcher: SearchMatcherKind,
     ) -> AppResult<(CommandOutcome, NoticeAction)> {
-        self.query = query;
-        self.matcher = matcher;
-
-        let query = self.query.trim().to_string();
+        let query = query.trim().to_string();
         if query.is_empty() {
             self.generation = search_engine.cancel(Arc::clone(&pdf))?;
             self.query.clear();
+            self.matcher = matcher;
             self.clear_results();
             return Ok((CommandOutcome::Noop, NoticeAction::Clear));
         }
 
-        let matcher = matcher_for_kind(self.matcher);
-        let generation = search_engine.submit(Arc::clone(&pdf), query.clone(), matcher)?;
+        let search_matcher = matcher_for_kind(matcher);
+        let generation = search_engine.submit(Arc::clone(&pdf), query.clone(), search_matcher)?;
 
         self.query = query;
+        self.matcher = matcher;
         self.generation = generation;
         self.in_progress = true;
         self.scanned_pages_progress = 0;

--- a/src/search/state.rs
+++ b/src/search/state.rs
@@ -16,6 +16,61 @@ pub struct SearchRuntime {
     engine: SearchEngine,
 }
 
+pub struct SearchCommandPort<'a> {
+    runtime: &'a mut SearchRuntime,
+}
+
+impl<'a> SearchCommandPort<'a> {
+    pub(crate) fn new(runtime: &'a mut SearchRuntime) -> Self {
+        Self { runtime }
+    }
+
+    pub(crate) fn open_palette(&mut self) -> PaletteRequest {
+        self.runtime.open_palette()
+    }
+
+    pub(crate) fn submit(
+        &mut self,
+        app: &mut AppState,
+        pdf: SharedPdfBackend,
+        query: String,
+        matcher: SearchMatcherKind,
+    ) -> AppResult<(CommandOutcome, NoticeAction)> {
+        self.runtime.submit(app, pdf, query, matcher)
+    }
+
+    pub(crate) fn open_results_palette(&mut self) -> Option<PaletteRequest> {
+        self.runtime.open_results_palette()
+    }
+
+    pub(crate) fn goto_result(
+        &mut self,
+        app: &mut AppState,
+        page_count: usize,
+        page: usize,
+    ) -> AppResult<(CommandOutcome, NoticeAction)> {
+        self.runtime.goto_result(app, page_count, page)
+    }
+
+    pub(crate) fn cancel(&mut self, pdf: SharedPdfBackend) -> AppResult<bool> {
+        self.runtime.cancel(pdf)
+    }
+
+    pub(crate) fn next_hit(&mut self, app: &mut AppState) -> (CommandOutcome, NoticeAction) {
+        self.runtime.next_hit(app)
+    }
+
+    pub(crate) fn prev_hit(&mut self, app: &mut AppState) -> (CommandOutcome, NoticeAction) {
+        self.runtime.prev_hit(app)
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SearchUiSnapshot {
+    pub active: bool,
+    pub results_entries: Arc<[SearchPaletteEntry]>,
+}
+
 impl SearchRuntime {
     pub fn open_palette(&mut self) -> PaletteRequest {
         self.state.open_palette()
@@ -111,6 +166,26 @@ impl SearchRuntime {
     ) -> HighlightOverlaySnapshot {
         self.state
             .highlight_overlay_for_visible_pages(visible_pages)
+    }
+
+    pub fn ui_snapshot(&self) -> SearchUiSnapshot {
+        SearchUiSnapshot {
+            active: self.is_active(),
+            results_entries: self.palette_entries(),
+        }
+    }
+
+    pub fn on_document_reloaded(&mut self, app: &mut AppState, pdf: SharedPdfBackend) {
+        let active_search = self
+            .is_active()
+            .then(|| (self.query().to_string(), self.matcher()));
+        *self = Self::default();
+        self.prewarm(Arc::clone(&pdf));
+        if let Some((query, matcher)) = active_search
+            && let Err(err) = self.submit(app, pdf, query, matcher)
+        {
+            app.set_warning_notice(format!("Could not restore search after reload: {err}"));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- split command-facing extension operations into typed feature ports
- keep ExtensionHost focused on lifecycle routing, snapshots, and render projection
- update extension docs to describe current ownership boundaries

## Rationale
ExtensionHost had accumulated feature-specific operations for search, history, and outline. This keeps feature behavior with feature-owned runtime/state while preserving static extension composition.

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more consistent behavior for document reloads and page changes, including preserving or restoring relevant app state where possible.
  * Improved search, history, and outline interactions so related panels and results update more reliably.

* **Documentation**
  * Clarified how extensions, shared UI data, and built-in features are organized and how they behave during navigation and reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->