### PR TITLE
feat(render): add graphics protocol option

### DIFF
--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -11,7 +11,7 @@ use crate::extension::ExtensionHost;
 use crate::input::InputHistoryService;
 use crate::input::sequence::{DEFAULT_SEQUENCE_TIMEOUT, SequenceRegistry, SequenceResolver};
 use crate::palette::{PaletteRegistry, PaletteSessionController};
-use crate::presenter::{ImagePresenter, PresenterKind, create_presenter_with_cache_limits};
+use crate::presenter::{ImagePresenter, PresenterFactoryOptions, PresenterKind, create_presenter};
 
 use super::runtime::RenderRuntime;
 use super::state::{AppState, CacheHandle, PaletteRequest};
@@ -180,9 +180,12 @@ impl App {
         let cache = options.cache;
         let view = options.view;
         let watch = options.watch;
-        let presenter = create_presenter_with_cache_limits(
+        let presenter = create_presenter(
             presenter_kind,
-            Some((cache.l2_max_entries, cache.l2_memory_budget_bytes())),
+            PresenterFactoryOptions {
+                l2_cache_limits: Some((cache.l2_max_entries, cache.l2_memory_budget_bytes())),
+                graphics_protocol: options.render.graphics_protocol,
+            },
         )?;
         let mut state = AppState {
             current_page: view.initial_page_index,
@@ -315,6 +318,7 @@ mod tests {
     fn new_with_options_threads_runtime_policies_to_owners() {
         let options = AppOptions {
             render: RenderOptions {
+                graphics_protocol: None,
                 worker_threads: Some(5),
                 input_poll_timeout_idle_ms: Some(17),
                 input_poll_timeout_busy_ms: Some(9),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,8 @@ use std::path::PathBuf;
 
 use clap::{ArgAction, Parser, ValueEnum};
 use pvf::app::PageLayoutMode;
-use pvf::config::{AppOptions, ConfigFileSelection, ViewOptions, WatchOptions};
+use pvf::config::{AppOptions, ConfigFileSelection, RenderOptions, ViewOptions, WatchOptions};
+use pvf::presenter::GraphicsProtocol;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(super) struct CliOptions {
@@ -15,6 +16,27 @@ pub(super) struct CliOptions {
 enum CliPageLayout {
     Single,
     Spread,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum CliGraphicsProtocol {
+    Auto,
+    Halfblocks,
+    Sixel,
+    Kitty,
+    Iterm2,
+}
+
+impl From<CliGraphicsProtocol> for GraphicsProtocol {
+    fn from(value: CliGraphicsProtocol) -> Self {
+        match value {
+            CliGraphicsProtocol::Auto => Self::Auto,
+            CliGraphicsProtocol::Halfblocks => Self::Halfblocks,
+            CliGraphicsProtocol::Sixel => Self::Sixel,
+            CliGraphicsProtocol::Kitty => Self::Kitty,
+            CliGraphicsProtocol::Iterm2 => Self::Iterm2,
+        }
+    }
 }
 
 impl From<CliPageLayout> for PageLayoutMode {
@@ -65,6 +87,13 @@ struct Cli {
     zoom: Option<f32>,
     #[arg(short, long, value_enum, help = "Set the initial page layout")]
     layout: Option<CliPageLayout>,
+    #[arg(
+        long,
+        value_enum,
+        value_name = "PROTOCOL",
+        help = "Set the terminal graphics protocol"
+    )]
+    graphics_protocol: Option<CliGraphicsProtocol>,
     #[arg(value_name = "FILE")]
     pdf_path: PathBuf,
 }
@@ -102,6 +131,10 @@ fn parse_cli(cli: Cli) -> CliOptions {
                 },
                 ..WatchOptions::default()
             },
+            render: RenderOptions {
+                graphics_protocol: cli.graphics_protocol.map(GraphicsProtocol::from),
+                ..RenderOptions::default()
+            },
             ..AppOptions::default()
         },
     }
@@ -114,6 +147,7 @@ mod tests {
     use clap::{Parser, error::ErrorKind};
     use pvf::app::PageLayoutMode;
     use pvf::config::ConfigFileSelection;
+    use pvf::presenter::GraphicsProtocol;
 
     use super::{Cli, parse_cli};
 
@@ -205,6 +239,25 @@ mod tests {
     }
 
     #[test]
+    fn parse_cli_accepts_graphics_protocol_override() {
+        let cli = Cli::try_parse_from(["pvf", "--graphics-protocol", "kitty", "sample.pdf"])
+            .expect("graphics protocol should parse");
+        let options = parse_cli(cli);
+        assert_eq!(
+            options.options.render.graphics_protocol,
+            Some(GraphicsProtocol::Kitty)
+        );
+
+        let cli = Cli::try_parse_from(["pvf", "--graphics-protocol", "auto", "sample.pdf"])
+            .expect("auto graphics protocol should parse");
+        let options = parse_cli(cli);
+        assert_eq!(
+            options.options.render.graphics_protocol,
+            Some(GraphicsProtocol::Auto)
+        );
+    }
+
+    #[test]
     fn parse_cli_accepts_short_initial_view_overrides() {
         let cli = Cli::try_parse_from([
             "pvf",
@@ -246,5 +299,8 @@ mod tests {
         );
         assert!(Cli::try_parse_from(["pvf", "--watch", "--no-watch", "sample.pdf"]).is_err());
         assert!(Cli::try_parse_from(["pvf", "--layout", "grid", "sample.pdf"]).is_err());
+        assert!(
+            Cli::try_parse_from(["pvf", "--graphics-protocol", "unknown", "sample.pdf"]).is_err()
+        );
     }
 }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 
 use crate::app::{PageLayoutMode, SpreadCoverPolicy, SpreadDirection};
 use crate::error::{AppError, AppResult};
+use crate::presenter::GraphicsProtocol;
 
 use super::options::{
     AppOptions, CacheOptions, InputOptions, KeymapOptions, RenderOptions, ViewOptions, WatchOptions,
@@ -73,6 +74,7 @@ struct RawConfig {
 #[derive(Debug, Clone, Deserialize, Default, PartialEq)]
 #[serde(default)]
 struct RawRenderConfig {
+    graphics_protocol: Option<String>,
     worker_threads: Option<usize>,
     input_poll_timeout_idle_ms: Option<u64>,
     input_poll_timeout_busy_ms: Option<u64>,
@@ -133,7 +135,11 @@ struct RawWatchConfig {
 impl RawConfig {
     fn into_options(self) -> AppResult<AppOptions> {
         Ok(AppOptions {
-            render: self.render.map(RenderOptions::from).unwrap_or_default(),
+            render: self
+                .render
+                .map(RenderOptions::try_from)
+                .transpose()?
+                .unwrap_or_default(),
             cache: self.cache.map(CacheOptions::from).unwrap_or_default(),
             view: self
                 .view
@@ -147,9 +153,16 @@ impl RawConfig {
     }
 }
 
-impl From<RawRenderConfig> for RenderOptions {
-    fn from(raw: RawRenderConfig) -> Self {
-        Self {
+impl TryFrom<RawRenderConfig> for RenderOptions {
+    type Error = AppError;
+
+    fn try_from(raw: RawRenderConfig) -> Result<Self, Self::Error> {
+        Ok(Self {
+            graphics_protocol: raw
+                .graphics_protocol
+                .as_deref()
+                .map(parse_graphics_protocol)
+                .transpose()?,
             worker_threads: raw.worker_threads,
             input_poll_timeout_idle_ms: raw.input_poll_timeout_idle_ms,
             input_poll_timeout_busy_ms: raw.input_poll_timeout_busy_ms,
@@ -158,7 +171,7 @@ impl From<RawRenderConfig> for RenderOptions {
             pending_redraw_interval_ms: raw.pending_redraw_interval_ms,
             prefetch_dispatch_budget_per_tick: raw.prefetch_dispatch_budget_per_tick,
             max_render_scale: raw.max_render_scale,
-        }
+        })
     }
 }
 
@@ -274,6 +287,19 @@ fn parse_spread_cover(value: &str) -> AppResult<SpreadCoverPolicy> {
     }
 }
 
+fn parse_graphics_protocol(value: &str) -> AppResult<GraphicsProtocol> {
+    match value {
+        "auto" => Ok(GraphicsProtocol::Auto),
+        "halfblocks" => Ok(GraphicsProtocol::Halfblocks),
+        "sixel" => Ok(GraphicsProtocol::Sixel),
+        "kitty" => Ok(GraphicsProtocol::Kitty),
+        "iterm2" => Ok(GraphicsProtocol::Iterm2),
+        _ => Err(AppError::invalid_argument(format!(
+            "unknown render.graphics_protocol: {value}"
+        ))),
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MissingConfigPolicy {
     Default,
@@ -373,6 +399,7 @@ mod tests {
         DEFAULT_SEQUENCE_TIMEOUT, KeyBindingContext, SequenceResolution, SequenceResolver,
     };
     use crate::input::shortcut::ShortcutKey;
+    use crate::presenter::GraphicsProtocol;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     use super::{
@@ -416,6 +443,7 @@ mod tests {
             pending_redraw_interval_ms = 0
             prefetch_dispatch_budget_per_tick = 0
             max_render_scale = 0.5
+            graphics_protocol = "kitty"
 
             [cache]
             l1_memory_budget_mb = 256
@@ -447,6 +475,10 @@ mod tests {
         assert_eq!(config.render.pending_redraw_interval_ms, 1);
         assert_eq!(config.render.prefetch_dispatch_budget_per_tick, 1);
         assert_eq!(config.render.max_render_scale, 2.5);
+        assert_eq!(
+            config.render.graphics_protocol,
+            Some(GraphicsProtocol::Kitty)
+        );
         assert_eq!(config.cache.l1_memory_budget_mb, 256);
         assert_eq!(config.cache.l2_memory_budget_mb, 64);
         assert_eq!(config.cache.l1_max_entries, 128);
@@ -867,6 +899,71 @@ mod tests {
         assert_eq!(options.input.sequence_timeout_ms, None);
         assert!(options.keymap.bindings.is_empty());
         assert_eq!(options.watch.enabled, None);
+        assert_eq!(options.render.graphics_protocol, None);
+
+        fs::remove_file(&path).expect("config file should be removed");
+    }
+
+    #[test]
+    fn explicit_config_reads_graphics_protocol() {
+        let path = unique_temp_path("graphics-protocol.toml");
+        fs::write(
+            &path,
+            r#"
+            [render]
+            graphics_protocol = "sixel"
+            "#,
+        )
+        .expect("config file should be written");
+
+        let options = load_options_from_explicit_path(&path).expect("config should load");
+        assert_eq!(
+            options.render.graphics_protocol,
+            Some(GraphicsProtocol::Sixel)
+        );
+
+        fs::remove_file(&path).expect("config file should be removed");
+    }
+
+    #[test]
+    fn explicit_config_reads_auto_graphics_protocol() {
+        let path = unique_temp_path("auto-graphics-protocol.toml");
+        fs::write(
+            &path,
+            r#"
+            [render]
+            graphics_protocol = "auto"
+            "#,
+        )
+        .expect("config file should be written");
+
+        let options = load_options_from_explicit_path(&path).expect("config should load");
+        assert_eq!(
+            options.render.graphics_protocol,
+            Some(GraphicsProtocol::Auto)
+        );
+
+        fs::remove_file(&path).expect("config file should be removed");
+    }
+
+    #[test]
+    fn explicit_config_rejects_unknown_graphics_protocol() {
+        let path = unique_temp_path("bad-graphics-protocol.toml");
+        fs::write(
+            &path,
+            r#"
+            [render]
+            graphics_protocol = "graphics-protocol"
+            "#,
+        )
+        .expect("config file should be written");
+
+        let err = load_options_from_explicit_path(&path)
+            .expect_err("unknown graphics protocol should be rejected");
+        assert!(
+            err.to_string()
+                .contains("unknown render.graphics_protocol: graphics-protocol")
+        );
 
         fs::remove_file(&path).expect("config file should be removed");
     }

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -1,4 +1,5 @@
 use crate::app::{PageLayoutMode, SpreadCoverPolicy, SpreadDirection};
+use crate::presenter::GraphicsProtocol;
 
 pub use super::keymap::{KeymapBinding, KeymapOptions, KeymapPreset, KeymapWhen};
 use super::types::Config;
@@ -29,6 +30,7 @@ impl From<Config> for AppOptions {
     fn from(config: Config) -> Self {
         Self {
             render: RenderOptions {
+                graphics_protocol: config.render.graphics_protocol,
                 worker_threads: Some(config.render.worker_threads),
                 input_poll_timeout_idle_ms: Some(config.render.input_poll_timeout_idle_ms),
                 input_poll_timeout_busy_ms: Some(config.render.input_poll_timeout_busy_ms),
@@ -68,6 +70,7 @@ impl From<Config> for AppOptions {
 
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct RenderOptions {
+    pub graphics_protocol: Option<GraphicsProtocol>,
     pub worker_threads: Option<usize>,
     pub input_poll_timeout_idle_ms: Option<u64>,
     pub input_poll_timeout_busy_ms: Option<u64>,
@@ -81,6 +84,7 @@ pub struct RenderOptions {
 impl RenderOptions {
     pub(super) fn merge(self, next: Self) -> Self {
         Self {
+            graphics_protocol: next.graphics_protocol.or(self.graphics_protocol),
             worker_threads: next.worker_threads.or(self.worker_threads),
             input_poll_timeout_idle_ms: next
                 .input_poll_timeout_idle_ms

--- a/src/config/policy.rs
+++ b/src/config/policy.rs
@@ -20,6 +20,7 @@ pub struct ResolvedAppOptions {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RenderPolicy {
+    pub graphics_protocol: Option<crate::presenter::GraphicsProtocol>,
     pub worker_threads: usize,
     pub max_render_scale: f32,
 }
@@ -28,6 +29,7 @@ impl Default for RenderPolicy {
     fn default() -> Self {
         let render = RenderConfig::default();
         Self {
+            graphics_protocol: render.graphics_protocol,
             worker_threads: render.worker_threads,
             max_render_scale: render.max_render_scale,
         }
@@ -179,6 +181,7 @@ impl From<ResolvedAppOptions> for Config {
     fn from(options: ResolvedAppOptions) -> Self {
         Self {
             render: RenderConfig {
+                graphics_protocol: options.render.graphics_protocol,
                 worker_threads: options.render.worker_threads,
                 input_poll_timeout_idle_ms: options.event_loop.input_poll_timeout_idle.as_millis()
                     as u64,
@@ -298,6 +301,10 @@ fn resolve_options(options: AppOptions) -> ResolvedAppOptions {
 
     ResolvedAppOptions {
         render: RenderPolicy {
+            graphics_protocol: options
+                .render
+                .graphics_protocol
+                .or(render_defaults.graphics_protocol),
             worker_threads,
             max_render_scale,
         },
@@ -362,6 +369,7 @@ mod tests {
     use crate::app::{PageLayoutMode, SpreadCoverPolicy, SpreadDirection};
 
     use crate::config::{AppOptions, RenderOptions, ViewOptions, WatchOptions};
+    use crate::presenter::GraphicsProtocol;
 
     use super::AppOptionsResolver;
 
@@ -369,6 +377,7 @@ mod tests {
     fn resolver_applies_defaults_and_sanitizes_without_file_source() {
         let options = AppOptions {
             render: RenderOptions {
+                graphics_protocol: None,
                 worker_threads: Some(0),
                 input_poll_timeout_idle_ms: Some(0),
                 input_poll_timeout_busy_ms: Some(0),
@@ -418,6 +427,7 @@ mod tests {
         );
         assert_eq!(resolved.event_loop.prefetch_dispatch_budget_per_tick, 1);
         assert_eq!(resolved.render.max_render_scale, 2.5);
+        assert_eq!(resolved.render.graphics_protocol, None);
         assert_eq!(resolved.view.initial_page_index, 0);
         assert_eq!(resolved.view.initial_zoom, 4.0);
         assert_eq!(resolved.view.initial_layout, PageLayoutMode::Spread);
@@ -432,6 +442,7 @@ mod tests {
     fn resolver_merges_later_options_over_earlier_options() {
         let base = AppOptions {
             render: RenderOptions {
+                graphics_protocol: Some(GraphicsProtocol::Sixel),
                 worker_threads: Some(2),
                 ..RenderOptions::default()
             },
@@ -439,6 +450,7 @@ mod tests {
         };
         let override_options = AppOptions {
             render: RenderOptions {
+                graphics_protocol: Some(GraphicsProtocol::Kitty),
                 worker_threads: Some(4),
                 ..RenderOptions::default()
             },
@@ -463,5 +475,9 @@ mod tests {
 
         assert_eq!(resolved.render.worker_threads, 4);
         assert!(!resolved.watch.enabled);
+        assert_eq!(
+            resolved.render.graphics_protocol,
+            Some(GraphicsProtocol::Kitty)
+        );
     }
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 
 use crate::app::{PageLayoutMode, SpreadCoverPolicy, SpreadDirection};
 use crate::input::sequence::DEFAULT_SEQUENCE_TIMEOUT;
+use crate::presenter::GraphicsProtocol;
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Config {
@@ -15,6 +16,7 @@ pub struct Config {
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct RenderConfig {
+    pub graphics_protocol: Option<GraphicsProtocol>,
     pub worker_threads: usize,
     pub input_poll_timeout_idle_ms: u64,
     pub input_poll_timeout_busy_ms: u64,
@@ -28,6 +30,7 @@ pub struct RenderConfig {
 impl Default for RenderConfig {
     fn default() -> Self {
         Self {
+            graphics_protocol: None,
             worker_threads: 3,
             input_poll_timeout_idle_ms: 16,
             input_poll_timeout_busy_ms: 8,

--- a/src/presenter/factory.rs
+++ b/src/presenter/factory.rs
@@ -1,23 +1,34 @@
 use crate::error::AppResult;
 
+use super::l2_cache::{L2_MAX_ENTRIES, L2_MEMORY_BUDGET_BYTES};
 use super::ratatui::RatatuiImagePresenter;
-use super::traits::{ImagePresenter, PresenterKind};
+use super::traits::{GraphicsProtocol, ImagePresenter, PresenterKind};
 
-pub fn create_presenter(kind: PresenterKind) -> AppResult<Box<dyn ImagePresenter>> {
-    create_presenter_with_cache_limits(kind, None)
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PresenterFactoryOptions {
+    pub l2_cache_limits: Option<(usize, usize)>,
+    pub graphics_protocol: Option<GraphicsProtocol>,
 }
 
-pub fn create_presenter_with_cache_limits(
+pub fn create_presenter(
     kind: PresenterKind,
-    l2_cache_limits: Option<(usize, usize)>,
+    options: PresenterFactoryOptions,
 ) -> AppResult<Box<dyn ImagePresenter>> {
     match kind {
         PresenterKind::RatatuiImage => {
-            let presenter = match l2_cache_limits {
+            let presenter = match options.l2_cache_limits {
                 Some((max_entries, memory_budget_bytes)) => {
-                    RatatuiImagePresenter::with_cache_limits(max_entries, memory_budget_bytes)
+                    RatatuiImagePresenter::with_cache_limits_and_graphics_protocol(
+                        max_entries,
+                        memory_budget_bytes,
+                        options.graphics_protocol,
+                    )
                 }
-                None => RatatuiImagePresenter::new(),
+                None => RatatuiImagePresenter::with_cache_limits_and_graphics_protocol(
+                    L2_MAX_ENTRIES,
+                    L2_MEMORY_BUDGET_BYTES,
+                    options.graphics_protocol,
+                ),
             };
             Ok(Box::new(presenter))
         }

--- a/src/presenter/factory.rs
+++ b/src/presenter/factory.rs
@@ -16,20 +16,14 @@ pub fn create_presenter(
 ) -> AppResult<Box<dyn ImagePresenter>> {
     match kind {
         PresenterKind::RatatuiImage => {
-            let presenter = match options.l2_cache_limits {
-                Some((max_entries, memory_budget_bytes)) => {
-                    RatatuiImagePresenter::with_cache_limits_and_graphics_protocol(
-                        max_entries,
-                        memory_budget_bytes,
-                        options.graphics_protocol,
-                    )
-                }
-                None => RatatuiImagePresenter::with_cache_limits_and_graphics_protocol(
-                    L2_MAX_ENTRIES,
-                    L2_MEMORY_BUDGET_BYTES,
-                    options.graphics_protocol,
-                ),
-            };
+            let (max_entries, memory_budget_bytes) = options
+                .l2_cache_limits
+                .unwrap_or((L2_MAX_ENTRIES, L2_MEMORY_BUDGET_BYTES));
+            let presenter = RatatuiImagePresenter::with_cache_limits_and_graphics_protocol(
+                max_entries,
+                memory_budget_bytes,
+                options.graphics_protocol,
+            );
             Ok(Box::new(presenter))
         }
     }

--- a/src/presenter/mod.rs
+++ b/src/presenter/mod.rs
@@ -9,11 +9,11 @@ mod traits;
 #[cfg(test)]
 mod tests;
 
-pub use factory::{create_presenter, create_presenter_with_cache_limits};
+pub use factory::{PresenterFactoryOptions, create_presenter};
 pub use ratatui::RatatuiImagePresenter;
 pub use traits::{
-    ImagePresenter, PanOffset, PresenterBackgroundEvent, PresenterCaps, PresenterFeedback,
-    PresenterHorizontalAlign, PresenterKind, PresenterRenderMode, PresenterRenderOptions,
-    PresenterRenderOutcome, PresenterRenderSlot, PresenterRuntimeInfo, PresenterSlot,
-    PresenterSlotOutcome, Viewport,
+    GraphicsProtocol, ImagePresenter, PanOffset, PresenterBackgroundEvent, PresenterCaps,
+    PresenterFeedback, PresenterHorizontalAlign, PresenterKind, PresenterRenderMode,
+    PresenterRenderOptions, PresenterRenderOutcome, PresenterRenderSlot, PresenterRuntimeInfo,
+    PresenterSlot, PresenterSlotOutcome, Viewport,
 };

--- a/src/presenter/ratatui/mod.rs
+++ b/src/presenter/ratatui/mod.rs
@@ -4,13 +4,14 @@ mod draw;
 mod geometry;
 use ratatui::layout::Rect;
 use ratatui::widgets::Clear;
+use ratatui_image::errors::Errors as RatatuiImageError;
 use ratatui_image::picker::Picker;
 use ratatui_image::picker::ProtocolType;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, error::TryRecvError};
 use tokio::task::JoinHandle;
 
 use crate::backend::RgbaFrame;
-use crate::error::{AppError, AppResult};
+use crate::error::AppResult;
 use crate::metrics::PerfStats;
 use crate::render::cache::RenderedPageKey;
 use crate::work::WorkClass;
@@ -68,6 +69,11 @@ struct EncodeChannels {
     _runtime: EncodeWorkerRuntime,
     current: EncodeLane,
     background: EncodeLane,
+}
+
+struct ResolvedTerminalPicker {
+    picker: Picker,
+    protocol_type: ProtocolType,
 }
 
 pub struct RatatuiImagePresenter {
@@ -367,6 +373,13 @@ impl RatatuiImagePresenter {
             worker.abort();
         }
     }
+
+    fn apply_terminal_picker(&mut self, resolved: ResolvedTerminalPicker) {
+        self.config.protocol_type = resolved.protocol_type;
+        self.config.protocol_label = protocol_type_label(resolved.protocol_type);
+        self.config.picker = resolved.picker;
+        self.reset_terminal_state();
+    }
 }
 
 impl ImagePresenter for RatatuiImagePresenter {
@@ -375,26 +388,9 @@ impl ImagePresenter for RatatuiImagePresenter {
             return Ok(());
         }
 
-        if let Some(protocol_type) = self
-            .config
-            .requested_protocol
-            .and_then(forced_protocol_type)
-        {
-            let mut picker = Picker::from_query_stdio().map_err(|err| {
-                AppError::unsupported(format!("failed to initialize graphics protocol: {err}"))
-            })?;
-            picker.set_protocol_type(protocol_type);
-            self.config.protocol_type = protocol_type;
-            self.config.protocol_label = protocol_type_label(protocol_type);
-            self.config.picker = picker_with_resolved_cell_size(picker, protocol_type);
-            self.reset_terminal_state();
-        } else if let Ok(picker) = Picker::from_query_stdio() {
-            let protocol_type = picker.protocol_type();
-            self.config.protocol_type = protocol_type;
-            self.config.protocol_label = protocol_type_label(protocol_type);
-            self.config.picker = picker_with_resolved_cell_size(picker, protocol_type);
-            self.reset_terminal_state();
-        }
+        let resolved =
+            resolve_terminal_picker(self.config.requested_protocol, Picker::from_query_stdio);
+        self.apply_terminal_picker(resolved);
 
         self.state.terminal_initialized = true;
         Ok(())
@@ -628,6 +624,40 @@ fn preferred_max_render_scale(protocol: ProtocolType) -> f32 {
     }
 }
 
+fn resolve_terminal_picker(
+    requested_protocol: Option<GraphicsProtocol>,
+    query_picker: impl FnOnce() -> std::result::Result<Picker, RatatuiImageError>,
+) -> ResolvedTerminalPicker {
+    match requested_protocol.and_then(forced_protocol_type) {
+        Some(protocol_type) => terminal_picker_for_forced_protocol(protocol_type),
+        None => terminal_picker_for_auto_protocol(query_picker),
+    }
+}
+
+fn terminal_picker_for_auto_protocol(
+    query_picker: impl FnOnce() -> std::result::Result<Picker, RatatuiImageError>,
+) -> ResolvedTerminalPicker {
+    // Auto is best-effort: terminal probing improves protocol and sizing when it works,
+    // but a failed probe should still leave the viewer usable.
+    let picker = query_picker().unwrap_or_else(|_| Picker::halfblocks());
+    let protocol_type = picker.protocol_type();
+    ResolvedTerminalPicker {
+        picker: picker_with_resolved_cell_size(picker, protocol_type),
+        protocol_type,
+    }
+}
+
+fn terminal_picker_for_forced_protocol(protocol_type: ProtocolType) -> ResolvedTerminalPicker {
+    // A forced protocol is already the user's choice, so do not run auto-detection here.
+    // Start from a basic picker and keep only non-probing cell-size resolution.
+    let mut picker = Picker::halfblocks();
+    picker.set_protocol_type(protocol_type);
+    ResolvedTerminalPicker {
+        picker: picker_with_resolved_cell_size(picker, protocol_type),
+        protocol_type,
+    }
+}
+
 fn forced_protocol_type(protocol: GraphicsProtocol) -> Option<ProtocolType> {
     match protocol {
         GraphicsProtocol::Auto => None,
@@ -650,7 +680,7 @@ mod tests {
     use crate::backend::RgbaFrame;
     use crate::presenter::l2_cache::TerminalFrameState;
     use crate::presenter::{
-        ImagePresenter, PanOffset, PresenterFeedback, PresenterHorizontalAlign,
+        GraphicsProtocol, ImagePresenter, PanOffset, PresenterFeedback, PresenterHorizontalAlign,
         PresenterRenderMode, PresenterRenderOptions, PresenterRenderSlot, PresenterSlot, Viewport,
     };
     use crate::render::cache::RenderedPageKey;
@@ -694,6 +724,41 @@ mod tests {
                 .is_some(),
             "presenter should have a ready frame for fallback"
         );
+    }
+
+    #[test]
+    fn forced_graphics_protocol_does_not_query_terminal_protocol() {
+        let resolved = super::resolve_terminal_picker(Some(GraphicsProtocol::Kitty), || {
+            panic!("forced graphics protocol should not query terminal protocol")
+        });
+
+        assert_eq!(resolved.protocol_type, super::ProtocolType::Kitty);
+        assert_eq!(resolved.picker.protocol_type(), super::ProtocolType::Kitty);
+    }
+
+    #[test]
+    fn auto_graphics_protocol_uses_halfblocks_when_query_fails() {
+        let resolved = super::resolve_terminal_picker(Some(GraphicsProtocol::Auto), || {
+            Err(super::RatatuiImageError::NoStdinResponse)
+        });
+
+        assert_eq!(resolved.protocol_type, super::ProtocolType::Halfblocks);
+        assert_eq!(
+            resolved.picker.protocol_type(),
+            super::ProtocolType::Halfblocks
+        );
+    }
+
+    #[test]
+    fn auto_graphics_protocol_uses_detected_protocol_when_query_succeeds() {
+        let resolved = super::resolve_terminal_picker(None, || {
+            let mut picker = super::Picker::halfblocks();
+            picker.set_protocol_type(super::ProtocolType::Sixel);
+            Ok(picker)
+        });
+
+        assert_eq!(resolved.protocol_type, super::ProtocolType::Sixel);
+        assert_eq!(resolved.picker.protocol_type(), super::ProtocolType::Sixel);
     }
 
     #[test]

--- a/src/presenter/ratatui/mod.rs
+++ b/src/presenter/ratatui/mod.rs
@@ -10,7 +10,7 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, error::TryRecvError}
 use tokio::task::JoinHandle;
 
 use crate::backend::RgbaFrame;
-use crate::error::AppResult;
+use crate::error::{AppError, AppResult};
 use crate::metrics::PerfStats;
 use crate::render::cache::RenderedPageKey;
 use crate::work::WorkClass;
@@ -26,8 +26,9 @@ use super::l2_cache::{
 };
 use super::terminal_cell::{picker_with_resolved_cell_size, protocol_type_label};
 use super::traits::{
-    ImagePresenter, PanOffset, PresenterBackgroundEvent, PresenterCaps, PresenterRenderOutcome,
-    PresenterRenderSlot, PresenterRuntimeInfo, PresenterSlot, PresenterSlotOutcome, Viewport,
+    GraphicsProtocol, ImagePresenter, PanOffset, PresenterBackgroundEvent, PresenterCaps,
+    PresenterRenderOutcome, PresenterRenderSlot, PresenterRuntimeInfo, PresenterSlot,
+    PresenterSlotOutcome, Viewport,
 };
 
 pub(super) const ENCODE_FAILURE_MESSAGE: &str = "failed to encode terminal image";
@@ -36,6 +37,7 @@ pub(super) struct PresenterConfig {
     pub(super) picker: Picker,
     pub(super) protocol_type: ProtocolType,
     pub(super) protocol_label: &'static str,
+    pub(super) requested_protocol: Option<GraphicsProtocol>,
 }
 
 pub(super) struct PresenterState {
@@ -82,6 +84,14 @@ impl Default for RatatuiImagePresenter {
 
 impl RatatuiImagePresenter {
     pub fn with_cache_limits(l2_max_entries: usize, l2_memory_budget_bytes: usize) -> Self {
+        Self::with_cache_limits_and_graphics_protocol(l2_max_entries, l2_memory_budget_bytes, None)
+    }
+
+    pub(super) fn with_cache_limits_and_graphics_protocol(
+        l2_max_entries: usize,
+        l2_memory_budget_bytes: usize,
+        graphics_protocol: Option<GraphicsProtocol>,
+    ) -> Self {
         let runtime = EncodeWorkerRuntime::new();
         let (current_tx, current_rx, current_worker) =
             spawn_encode_worker(&runtime, EncodeLaneKind::Current);
@@ -92,6 +102,7 @@ impl RatatuiImagePresenter {
                 picker: Picker::halfblocks(),
                 protocol_type: ProtocolType::Halfblocks,
                 protocol_label: "halfblocks",
+                requested_protocol: graphics_protocol,
             },
             state: PresenterState {
                 terminal_initialized: false,
@@ -364,7 +375,20 @@ impl ImagePresenter for RatatuiImagePresenter {
             return Ok(());
         }
 
-        if let Ok(picker) = Picker::from_query_stdio() {
+        if let Some(protocol_type) = self
+            .config
+            .requested_protocol
+            .and_then(forced_protocol_type)
+        {
+            let mut picker = Picker::from_query_stdio().map_err(|err| {
+                AppError::unsupported(format!("failed to initialize graphics protocol: {err}"))
+            })?;
+            picker.set_protocol_type(protocol_type);
+            self.config.protocol_type = protocol_type;
+            self.config.protocol_label = protocol_type_label(protocol_type);
+            self.config.picker = picker_with_resolved_cell_size(picker, protocol_type);
+            self.reset_terminal_state();
+        } else if let Ok(picker) = Picker::from_query_stdio() {
             let protocol_type = picker.protocol_type();
             self.config.protocol_type = protocol_type;
             self.config.protocol_label = protocol_type_label(protocol_type);
@@ -601,6 +625,16 @@ fn preferred_max_render_scale(protocol: ProtocolType) -> f32 {
     match protocol {
         ProtocolType::Kitty | ProtocolType::Iterm2 | ProtocolType::Sixel => 2.5,
         ProtocolType::Halfblocks => 1.0,
+    }
+}
+
+fn forced_protocol_type(protocol: GraphicsProtocol) -> Option<ProtocolType> {
+    match protocol {
+        GraphicsProtocol::Auto => None,
+        GraphicsProtocol::Halfblocks => Some(ProtocolType::Halfblocks),
+        GraphicsProtocol::Sixel => Some(ProtocolType::Sixel),
+        GraphicsProtocol::Kitty => Some(ProtocolType::Kitty),
+        GraphicsProtocol::Iterm2 => Some(ProtocolType::Iterm2),
     }
 }
 

--- a/src/presenter/tests/mod.rs
+++ b/src/presenter/tests/mod.rs
@@ -14,7 +14,7 @@ use crate::work::WorkClass;
 use super::encode::{
     EncodeLaneKind, EncodeWorkerRequest, enqueue_encode_request, pop_next_encode_task,
 };
-use super::factory::create_presenter;
+use super::factory::{PresenterFactoryOptions, create_presenter};
 use super::l2_cache::{TerminalFrameKey, TerminalFrameState};
 use super::ratatui::RatatuiImagePresenter;
 use super::terminal_cell::cell_size_from_window_metrics;
@@ -60,8 +60,11 @@ fn render_until_ready(presenter: &mut RatatuiImagePresenter, area: Rect) {
 
 #[test]
 fn select_ratatui_presenter() {
-    let presenter = create_presenter(PresenterKind::RatatuiImage)
-        .expect("ratatui presenter should be selectable");
+    let presenter = create_presenter(
+        PresenterKind::RatatuiImage,
+        PresenterFactoryOptions::default(),
+    )
+    .expect("ratatui presenter should be selectable");
     assert_eq!(presenter.capabilities().backend_name, "ratatui-image");
 }
 

--- a/src/presenter/traits.rs
+++ b/src/presenter/traits.rs
@@ -15,6 +15,16 @@ pub enum PresenterKind {
     RatatuiImage,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GraphicsProtocol {
+    Auto,
+    Halfblocks,
+    Sixel,
+    Kitty,
+    Iterm2,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Viewport {
     pub x: u16,


### PR DESCRIPTION
Adds an explicit graphics protocol option so users can force auto, halfblocks, sixel, kitty, or iterm2 instead of relying only on terminal detection.

The option is exposed as --graphics-protocol and [render].graphics_protocol, then threaded through render policy into the presenter factory. Forced protocols reuse terminal query data for cell sizing and tmux handling, while auto follows the existing detection path.

Verification:
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added terminal graphics protocol selection via command line and config file (auto/halfblocks/sixel/kitty/iterm2).
  * The selected protocol is carried through app rendering and applied consistently across runs.

* **Bug Fixes**
  * Improved validation and error reporting for unknown or invalid protocol values.
  * Terminal rendering now honors explicit protocol requests reliably, while “auto” mode falls back to a safe halfblocks option if detection fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->